### PR TITLE
ci(release): auto-trigger PyPI publish after GitHub Release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -73,7 +73,12 @@ jobs:
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file /tmp/release-notes.md
 
-      # Note: The tag push above already triggers release.yml via
-      # the "push: tags: v*" event.  No workflow_dispatch needed.
-      # Use "gh workflow run release.yml -f tag=vX.Y.Z" only for
-      # manual retries when the tag-triggered run fails.
+      # GITHUB_TOKEN tag pushes do NOT trigger other workflows
+      # (push events are blocked), but workflow_dispatch is explicitly
+      # exempt from this restriction since Sep 2022.
+      # See: https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/
+      - name: Trigger PyPI release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml -f tag=${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger from auto-release.yml to release.yml after GitHub Release creation
- Fixes: GITHUB_TOKEN tag pushes don't trigger other workflows (push events blocked), but workflow_dispatch is explicitly exempt since Sep 2022
- Eliminates need for manual `gh workflow run release.yml -f tag=vX.Y.Z` after every release

## Reference
- https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/

## DoD
- [x] No code changes — CI workflow only
- [x] `actions: write` permission already present in auto-release.yml

## Test plan
- Will be verified on next release (v0.7.4+)