### PR TITLE
docs: add CHANGELOG entry for v0.8.0

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -39,9 +39,9 @@ Widget は LizyML の型・契約（`BackendAdapter` Protocol, `TuningResult`, `
 
 | lizyml-widget | lizyml           | 主な新機能 / 破壊的変更                                               |
 | ------------- | ---------------- | --------------------------------------------------------------------- |
-| **0.5.x**     | `>=0.9.0,<0.10`  | P-027: Re-tune monitoring（Round progress, Boundary Expansion, Score History）|
-| 0.4.x         | `>=0.7.0,<0.9`   | Learning curve metrics フィルタ, CV strategy metadata                  |
-| 0.3.x         | `>=0.5.0,<0.7`   | Canonical config, Backend Contract 駆動 UI                             |
+| **0.8.x**     | `>=0.9.0,<0.10`  | P-027/P-028/P-029: Re-tune（Round progress, Boundary Expansion, Tuning History, `w.retune()` API, UI ボタン）|
+| 0.7.x         | `>=0.7.0,<0.9`   | Calibration / Search Space default refresh                             |
+| 0.6.x / 0.5.x | `>=0.5.0,<0.7`   | Learning curve metrics フィルタ, CV strategy metadata                  |
 
 推奨インストール: `pip install "lizyml-widget[lizyml]"` — extras 経由で互換な lizyml を自動解決する。`LizyMLAdapter.__init__` はランタイムで lizyml のバージョンを検証し、範囲外なら明確な ImportError を投げる。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-12
+
+### Added
+- **Re-tune monitoring (P-027)** — round-aware Tune progress display,
+  Boundary Expansion panel, Convergence Signal banner, and backend
+  version guard that requires `lizyml>=0.9.0,<0.10`. The `progress`
+  traitlet now carries optional `round`, `total_rounds`,
+  `cumulative_trials`, `expanded_dims`, `latest_score`, `latest_state`,
+  and `best_score` fields during Tune runs.
+- **Re-tune launcher (P-028)** — new `w.retune(n_trials=..., expand_boundary=..., boundary_threshold=...)`
+  Python API and a matching `retune` UI action. The Results tab gains
+  a "Re-tune (resume)" button inside the Best Params accordion so
+  users can resume the Optuna study with additional trials (and
+  optionally widen boundaries) without leaving the widget.
+- **Tuning History accordion (P-029)** — the Results tab now renders
+  lizyml's `Model.tuning_plot()` figure in a dedicated "Tuning History"
+  accordion on Tune completion, via the standard PlotViewer pipeline.
+- `TuningSummary` gains `rounds: list[dict]` and
+  `boundary_report: dict | None` fields, propagated through
+  `LizyMLAdapter.tune()` and the `tune_summary` traitlet so the new UI
+  components can render round-aware history.
+- `docs/VERSION_COMPAT.md` — documents the widget ↔ lizyml
+  compatibility matrix, supported upgrade paths, and install
+  recommendations.
+- `WidgetService` gains a dedicated `_tune_model` slot so an
+  intervening `fit()` cannot clobber the Optuna study that the next
+  `retune()` must resume.
+- Closes [#101](https://github.com/nbx-liz/LizyML-Widget/issues/101).
+
+### Changed
+- **Required lizyml version bumped to `>=0.9.0,<0.10`** (previously
+  `>=0.7.0`). The widget no longer works with lizyml 0.7.x / 0.8.x;
+  use `pip install "lizyml-widget[lizyml]"` to let pip auto-resolve a
+  compatible backend. `LizyMLAdapter.__init__` now validates the
+  installed lizyml version at import time and raises a clear
+  `ImportError` with an upgrade hint if the backend is out of range.
+- `ResultsTab` layout on Tune completion:
+  Best Params → RetuneControls → Convergence Signal →
+  Boundary Expansion → Tuning History → (existing) Score / Plots / etc.
+- `BackendAdapter.tune()` Protocol and `LizyMLAdapter.tune()` accept
+  `resume`, `n_trials`, `expand_boundary`, and `boundary_threshold`
+  kwargs (all default to their pre-P-028 values, so in-tree callers
+  are unchanged).
+- README adds a Re-tune usage section and a lizyml compatibility
+  matrix.
+
+### Removed
+- `js/src/components/ScoreHistoryChart.tsx` — the widget-local Plotly
+  duplicate of lizyml's `tuning_plot`. The P-029 refactor consolidates
+  on the backend figure, dropping roughly 2.4 KB from the production
+  bundle.
+
+### Fixed
+- **ConvergenceSignal** showed the literal 6-character string
+  `\u2713` instead of a real checkmark glyph because the JSX text node
+  was not wrapped in an expression.
+- **ConvergenceSignal** "Round N" label was off by one after the
+  third tune: `ResultsTab` was passing `lastRound.round + 1`, but
+  lizyml's `RoundSummary.round` is already 1-indexed. The `+1` has
+  been removed along with the now-redundant `>= 1` guard.
+- `WidgetService.tune(resume=True)` now takes the `_tune_model` check
+  inside the existing `_model_lock` section to close a TOCTOU window
+  where an intervening `load()` could race with the check.
+- `ResultsTab` Best Score row renders an em-dash placeholder instead
+  of the literal string `"undefined"` when `tune_summary.best_score`
+  is missing (defensive guard).
+
 ## [0.7.3] - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ the widget targets a specific `lizyml` range:
 
 | lizyml-widget | lizyml           | Highlights                                                    |
 | ------------- | ---------------- | ------------------------------------------------------------- |
-| **0.5.x**     | `>=0.9.0,<0.10`  | Re-tune monitoring (round progress, boundary expansion, chart)|
-| 0.4.x         | `>=0.7.0,<0.9`   | Learning curve metric filter, CV strategy metadata            |
-| 0.3.x         | `>=0.5.0,<0.7`   | Canonical config, contract-driven UI                          |
+| **0.8.x**     | `>=0.9.0,<0.10`  | Re-tune (round progress, boundary expansion, tuning history, `w.retune()` API) |
+| 0.7.x         | `>=0.7.0,<0.9`   | Calibration / Search Space default refresh                    |
+| 0.6.x / 0.5.x | `>=0.5.0,<0.7`   | Learning curve metric filter, CV strategy metadata            |
 
 See [docs/VERSION_COMPAT.md](docs/VERSION_COMPAT.md) for the full matrix,
 troubleshooting, and upgrade guidance.

--- a/docs/VERSION_COMPAT.md
+++ b/docs/VERSION_COMPAT.md
@@ -13,10 +13,10 @@ LizyML-Widget は `lizyml` の ML 仕様（`Config schema`, `TuningResult`,
 
 | lizyml-widget | lizyml               | Python  | 主な新機能 / 破壊的変更                                               |
 | ------------- | -------------------- | ------- | --------------------------------------------------------------------- |
-| **0.5.x**     | `>=0.9.0, <0.10`     | `>=3.10`| Re-tune monitoring（Round progress, Boundary Expansion, Score History）|
-| 0.4.x         | `>=0.7.0, <0.9`      | `>=3.10`| Learning Curve metrics フィルタ, CV strategy metadata                  |
-| 0.3.x         | `>=0.5.0, <0.7`      | `>=3.10`| Canonical config, Backend Contract 駆動 UI                             |
-| 0.2.x         | `>=0.3.0, <0.5`      | `>=3.10`| Fit/Tune タブ再設計, Apply to Fit                                     |
+| **0.8.x**     | `>=0.9.0, <0.10`     | `>=3.10`| Re-tune（Round progress, Boundary Expansion, Tuning History, `w.retune()` API, UI ボタン）|
+| 0.7.x         | `>=0.7.0, <0.9`      | `>=3.10`| Calibration method 既定変更, training seed 既定変更, Search Space 既定値整理 |
+| 0.6.x / 0.5.x | `>=0.5.0, <0.7`      | `>=3.10`| Learning Curve metrics フィルタ, CV strategy metadata                  |
+| 0.4.x         | `>=0.3.0, <0.5`      | `>=3.10`| Canonical config, Backend Contract 駆動 UI                             |
 
 表の最上段が **最新** 。それ以外のバージョンは過去参照用。
 


### PR DESCRIPTION
## Summary

Prep for v0.8.0 release.  Summarises the P-027 / P-028 / P-029 work and the ConvergenceSignal display fixes from PR #102 as the first user-visible entries since v0.7.3.

Also corrects the `lizyml-widget` version matrix in `README.md`, `BLUEPRINT.md` §1, and `docs/VERSION_COMPAT.md` — the initial P-027 draft listed the new feature as landing in 0.5.x, but the current branch is already on 0.7.x so the correct row is **0.8.x**.

No code changes; this PR only touches docs that the release script (`scripts/release.py`) reads.

## Test plan

- [x] ruff check / format — clean
- [x] eslint — clean
- [x] No code files touched, so no functional tests needed
- [ ] CI must pass before merge

## Next steps

After this PR is merged to `develop`, run:

```
uv run python scripts/release.py v0.8.0
```

which will create the `release: v0.8.0` PR from develop → main and let the auto-release pipeline handle the tag / GitHub Release / PyPI publish.