### PR TITLE
chore: PyPI packaging prep and CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
-allowBuilds:
-  esbuild: false
+packages: []
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Summary

- Add MIT LICENSE file
- Add `__version__` via `importlib.metadata` in `__init__.py`
- Fix `project.urls` to actual repository (`nbx-liz/LizyML-Widget`)
- Add `authors` and `keywords` to `pyproject.toml`
- Track built `widget.js` / `widget.css` in git for sdist distribution
- Add Trusted Publisher workflow (`publish.yml`) for PyPI/TestPyPI
- Fix pnpm v9→v10 upgrade and workspace config in CI
- Fix ruff E501 in test docstrings

## Test Plan
- [x] `uv build` — sdist + wheel verified
- [x] Wheel contents verified (LICENSE, widget.js, widget.css, py.typed)
- [x] `__version__` returns `"0.1.0"`
- [x] `uv run ruff check .` / `mypy` / `pytest` — all passed
- [x] `pnpm install && pnpm build` — verified with pnpm v10