### PR TITLE
docs: add versioning policy and improve README

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1307,6 +1307,56 @@ class LizyWidget(anywidget.AnyWidget):
 - ビルド済み JS を内包（ユーザーに Node.js 不要）
 - `pip install lizyml-widget` のみで利用可能
 
+### 8.5 バージョニング
+
+[Semantic Versioning 2.0.0](https://semver.org/) に準拠する。
+
+```
+MAJOR.MINOR.PATCH   例: 0.1.0, 0.2.0, 1.0.0
+```
+
+#### Alpha 期間 (`0.x.y`)
+
+`1.0.0` に達するまでは public API は安定保証しない。
+
+| バージョン変更 | 条件 | 例 |
+|---------------|------|-----|
+| `0.MINOR+1.0` | 機能追加・破壊的変更 | 新タブ追加、traitlets 変更、Adapter Protocol 変更 |
+| `0.MINOR.PATCH+1` | バグ修正・ドキュメント修正 | メトリクス修正、UI 調整 |
+
+#### Stable 期間 (`>=1.0.0`)
+
+| バージョン変更 | 条件 |
+|---------------|------|
+| `MAJOR+1.0.0` | 後方互換性を破る変更（破壊的変更） |
+| `MINOR+1.0` | 後方互換で機能追加 |
+| `PATCH+1` | 後方互換でバグ修正 |
+
+#### バージョン取得
+
+`hatch-vcs` が git タグから自動取得する。手動でのバージョン指定は不要。
+
+```python
+import lizyml_widget
+print(lizyml_widget.__version__)  # "0.1.0"
+```
+
+| 状態 | バージョン例 |
+|------|-------------|
+| タグ `v0.1.0` が HEAD | `0.1.0` |
+| タグから 3 コミット先 | `0.1.1.dev3+gabc1234` |
+
+#### リリースフロー
+
+1. develop → main にマージ
+2. GitHub Release を作成（タグ `vX.Y.Z`）
+3. `publish.yml` が自動起動 → TestPyPI → PyPI
+
+#### 破壊的変更ポリシー
+
+- Alpha 期間中でも HISTORY.md に Proposal を記録してから実施
+- Stable 期間では deprecation warning を 1 MINOR バージョン以上出してから削除
+
 ---
 
 ## 9. テスト戦略

--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
 # LizyML Widget
 
+[![PyPI](https://img.shields.io/pypi/v/lizyml-widget)](https://pypi.org/project/lizyml-widget/)
+[![Python](https://img.shields.io/pypi/pyversions/lizyml-widget)](https://pypi.org/project/lizyml-widget/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Interactive Jupyter widget for [LizyML](https://github.com/lizyml/lizyml) — fit, tune, and run inference on machine learning models without writing code.
 
 ## Features
 
 - **Data Tab** — Load a DataFrame, select target, configure columns and cross-validation
-- **Model Tab** — Edit LightGBM hyperparameters, configure tuning search space
+- **Config Tab** — Edit LightGBM hyperparameters, configure tuning search space
 - **Results Tab** — View scores, Plotly plots, feature importance, and inference results
 - **Config Import/Export** — Save and load configurations as YAML
 - **Python API** — Programmatic access to all widget functionality
+
+## Requirements
+
+- Python >= 3.10
+- Jupyter Notebook, JupyterLab, Google Colab, or VS Code Notebooks
 
 ## Installation
 
 ```bash
 pip install lizyml-widget
+```
+
+With the LizyML backend (required for Fit/Tune):
+
+```bash
+pip install lizyml-widget[lizyml]
 ```
 
 ## Quick Start
@@ -41,11 +56,17 @@ w.save_model("./model")
 w.save_config("config.yaml")
 ```
 
+### Version
+
+```python
+import lizyml_widget
+print(lizyml_widget.__version__)
+```
+
 ## Tutorials
 
 | Notebook | Task | Dataset |
 |----------|------|---------|
-| [Quick Start](notebooks/tutorial.ipynb) | Binary (synthetic) | Synthetic data |
 | [Regression](notebooks/tutorial_regression.ipynb) | Regression | California Housing (sklearn) |
 | [Binary Classification](notebooks/tutorial_binary.ipynb) | Binary | Breast Cancer Wisconsin (sklearn) |
 | [Multiclass Classification](notebooks/tutorial_multiclass.ipynb) | Multiclass | Wine (sklearn) |
@@ -57,11 +78,13 @@ w.save_config("config.yaml")
 - Google Colab
 - VS Code Notebooks
 
+Powered by [anywidget](https://anywidget.dev/) for cross-environment compatibility.
+
 ## Development
 
 ```bash
 # Python
-uv sync --all-extras
+uv sync --all-extras    # installs dev + lizyml dependencies
 uv run pytest
 uv run ruff check .
 uv run mypy src/lizyml_widget/


### PR DESCRIPTION
## Summary

### BLUEPRINT §8.5 — Versioning Policy (new)
- SemVer 2.0.0 compliance
- Alpha period (`0.x.y`): MINOR for features/breaking, PATCH for fixes
- Stable period (`>=1.0.0`): standard MAJOR/MINOR/PATCH rules
- hatch-vcs tag-based version derivation
- Release flow documentation
- Breaking change policy (Proposal in HISTORY.md required)

### README improvements
- Add PyPI / Python / License badges
- Add Requirements section (Python >= 3.10)
- Document optional dependency: `pip install lizyml-widget[lizyml]`
- Add `__version__` usage example
- Fix broken link to non-existent `notebooks/tutorial.ipynb`
- Add anywidget attribution
- Rename "Model Tab" → "Config Tab" to match implementation

## Test Plan
- [x] No code changes — documentation only