### PR TITLE
chore: adopt hatch-vcs for git-tag-based versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ js/node_modules/
 *.tsbuildinfo
 .eslintcache
 
+# hatch-vcs generated version file
+src/lizyml_widget/_version.py
+
 # Built widget assets (esbuild output)
 # NOTE: widget.js and widget.css are tracked in git for PyPI distribution
 # (sdist consumers should not need Node.js/pnpm to install)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lizyml-widget"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Jupyter Notebook / Google Colab / VS Code Notebooks widget for LizyML"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,6 +46,12 @@ dev = [
     "lizyml[plots,tuning,calibration,explain]",
     "watchfiles>=1.1",
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/lizyml_widget/_version.py"
 
 [tool.hatch.build]
 artifacts = ["src/lizyml_widget/static/**"]

--- a/src/lizyml_widget/__init__.py
+++ b/src/lizyml_widget/__init__.py
@@ -1,12 +1,10 @@
 """LizyML Widget - Jupyter/Colab/VS Code notebook widget for LizyML."""
 
-from importlib.metadata import PackageNotFoundError, version
-
 from .widget import LizyWidget
 
 try:
-    __version__ = version("lizyml-widget")
-except PackageNotFoundError:
+    from ._version import __version__
+except ImportError:
     __version__ = "0.0.0"
 
 __all__ = ["LizyWidget", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,6 @@ tuning = [
 
 [[package]]
 name = "lizyml-widget"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
@@ -1215,8 +1214,8 @@ dev = [
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9" },
     { name = "jupyterlab", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "lizyml", extras = ["plots", "tuning", "calibration", "explain"], marker = "extra == 'dev'" },
-    { name = "lizyml", extras = ["plots", "tuning", "calibration", "explain"], marker = "extra == 'lizyml'" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'dev'" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'lizyml'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pandas", specifier = ">=1.5" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.0" },
@@ -1226,7 +1225,7 @@ requires-dist = [
     { name = "traitlets", specifier = ">=5.0" },
     { name = "watchfiles", marker = "extra == 'dev'", specifier = ">=1.1" },
 ]
-provides-extras = ["lizyml", "dev"]
+provides-extras = ["dev", "lizyml"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "vulture", specifier = ">=2.15" }]


### PR DESCRIPTION
## Summary

- Replace static `version = "0.1.0"` with `dynamic = ["version"]` powered by hatch-vcs
- Version is now derived from git tags (e.g. `v0.1.0` → `0.1.0`)
- No manual version bumps needed — just create a GitHub Release with a tag

### Changes
- `pyproject.toml`: add `hatch-vcs` to build requires, configure `[tool.hatch.version]`
- `__init__.py`: import `__version__` from auto-generated `_version.py`
- `.gitignore`: add `_version.py` (build artifact)
- `uv.lock`: updated for new build dependency

## Test Plan
- [x] `uv run python -c "import lizyml_widget; print(lizyml_widget.__version__)"` — returns dev version
- [x] `uv build` — sdist + wheel with correct version
- [x] `uv run pytest` — 377 tests passed
- [x] `uv run ruff check .` / `mypy` — passed