### PR TITLE
fix(ci): enable workflow_dispatch for PyPI release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -71,3 +71,11 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file /tmp/release-notes.md
+
+      - name: Trigger PyPI release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --ref "${{ steps.version.outputs.tag }}" \
+            -f tag="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.4.1)"
+        required: true
 
 permissions:
   contents: read
@@ -16,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Install uv


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` tag pushes do not trigger other workflows (GitHub limitation)
- `auto-release.yml` tag push was not firing `release.yml` pipeline
- Added `workflow_dispatch` trigger to `release.yml` with tag input
- Added `gh workflow run release.yml` step at end of `auto-release.yml`

## Test plan

- [x] Confirmed v0.4.0 and v0.4.1 are not published on PyPI
- [ ] After merge, manually trigger: `gh workflow run release.yml -f tag=v0.4.1`
- [ ] Verify TestPyPI → PyPI publish succeeds