### PR TITLE
v0.2.1: test coverage and reliability improvements

### DIFF
--- a/tests/test_adapter_config.py
+++ b/tests/test_adapter_config.py
@@ -708,6 +708,130 @@ class TestValidationDiagnostics:
         assert errors[0]["type"] == "unknown"
 
 
+class TestEnforceAutoNumLeavesFalse:
+    """Cover auto_num_leaves=False path (adapter.py lines 186-187, 306-318)."""
+
+    def test_enforce_false_inserts_default_256(self) -> None:
+        """auto_num_leaves=False with no num_leaves → inserts 256."""
+        result = LizyMLAdapter._enforce_auto_num_leaves({"auto_num_leaves": False, "params": {}})
+        assert result["params"]["num_leaves"] == 256
+
+    def test_enforce_false_preserves_existing_num_leaves(self) -> None:
+        """auto_num_leaves=False with existing num_leaves → preserves value."""
+        result = LizyMLAdapter._enforce_auto_num_leaves(
+            {"auto_num_leaves": False, "params": {"num_leaves": 128}}
+        )
+        assert result["params"]["num_leaves"] == 128
+
+
+class TestExtractDefaultsSchemaResolution:
+    """Cover allOf + $ref schema resolution (adapter.py lines 420-423)."""
+
+    def test_allof_single_ref_resolved(self) -> None:
+        """allOf with a single $ref should be resolved and defaults extracted."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "allOf": [{"$ref": "#/$defs/ModelConfig"}],
+                },
+            },
+            "$defs": {
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "default": "lgbm"},
+                        "depth": {"type": "integer", "default": 5},
+                    },
+                },
+            },
+        }
+        result = LizyMLAdapter._extract_defaults(schema)
+        assert result["model"]["name"] == "lgbm"
+        assert result["model"]["depth"] == 5
+
+    def test_simple_ref_resolved(self) -> None:
+        """Plain $ref should be resolved and defaults extracted."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "training": {"$ref": "#/$defs/TrainConfig"},
+            },
+            "$defs": {
+                "TrainConfig": {
+                    "type": "object",
+                    "properties": {
+                        "seed": {"type": "integer", "default": 42},
+                    },
+                },
+            },
+        }
+        result = LizyMLAdapter._extract_defaults(schema)
+        assert result["training"]["seed"] == 42
+
+
+class TestVersionFallbackPaths:
+    """Cover LizyML version fallback paths for import failures."""
+
+    def test_search_space_fallback_returns_empty(self) -> None:
+        """adapter_schema.py:250-258: when all imports fail, returns {}."""
+        adapter_schema.reset_schema_cache()
+        old_cache = adapter_schema._schema_cache
+        try:
+            with patch.dict(
+                "sys.modules",
+                {
+                    "lizyml.estimators.lgbm.defaults": None,
+                    "lizyml.estimators.lgbm": None,
+                    "lizyml.estimators": None,
+                    "lizyml.tuning": None,
+                },
+            ):
+                result = adapter_schema.get_default_search_space("binary")
+                assert result == {}
+        finally:
+            adapter_schema._schema_cache = old_cache
+
+    def test_resolve_direction_import_error_returns_minimize(self) -> None:
+        """adapter_params.py:83-84: when metric registry unavailable, returns minimize."""
+        from lizyml_widget.adapter_params import resolve_direction
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "lizyml.metrics.registry": None,
+                "lizyml.metrics": None,
+                "lizyml.core.exceptions": None,
+                "lizyml.core": None,
+            },
+        ):
+            result = resolve_direction("auc")
+            assert result == "minimize"
+
+    def test_eval_metrics_fallback_uses_hardcoded(self) -> None:
+        """adapter_params.py:170-172: fallback metrics when _TASK_METRICS unavailable."""
+        from lizyml_widget.adapter_params import get_eval_metrics_by_task
+
+        adapter_params._eval_metrics_cache = None
+        try:
+            # Mock _TASK_METRICS to raise AttributeError
+            mock_registry = MagicMock(spec=[])  # no _TASK_METRICS attribute
+            with patch.dict(
+                "sys.modules",
+                {
+                    "lizyml.metrics.registry": mock_registry,
+                    "lizyml.metrics": MagicMock(),
+                },
+            ):
+                result = get_eval_metrics_by_task()
+                assert "binary" in result
+                assert "regression" in result
+                assert "multiclass" in result
+                assert len(result["binary"]) > 0
+        finally:
+            adapter_params._eval_metrics_cache = None
+
+
 class TestPrepareRunConfigImmutability:
     """prepare_run_config must not mutate the input config dict."""
 

--- a/tests/test_adapter_core.py
+++ b/tests/test_adapter_core.py
@@ -441,6 +441,20 @@ class TestAvailablePlots:
         assert "roc-curve" in plots
         assert "calibration" not in plots
 
+    def test_multiclass_includes_roc_curve(self) -> None:
+        """adapter.py:736-737: multiclass fitted model includes roc-curve."""
+        adapter = LizyMLAdapter()
+        mock_model = MagicMock()
+        mock_model._cfg.task = "multiclass"
+        mock_model.fit_result.calibrator = None
+        del mock_model._tuning_result
+
+        plots = adapter.available_plots(mock_model)
+        assert "roc-curve" in plots
+        assert "calibration" not in plots
+        assert "probability-histogram" not in plots
+        assert "residuals" not in plots
+
     def test_tuning_plot_when_tuned(self) -> None:
         adapter = LizyMLAdapter()
         mock_model = MagicMock()
@@ -801,3 +815,22 @@ class TestPlotInference:
         df = pd.DataFrame({"pred": [0.1, 0.5]})
         with pytest.raises(ValueError, match="Unknown inference plot type"):
             adapter.plot_inference(df, "nonexistent")
+
+    def test_plotly_not_installed_raises_import_error(self) -> None:
+        """adapter.py:755-757: ImportError when plotly is not available."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _block_plotly(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "plotly.graph_objects" or name == "plotly":
+                raise ImportError("No module named 'plotly'")
+            return original_import(name, *args, **kwargs)
+
+        adapter = LizyMLAdapter()
+        df = pd.DataFrame({"pred": [0.1, 0.5]})
+        with (
+            patch.object(builtins, "__import__", side_effect=_block_plotly),
+            pytest.raises(ImportError, match="plotly is required"),
+        ):
+            adapter.plot_inference(df, "prediction-distribution")

--- a/tests/test_adapter_schema.py
+++ b/tests/test_adapter_schema.py
@@ -412,6 +412,61 @@ class TestNormalizeInnerValidExclusivity:
         assert "inner_valid" not in es
         assert "validation_ratio" not in es
 
+    def test_prepare_run_config_holdout_preserves_all(self) -> None:
+        """holdout via prepare_run_config preserves ratio, random_state, stratify."""
+        adapter = LizyMLAdapter()
+        config = adapter.initialize_config(task="binary")
+        config = {
+            **config,
+            "task": "binary",
+            "data": {"target": "y"},
+            "features": {"exclude": [], "categorical": []},
+            "split": {"method": "kfold", "n_splits": 5},
+            "training": {
+                "early_stopping": {
+                    "inner_valid": {
+                        "method": "holdout",
+                        "ratio": 0.1,
+                        "random_state": 42,
+                        "stratify": True,
+                    }
+                }
+            },
+        }
+        result = adapter.prepare_run_config(config, job_type="fit", task="binary")
+        iv = result.get("training", {}).get("early_stopping", {}).get("inner_valid", {})
+        assert iv["method"] == "holdout"
+        assert iv["ratio"] == 0.1
+        assert iv["random_state"] == 42
+        assert iv["stratify"] is True
+
+    def test_prepare_run_config_group_holdout_strips_stratify(self) -> None:
+        """group_holdout via prepare_run_config strips stratify, keeps random_state."""
+        adapter = LizyMLAdapter()
+        config = adapter.initialize_config(task="binary")
+        config = {
+            **config,
+            "task": "binary",
+            "data": {"target": "y"},
+            "features": {"exclude": [], "categorical": []},
+            "split": {"method": "kfold", "n_splits": 5},
+            "training": {
+                "early_stopping": {
+                    "inner_valid": {
+                        "method": "group_holdout",
+                        "ratio": 0.1,
+                        "random_state": 42,
+                        "stratify": True,
+                    }
+                }
+            },
+        }
+        result = adapter.prepare_run_config(config, job_type="fit", task="binary")
+        iv = result.get("training", {}).get("early_stopping", {}).get("inner_valid", {})
+        assert iv["method"] == "group_holdout"
+        assert iv["random_state"] == 42
+        assert "stratify" not in iv
+
     def test_validation_ratio_only_no_inner_valid_key_unchanged(self) -> None:
         """When only validation_ratio is present (no inner_valid key at all), unchanged."""
         from lizyml_widget.adapter_schema import enforce_iv_exclusivity

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -336,6 +336,79 @@ class TestLoadDefaults:
         assert len(space) > 0, "tune search space should not be empty after load"
 
 
+class TestMulticlassE2E:
+    """Full multiclass workflow: load → fit → tune → inference → plot."""
+
+    def test_multiclass_fit_tune_inference(self) -> None:
+        w, adapter = _make_widget_with_adapter()
+        # 3-class target → multiclass (x has repeated values to avoid ID auto-exclusion)
+        df = pd.DataFrame({"x": [i % 10 for i in range(51)], "y": [0, 1, 2] * 17})
+
+        mock_model = MagicMock()
+        adapter.create_model.return_value = mock_model
+        adapter.fit.return_value = FitSummary(
+            metrics={"multi_logloss": {"is": 0.5, "oos": 0.6}},
+            fold_count=5,
+            params=[],
+        )
+        adapter.evaluate_table.return_value = [
+            {"index": "multi_logloss", "if_mean": 0.5, "oof": 0.6}
+        ]
+        adapter.split_summary.return_value = [{"fold": 0, "n_train": 40, "n_valid": 11}]
+        adapter.available_plots.return_value = [
+            "learning-curve",
+            "roc-curve",
+            "feature-importance-split",
+        ]
+        adapter.predict.return_value = PredictionSummary(
+            predictions=pd.DataFrame(
+                {
+                    "pred": [0, 1, 2],
+                    "proba_0": [0.7, 0.1, 0.1],
+                    "proba_1": [0.2, 0.8, 0.1],
+                    "proba_2": [0.1, 0.1, 0.8],
+                }
+            ),
+            warnings=[],
+        )
+        adapter.classify_best_params = MagicMock(side_effect=LizyMLAdapter().classify_best_params)
+
+        # Load & verify multiclass detection
+        w.load(df, target="y")
+        assert w.df_info["task"] == "multiclass"
+
+        # Fit
+        w.action = {"type": "fit", "payload": {}}
+        if w._job_thread is not None:
+            w._job_thread.join(timeout=5.0)
+        assert w.status == "completed"
+        assert w.fit_summary["fold_count"] == 5
+
+        # Tune
+        adapter.tune.return_value = TuningSummary(
+            best_params={"learning_rate": 0.01},
+            best_score=0.45,
+            trials=[],
+            metric_name="multi_logloss",
+            direction="minimize",
+        )
+        w.action = {"type": "tune", "payload": {}}
+        if w._job_thread is not None:
+            w._job_thread.join(timeout=5.0)
+        assert w.status == "completed"
+        assert w.tune_summary["best_score"] == 0.45
+
+        # Inference
+        test_df = pd.DataFrame({"x": [10, 20, 30]})
+        w.load_inference(test_df)
+        w.action = {"type": "run_inference", "payload": {"return_shap": False}}
+        assert w.inference_result["status"] == "completed"
+        assert w.inference_result["rows"] == 3
+
+        # Available plots should include roc-curve for multiclass
+        assert "roc-curve" in w.available_plots
+
+
 class TestCancelFlow:
     """Test job cancellation."""
 

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -280,6 +280,85 @@ class TestStratifiedGroupKfold:
         assert "stratified_group_kfold" in caps["cv_strategies"]
 
 
+class TestBuildConfigCVStrategySplitFields:
+    """Cover CV strategy-dependent split field logic (service.py lines 260-274)."""
+
+    def _make_service(self, cv_strategy: str, **cv_kwargs: Any) -> WidgetService:
+        adapter = _mock_adapter()
+        adapter.classify_best_params = MagicMock(side_effect=LizyMLAdapter().classify_best_params)
+        svc = WidgetService(adapter=adapter)
+        df = pd.DataFrame({"x": range(50), "t": range(50), "g": [0, 1] * 25, "y": [0, 1] * 25})
+        svc.load_data(df, target="y")
+        svc.update_cv(cv_strategy, n_splits=3, **cv_kwargs)
+        return svc
+
+    def test_purged_time_series_includes_purge_gap_embargo(self) -> None:
+        """service.py:267-269: purged_time_series adds purge_gap, embargo."""
+        svc = self._make_service(
+            "purged_time_series",
+            time_column="t",
+            purge_gap=10,
+            embargo=5,
+            train_size_max=100,
+            test_size_max=50,
+        )
+        config = svc.build_config({"model": {"name": "lgbm"}})
+        split = config["split"]
+        assert split["method"] == "purged_time_series"
+        assert split["purge_gap"] == 10
+        assert split["embargo"] == 5
+        assert split["train_size_max"] == 100
+        assert split["test_size_max"] == 50
+        assert "gap" not in split
+        assert "random_state" not in split
+
+    def test_time_series_includes_gap(self) -> None:
+        """service.py:265-266: time_series adds gap."""
+        svc = self._make_service("time_series", time_column="t", gap=3)
+        config = svc.build_config({"model": {"name": "lgbm"}})
+        split = config["split"]
+        assert split["method"] == "time_series"
+        assert split["gap"] == 3
+        assert "purge_gap" not in split
+        assert "embargo" not in split
+
+    def test_group_time_series_includes_gap_and_size_limits(self) -> None:
+        """service.py:265-266,271-274: group_time_series adds gap + size limits."""
+        svc = self._make_service(
+            "group_time_series",
+            time_column="t",
+            group_column="g",
+            gap=2,
+            train_size_max=200,
+        )
+        config = svc.build_config({"model": {"name": "lgbm"}})
+        split = config["split"]
+        assert split["method"] == "group_time_series"
+        assert split["gap"] == 2
+        assert split["train_size_max"] == 200
+        assert config["data"]["group_col"] == "g"
+        assert config["data"]["time_col"] == "t"
+
+    def test_kfold_includes_random_state_and_shuffle(self) -> None:
+        """service.py:260-264: kfold adds random_state and shuffle."""
+        svc = self._make_service("kfold", random_state=99, shuffle=False)
+        config = svc.build_config({"model": {"name": "lgbm"}})
+        split = config["split"]
+        assert split["random_state"] == 99
+        assert split["shuffle"] is False
+        assert "gap" not in split
+        assert "purge_gap" not in split
+
+    def test_stratified_kfold_has_random_state_no_shuffle(self) -> None:
+        """service.py:261-264: stratified_kfold adds random_state but not shuffle."""
+        svc = self._make_service("stratified_kfold", random_state=42)
+        config = svc.build_config({"model": {"name": "lgbm"}})
+        split = config["split"]
+        assert split["random_state"] == 42
+        assert "shuffle" not in split
+        assert "gap" not in split
+
+
 class TestZeroFeatureGuard:
     """build_config should raise ValueError when all features are excluded."""
 

--- a/tests/test_widget_actions.py
+++ b/tests/test_widget_actions.py
@@ -647,6 +647,56 @@ class TestPatchConfigOpValidation:
             assert w.error.get("code") != "INVALID_PATCH", f"op={op!r} should be valid"
 
 
+class TestActionHandlerExceptionBranches:
+    """Cover except branches in action handlers (widget.py lines 260-335)."""
+
+    def test_set_target_service_error_sets_target_error(self) -> None:
+        """widget.py:260-261: service.set_target raises → TARGET_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df)
+        w._service.set_target = MagicMock(side_effect=ValueError("column not found"))
+        w.action = {"type": "set_target", "payload": {"target": "y"}}
+        assert w.error["code"] == "TARGET_ERROR"
+        assert "column not found" in w.error["message"]
+
+    def test_set_task_service_error_sets_task_error(self) -> None:
+        """widget.py:272-273: service.set_task raises → TASK_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+        w._service.set_task = MagicMock(side_effect=ValueError("Invalid task"))
+        w.action = {"type": "set_task", "payload": {"task": "bad"}}
+        assert w.error["code"] == "TASK_ERROR"
+        assert "Invalid task" in w.error["message"]
+
+    def test_update_column_service_error_sets_column_error(self) -> None:
+        """widget.py:293-294: service.update_column raises → COLUMN_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+        w._service.update_column = MagicMock(side_effect=RuntimeError("db error"))
+        w.action = {
+            "type": "update_column",
+            "payload": {"name": "x", "excluded": True, "col_type": "numeric"},
+        }
+        assert w.error["code"] == "COLUMN_ERROR"
+        assert "db error" in w.error["message"]
+
+    def test_update_cv_service_error_sets_cv_error(self) -> None:
+        """widget.py:334-335: service.update_cv raises → CV_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+        w._service.update_cv = MagicMock(side_effect=ValueError("bad cv config"))
+        w.action = {
+            "type": "update_cv",
+            "payload": {"strategy": "kfold", "n_splits": 5},
+        }
+        assert w.error["code"] == "CV_ERROR"
+        assert "bad cv config" in w.error["message"]
+
+
 class TestPatchConfigExceptionHandling:
     """apply_config_patch errors should be caught, not propagated."""
 

--- a/tests/test_widget_core.py
+++ b/tests/test_widget_core.py
@@ -144,6 +144,25 @@ class TestNormalizeMetrics:
         w = _make_widget()
         assert w._normalize_metrics([]) == {}
 
+    def test_normalize_metrics_skips_empty_name(self) -> None:
+        """widget.py:664-666: records with empty metric name are skipped."""
+        w = _make_widget()
+        records = [
+            {"index": "", "if_mean": 0.5, "oof": 0.6},
+            {"index": "rmse", "if_mean": 0.3},
+        ]
+        result = w._normalize_metrics(records)
+        assert "rmse" in result
+        assert "" not in result
+        assert len(result) == 1
+
+    def test_normalize_metrics_skips_missing_name_keys(self) -> None:
+        """widget.py:664-666: records with no 'index' or 'metric' key are skipped."""
+        w = _make_widget()
+        records = [{"if_mean": 0.5}]
+        result = w._normalize_metrics(records)
+        assert result == {}
+
 
 class TestDfInfoChangeDetection:
     """Verify traitlet change notification fires on every df_info update."""

--- a/tests/test_widget_jobs.py
+++ b/tests/test_widget_jobs.py
@@ -310,6 +310,112 @@ class TestRunJobConfigError:
         assert "still bad" in w.error.get("message", "")
 
 
+class TestRunBlockingJob:
+    """Cover _run_blocking_job status→exception paths (widget.py lines 119-132)."""
+
+    def test_immediate_completion_returns(self) -> None:
+        """widget.py:123-124: job completes synchronously before observer fires."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        def _instant_complete(job_type: str) -> None:
+            w.status = "completed"
+
+        w._run_job = _instant_complete  # type: ignore[assignment]
+        result = w.fit()
+        assert result is w
+
+    def test_failed_status_raises_runtime_error(self) -> None:
+        """widget.py:129-131: status=='failed' → RuntimeError with message."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        def _instant_fail(job_type: str) -> None:
+            w.error = {"code": "BACKEND_ERROR", "message": "boom"}
+            w.status = "failed"
+
+        w._run_job = _instant_fail  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="boom"):
+            w.fit()
+
+    def test_failed_status_default_message(self) -> None:
+        """widget.py:130: fallback message when error dict has no 'message'."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        def _instant_fail(job_type: str) -> None:
+            w.error = {"code": "INTERNAL_ERROR"}
+            w.status = "failed"
+
+        w._run_job = _instant_fail  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="Fit failed"):
+            w.fit()
+
+
+class TestJobWorkerErrorClassification:
+    """Cover BACKEND_ERROR vs INTERNAL_ERROR classification (widget.py:635-639)."""
+
+    def test_lizyml_exception_gets_backend_error(self) -> None:
+        """Exceptions from lizyml module → BACKEND_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        class FakeLizyMLError(Exception):
+            pass
+
+        FakeLizyMLError.__module__ = "lizyml.core.exceptions"
+
+        w._service.fit = MagicMock(side_effect=FakeLizyMLError("backend crash"))
+        w._service.validate_config = MagicMock(return_value=[])
+
+        w._run_job("fit")
+        if w._job_thread is not None:
+            w._job_thread.join(timeout=5.0)
+
+        assert w.error["code"] == "BACKEND_ERROR"
+        assert "backend crash" in w.error["message"]
+
+    def test_generic_exception_gets_internal_error(self) -> None:
+        """Non-lizyml exceptions → INTERNAL_ERROR."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        w._service.fit = MagicMock(side_effect=RuntimeError("oops"))
+        w._service.validate_config = MagicMock(return_value=[])
+
+        w._run_job("fit")
+        if w._job_thread is not None:
+            w._job_thread.join(timeout=5.0)
+
+        assert w.error["code"] == "INTERNAL_ERROR"
+        assert "oops" in w.error["message"]
+
+    def test_exception_with_none_module_gets_internal_error(self) -> None:
+        """Exception with __module__=None → INTERNAL_ERROR (the `or ''` fallback)."""
+        w = _make_widget()
+        df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
+        w.load(df, target="y")
+
+        class WeirdError(Exception):
+            pass
+
+        WeirdError.__module__ = None  # type: ignore[assignment]
+
+        w._service.fit = MagicMock(side_effect=WeirdError("weird"))
+        w._service.validate_config = MagicMock(return_value=[])
+
+        w._run_job("fit")
+        if w._job_thread is not None:
+            w._job_thread.join(timeout=5.0)
+
+        assert w.error["code"] == "INTERNAL_ERROR"
+
+
 class TestBlockingHelperTimeout:
     """fit()/tune() must raise TimeoutError when timeout expires."""
 


### PR DESCRIPTION
## Summary
- Add 29 new tests covering error paths, parameter combinations, and version fallbacks
- Test coverage improved from 95% → 98% (469 → 498 tests)
- No source code changes — test-only release

### Changes included
- **CRITICAL**: Widget action handler exception branches, `_run_blocking_job` status→exception conversion, BACKEND_ERROR vs INTERNAL_ERROR classification
- **HIGH**: CV strategy × split fields in `build_config`, multiclass E2E flow, multiclass `available_plots` roc-curve
- **MEDIUM**: `auto_num_leaves=False` path, `inner_valid` method field stripping, `_normalize_metrics` edge cases, `allOf`/`$ref` schema resolution, LizyML version fallback paths, plotly ImportError guard

### Coverage delta

| File | Before | After |
|------|--------|-------|
| adapter.py | 96% | 98% |
| adapter_params.py | 91% | 98% |
| adapter_schema.py | 92% | 95% |
| service.py | 97% | 98% |
| widget.py | 95% | 99% |
| **TOTAL** | **95%** | **98%** |

## Test plan
- [x] 498 tests pass (`uv run pytest`)
- [x] Coverage 98% (`uv run pytest --cov=lizyml_widget`)
- [x] Lint clean (`uv run ruff check .`)
- [x] Format clean (`uv run ruff format --check .`)
- [x] Type check clean (`uv run mypy src/lizyml_widget/`)