### PR TITLE
fix(service): restore features and task from imported config

### DIFF
--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -297,9 +297,9 @@ class WidgetService:
         """Apply parsed config to service state; return canonicalized widget-owned keys."""
         loaded = copy.deepcopy(loaded_config)
         data_section = loaded.pop("data", {})
-        loaded.pop("features", {})  # consumed by build_config from df_info
+        features_section = loaded.pop("features", {})
         split_section = loaded.pop("split", {})
-        loaded.pop("task", None)
+        task_override = loaded.pop("task", None)
 
         if "target" in data_section and self.has_data():
             self.set_target(data_section["target"])
@@ -324,6 +324,26 @@ class WidgetService:
                 train_size_max=split_section.get("train_size_max"),
                 test_size_max=split_section.get("test_size_max"),
             )
+
+        # Restore feature exclusions and categorical overrides
+        if features_section and self.has_data():
+            exclude_set = set(features_section.get("exclude", []))
+            categorical_set = set(features_section.get("categorical", []))
+            target = self._df_info.get("target")
+            for col in self._df_info["columns"]:
+                name = col["name"]
+                if name == target:
+                    continue
+                excluded = name in exclude_set
+                col_type = (
+                    "categorical" if name in categorical_set else col.get("col_type", "numeric")
+                )
+                if excluded != col.get("excluded", False) or col_type != col.get("col_type"):
+                    self.update_column(name, excluded=excluded, col_type=col_type)
+
+        # Restore explicit task override
+        if task_override and self.has_data():
+            self._df_info = {**self._df_info, "task": task_override}
 
         return self.canonicalize_config(loaded)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -651,6 +651,57 @@ class TestGroupColRoundTrip:
         assert svc._df_info["cv"]["group_column"] == "grp"
 
 
+class TestApplyLoadedConfigFeaturesAndTask:
+    """apply_loaded_config must restore features and task from imported config."""
+
+    def test_restores_excluded_features(self) -> None:
+        """Excluded columns in features section should be reflected in df_info."""
+        import numpy as np
+
+        rng = np.random.default_rng(42)
+        df = pd.DataFrame({"a": rng.normal(size=50), "b": rng.normal(size=50), "y": [0, 1] * 25})
+        svc = WidgetService(adapter=_mock_adapter())
+        svc.load_data(df, target="y")
+
+        # Verify b is not excluded initially
+        col_b = next(c for c in svc._df_info["columns"] if c["name"] == "b")
+        assert not col_b["excluded"]
+
+        # Import config with b excluded
+        config = {"features": {"exclude": ["b"], "categorical": []}}
+        svc.apply_loaded_config(config)
+
+        col_b_after = next(c for c in svc._df_info["columns"] if c["name"] == "b")
+        assert col_b_after["excluded"]
+
+    def test_restores_categorical_type(self) -> None:
+        """Categorical columns in features section should update col_type."""
+        df = pd.DataFrame({"a": range(50), "b": range(50), "y": [0, 1] * 25})
+        svc = WidgetService(adapter=_mock_adapter())
+        svc.load_data(df, target="y")
+
+        col_a = next(c for c in svc._df_info["columns"] if c["name"] == "a")
+        assert col_a["col_type"] != "categorical"
+
+        config = {"features": {"exclude": [], "categorical": ["a"]}}
+        svc.apply_loaded_config(config)
+
+        col_a_after = next(c for c in svc._df_info["columns"] if c["name"] == "a")
+        assert col_a_after["col_type"] == "categorical"
+
+    def test_restores_task_override(self) -> None:
+        """Explicit task in imported config should override auto-detected task."""
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        svc = WidgetService(adapter=_mock_adapter())
+        svc.load_data(df, target="y")
+        assert svc._df_info["task"] == "binary"
+
+        config = {"task": "regression"}
+        svc.apply_loaded_config(config)
+
+        assert svc._df_info["task"] == "regression"
+
+
 class TestZeroFeatureGuard:
     """build_config should raise ValueError when all features are excluded."""
 


### PR DESCRIPTION
## Summary

Fixes Codex review finding #7 (P1) from PR #3.

`apply_loaded_config()` was discarding `features` and `task` from imported YAML configs via `loaded.pop()`. This silently lost:
- Manual feature exclusions (`features.exclude`)
- Categorical type overrides (`features.categorical`)
- Explicit task overrides (`task`)

Now restores all three into `df_info` on config import, preserving experiment reproducibility.

## Test Plan
- [x] 3 new tests covering exclude, categorical, and task restoration
- [x] `uv run pytest` — 391 tests passed
- [x] `uv run ruff check .` / `ruff format --check .` / `mypy` — all passed