### PR TITLE
feat: bump lizyml compat to >=0.10,<0.13 (P-030, closes #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-08
+
+### Changed
+- **Required lizyml version bumped to `>=0.10.0,<0.13`** (P-030, [#112](https://github.com/nbx-liz/LizyML-Widget/issues/112))
+  — the widget now admits lizyml 0.10 / 0.11 / 0.12. Lower bound is raised to
+  0.10.0 because the Adapter relies on lizyml 0.10's `FitResult.target_encoder`
+  for label dtype preservation; running the new code paths against 0.9.x would
+  surface late-bound `AttributeError`. Existing users on lizyml 0.9.x must
+  upgrade alongside the widget.
+
+### Added
+- **Non-numeric classification target round-trip** (P-030) — lizyml 0.10
+  auto-encodes non-numeric `y` (`object` / `pd.StringDtype` / `category` / `bool`)
+  via `TargetEncoder` and decodes predictions back to the original label dtype.
+  The widget now passes that contract through transparently: `LizyWidget.predict()`
+  on a multiclass model trained on string labels returns `pred` values like
+  `"Adelie"` / `"Chinstrap"` rather than int codes. New regression test
+  `test_reg_112_target_encoder_roundtrip.py` locks this in.
+- **smape / wape regression metrics** (P-030) — lizyml 0.11's zero-tolerant
+  percentage-style regression metrics are now exposed in the BackendContract
+  `model_metric.regression` option set, surfaced as Search Space / Model tab
+  metric chips, and routed correctly by tune direction resolution
+  (`MODEL_METRIC_TO_EVAL` identity mappings + `minimize` direction).
+
+### Compatibility
+- The widget's compat-matrix doc (`docs/VERSION_COMPAT.md`) gains a new top
+  row pinning `lizyml-widget 0.9.x` to `lizyml >=0.10.0,<0.13`. Older widgets
+  remain documented for past-release reference.
+- The 0.12 resumable-tuning Optuna storage is **not** surfaced through the
+  widget UI in this release — that exposure is tracked separately and will
+  ship under a follow-up Proposal.
+
 ## [0.8.0] - 2026-04-12
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,95 @@
 ## LizyML-Widget 仕様変更履歴
 
+### P-030: lizyml 0.10 / 0.11 / 0.12 互換窓拡大
+
+- **日付**: 2026-05-08
+- **ステータス**: 提案
+- **関連 Issue**: [#112](https://github.com/nbx-liz/LizyML-Widget/issues/112)
+- **背景**:
+  - LizyML が 0.9.0 公開後に `0.9.1` / `0.10.0` / `0.11.0` / `0.12.0` を続けて release。
+  - lizyml-widget 0.8.0 は `lizyml>=0.9.0,<0.10` に固定されており、`pyproject.toml` の extra と
+    `src/lizyml_widget/adapter.py` の `LIZYML_MIN_VERSION` / `LIZYML_MAX_VERSION` が二重に
+    範囲を強制するため、ユーザー側で `lizyml>=0.10` を選択できない。
+  - 0.10–0.12 の主な変更は **加算的（破壊的変更なし）**:
+    - **0.10**: 非数値分類ラベル自動エンコード（`FitResult.target_encoder` 新設、`FORMAT_VERSION` 1→2、
+      旧 v1 artifact は `Model.load()` が in-memory migrate する）、新エラーコード `TARGET_NOT_NUMERIC` /
+      `TARGET_UNSEEN_LABEL`。
+    - **0.11**: 回帰メトリック `smape` / `wape` を `MetricRegistry` に追加、LightGBM feval bridge 経由で
+      `eval_history` / 学習曲線にも反映。
+    - **0.12**: Optuna 永続化ストレージによる resumable tuning（`Tuner.tune(storage=, study_name=)` 追加、
+      `storage=None` で従来挙動）。
+- **提案内容**:
+  - **Phase 1 — 互換窓拡大（基盤）**:
+    - `pyproject.toml` の lizyml extras を `>=0.10.0,<0.13` に更新（**lower bound を 0.10 に切り上げ**: 0.10
+      の `target_encoder` 経由のラベル dtype 保持を Widget 側でも前提とするため）。
+    - `LIZYML_MIN_VERSION = (0, 10, 0)`, `LIZYML_MAX_VERSION = (0, 13, 0)` に更新。
+    - `tests/test_retune_monitoring.py` の guard 定数アサートを追従。
+    - `docs/VERSION_COMPAT.md` に新行追加（`lizyml-widget 0.9.x` ↔ `lizyml >=0.10.0,<0.13`）。
+    - `uv.lock` を `uv lock --upgrade-package lizyml` で再生成。
+  - **Phase 2 — 0.10 統合**:
+    - `LizyMLAdapter.predict()` は `result.pred` がすでに元 dtype（object / category / bool）でデコード済み
+      な前提で受け取り、pandas DataFrame に dtype を保持して載せ替えるだけに留める。
+    - 新エラーコード `TARGET_NOT_NUMERIC` / `TARGET_UNSEEN_LABEL` は `LizyMLError` の message に含めて
+      `BACKEND_ERROR` 配下で表示する（Widget 側で再分類はしない、UI 上はメッセージで識別）。
+    - 旧 v1 artifact の `Model.load()` 後方互換は lizyml 側で吸収済みのため、Widget 追加実装は不要。
+      回帰テストでのみ verify する。
+  - **Phase 3 — 0.11 統合**:
+    - `adapter_params.py` の回帰タスク metric option set に `smape` / `wape` を追加。
+    - `adapter_schema.py` の Search Space catalog（regression metric 選択肢）に `smape` / `wape` を加える。
+    - `LizyMLAdapter.plot()` の `learning-curve` 経路は既存 `metrics` kwarg 透過で動作（追加実装不要、
+      e2e テストで検証）。
+  - **Phase 4 — 0.12 決定**:
+    - **本 Proposal の範囲では UI 露出しない**。`Tuner.tune(storage=, study_name=)` を Widget で公開する場合
+      SQLite ファイル lifecycle / kernel 横断 study 共有 / cleanup の設計が必要となるため、別 Proposal
+      （P-031 仮）で扱う。compat 範囲に 0.12 を含めること自体の動作確認は Phase 1 + Phase 5 の smoke で
+      カバーする。
+- **影響範囲**:
+  - `pyproject.toml` — extras / dev dependency 範囲（**change gate**: 外部依存変更）
+  - `uv.lock` — 再生成
+  - `src/lizyml_widget/adapter.py` — `LIZYML_MIN_VERSION` / `LIZYML_MAX_VERSION` 定数（**change gate**:
+    BackendAdapter Protocol の依存）
+  - `src/lizyml_widget/adapter_params.py` — regression metric option set
+  - `src/lizyml_widget/adapter_schema.py` — Search Space catalog の regression metric
+  - `tests/test_retune_monitoring.py` — guard 定数アサート
+  - `tests/regression/test_reg_112_target_encoder_roundtrip.py` — 新規（非数値ラベル分類の round-trip）
+  - `tests/regression/test_reg_112_smape_wape.py` — 新規（回帰メトリック登録 + learning curve）
+  - `docs/VERSION_COMPAT.md` — 新行
+  - `CHANGELOG.md` — `[0.9.0]` セクション
+  - `HISTORY.md` — 本 Proposal
+- **互換性**:
+  - **Widget 0.9.0 リリース時、lizyml 0.9.x ユーザーは強制的に 0.10 へアップグレードが必要**。
+    0.9.x の `Model.fit` / `Model.tune` / `Model.predict` 公開 API は 0.10 で互換維持されているため、
+    アップグレード自体は import 互換のはず（ただし `FORMAT_VERSION` バンプにより lizyml 0.9 で保存した
+    `model.lizyml` artifact を 0.9 で再ロードする経路は 0.10 への移行で 1 度だけ migrate される）。
+  - `BackendAdapter` Protocol のシグネチャは無変更。
+  - `FitSummary` / `TuningSummary` / `PredictionSummary` / `BackendInfo` の構造は無変更（0.10 の
+    `target_encoder` フィールドは Adapter 内部で吸収、Widget の共通型には漏らさない）。
+  - 既存 traitlet / action / Python API の互換破壊なし。
+  - JS 側の backend_contract 駆動 UI は無変更（metric option set は backend 経由で配信）。
+- **代替案（却下）**:
+  - **案A: 0.10 / 0.11 / 0.12 を別々の PR / Proposal に分割** — 加算的変更が中心で blast radius が小さい
+    ため、3 PR 分の CI / レビューコストに見合わない。単一 PR で段階コミットする方が churn が少ない。
+  - **案B: 互換窓を `>=0.9.0,<0.13` のままにして 0.9 ユーザーを残す** — 0.10 の `target_encoder` を
+    Adapter 内で前提として書くと 0.9 環境では型・属性が存在せず実行時に失敗する。条件分岐で吸収する
+    複雑さは長期保守負債になるため不採用。
+  - **案C: 0.12 の resumable tuning を本 PR で UI 露出する** — SQLite path 解決 / kernel restart 横断 /
+    Widget 間 study 共有 / cleanup は独立した設計が必要。本 Proposal の主目的（compat 窓拡大）から外して
+    P-031（仮）に分離する。
+- **受け入れ基準**:
+  - `pip install "lizyml-widget[lizyml]"` で `lizyml==0.12.x` が解決される。
+  - `LizyWidget` の import / Fit / Tune / Inference が `lizyml==0.12.0` で全 green
+    （Python 3.10 / 3.11 / 3.12 マトリクス CI）。
+  - 非数値ラベル分類（`y` が `object` / `category` / `bool`）で `LizyWidget.fit()` → `predict()` が
+    元 dtype を保持して結果を返す（回帰テストで assert）。
+  - 回帰タスクで `metric=["smape", "wape"]` が backend に届き、学習曲線にプロットされる
+    （e2e テストで assert）。
+  - 旧 lizyml 0.9.x で保存された `model.lizyml` artifact が `Model.load()` 経由で読み込めることを
+    smoke テストで確認（fixture 整備）。
+  - `ruff check` / `ruff format --check` / `mypy --strict` / `pytest` / `eslint` / `tsc` / `vitest` 全 green。
+  - `docs/VERSION_COMPAT.md` の対応表最上行が `lizyml-widget 0.9.x ↔ lizyml >=0.10.0,<0.13` になっている。
+
+---
+
 ### Bug Fix: Convergence Signal の Round 表示 +1 ずれ + チェックマーク escape 不正
 
 - **日付**: 2026-04-12

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,16 @@
 ### P-030: lizyml 0.10 / 0.11 / 0.12 互換窓拡大
 
 - **日付**: 2026-05-08
-- **ステータス**: 提案
+- **ステータス**: 承認・実装
 - **関連 Issue**: [#112](https://github.com/nbx-liz/LizyML-Widget/issues/112)
+- **決定事項**:
+  - **Phase 1–3 を実装**: 互換窓拡大 (`>=0.10.0,<0.13`) + 0.10 の非数値ラベル分類の通過確認 +
+    0.11 の `smape` / `wape` 回帰メトリックの BackendContract 露出。
+  - **Phase 4 (0.12 resumable tuning) は本 Proposal では UI 露出しない**: `Tuner.tune(storage=, study_name=)`
+    の Widget 経由公開は SQLite path lifecycle / kernel 横断 study 共有 / cleanup の独立した設計を要するため、
+    将来の P-031（仮）で扱う。0.12 を compat 範囲に含めること自体の動作確認は Phase 1 + Phase 5 の smoke で
+    完了している。
+  - **Widget 0.9.0 として release**: lizyml 0.9.x は compat 範囲から外れるため、minor bump とする。
 - **背景**:
   - LizyML が 0.9.0 公開後に `0.9.1` / `0.10.0` / `0.11.0` / `0.12.0` を続けて release。
   - lizyml-widget 0.8.0 は `lizyml>=0.9.0,<0.10` に固定されており、`pyproject.toml` の extra と

--- a/docs/VERSION_COMPAT.md
+++ b/docs/VERSION_COMPAT.md
@@ -13,7 +13,8 @@ LizyML-Widget は `lizyml` の ML 仕様（`Config schema`, `TuningResult`,
 
 | lizyml-widget | lizyml               | Python  | 主な新機能 / 破壊的変更                                               |
 | ------------- | -------------------- | ------- | --------------------------------------------------------------------- |
-| **0.8.x**     | `>=0.9.0, <0.10`     | `>=3.10`| Re-tune（Round progress, Boundary Expansion, Tuning History, `w.retune()` API, UI ボタン）|
+| **0.9.x**     | `>=0.10.0, <0.13`    | `>=3.10`| 非数値ラベル分類（`FitResult.target_encoder`）, 回帰メトリック `smape` / `wape`, lizyml 0.10–0.12 対応 |
+| 0.8.x         | `>=0.9.0, <0.10`     | `>=3.10`| Re-tune（Round progress, Boundary Expansion, Tuning History, `w.retune()` API, UI ボタン）|
 | 0.7.x         | `>=0.7.0, <0.9`      | `>=3.10`| Calibration method 既定変更, training seed 既定変更, Search Space 既定値整理 |
 | 0.6.x / 0.5.x | `>=0.5.0, <0.7`      | `>=3.10`| Learning Curve metrics フィルタ, CV strategy metadata                  |
 | 0.4.x         | `>=0.3.0, <0.5`      | `>=3.10`| Canonical config, Backend Contract 駆動 UI                             |
@@ -37,10 +38,10 @@ LizyML-Widget は `lizyml` の ML 仕様（`Config schema`, `TuningResult`,
 
 ```toml
 [project.optional-dependencies]
-lizyml = ["lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10"]
+lizyml = ["lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13"]
 ```
 
-のように **lower bound = 0.9.0**, **upper bound = 0.10 未満** の厳密範囲を
+のように **lower bound = 0.10.0**, **upper bound = 0.13 未満** の厳密範囲を
 指定する。
 
 ---
@@ -54,7 +55,7 @@ pip install "lizyml-widget[lizyml]"
 ```
 
 - pip / uv / Poetry の resolver が自動的に互換な `lizyml` を選択する。
-- optional extras `[lizyml]` は `lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10`
+- optional extras `[lizyml]` は `lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13`
   を内包する。
 - ユーザー側で `lizyml` のバージョンを気にする必要がない。
 
@@ -65,7 +66,7 @@ pip install "lizyml-widget[lizyml]"
 ```bash
 pip install lizyml-widget
 # lizyml は既に入っているが、互換バージョンに合わせる必要がある
-pip install "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10"
+pip install "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13"
 ```
 
 - 既存の `lizyml==0.7.x` などがあると pip resolver が **ResolutionImpossible** を
@@ -89,17 +90,17 @@ Colab は pip の resolver がラックして古い `lizyml` を強制するこ�
 
 ## トラブルシューティング
 
-### `ImportError: lizyml-widget requires lizyml>=0.9.0`
+### `ImportError: lizyml-widget requires lizyml>=0.10.0`
 
 - 旧い `lizyml` がインストールされている。
 - 解決策:
   ```bash
-  pip install --upgrade "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10"
+  pip install --upgrade "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13"
   ```
 
-### `AttributeError: 'TuningResult' object has no attribute 'rounds'`
+### `AttributeError: 'FitResult' object has no attribute 'target_encoder'`
 
-- `lizyml < 0.9.0` が残存している（インストール順の問題）。
+- `lizyml < 0.10.0` が残存している（インストール順の問題）。
 - 仮想環境を作り直すか、`pip list | grep lizyml` で実際のバージョンを確認する。
 
 ### pip resolver が `ResolutionImpossible` を返す
@@ -118,9 +119,9 @@ LizyML-Widget は import 時に `lizyml` の version を検証する。
 ```python
 >>> from lizyml_widget import LizyWidget
 >>> w = LizyWidget()
-ImportError: lizyml-widget 0.5.0 requires lizyml>=0.9.0,<0.10
-  (found: lizyml==0.7.3). Run:
-  pip install --upgrade "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10"
+ImportError: lizyml-widget 0.9.0 requires lizyml>=0.10.0,<0.13
+  (found: lizyml==0.9.1). Run:
+  pip install --upgrade "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13"
 ```
 
 この検証は `LizyMLAdapter.__init__` で行われ、

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Repository = "https://github.com/nbx-liz/LizyML-Widget"
 # The upper bound is excluded so that new minor releases with potentially
 # incompatible type/contract changes do not silently break the widget.
 # See docs/VERSION_COMPAT.md for the full compatibility matrix.
-lizyml = ["lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10"]
+lizyml = ["lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13"]
 dev = [
     "pytest>=7.0",
     "ruff>=0.4",
@@ -48,7 +48,7 @@ dev = [
     "jupyterlab>=4.0",
     "ipykernel>=6.0",
     "pandas-stubs>=2.0",
-    "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10",
+    "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13",
     "scikit-learn>=1.0",
     "watchfiles>=1.1",
 ]
@@ -94,7 +94,7 @@ dev = [
     "jupyterlab>=4.0",
     "ipykernel>=6.0",
     "pandas-stubs>=2.0",
-    "lizyml[plots,tuning,calibration,explain]>=0.9.0,<0.10",
+    "lizyml[plots,tuning,calibration,explain]>=0.10.0,<0.13",
     "scikit-learn>=1.0",
     "watchfiles>=1.1",
     "twine>=6.2.0",

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -129,10 +129,12 @@ class BackendAdapter(Protocol):
     def plot_inference(self, predictions: pd.DataFrame, plot_type: str) -> PlotData: ...
 
 
-#: Minimum supported lizyml version (inclusive). P-027: re-tune monitoring.
-LIZYML_MIN_VERSION = (0, 9, 0)
-#: Maximum supported lizyml version (exclusive).
-LIZYML_MAX_VERSION = (0, 10, 0)
+#: Minimum supported lizyml version (inclusive). P-030: bumped to 0.10.0
+#: because the Adapter assumes target_encoder-driven label dtype preservation
+#: (FitResult.target_encoder, FORMAT_VERSION=2 — added in lizyml 0.10).
+LIZYML_MIN_VERSION = (0, 10, 0)
+#: Maximum supported lizyml version (exclusive). P-030: covers 0.10 / 0.11 / 0.12.
+LIZYML_MAX_VERSION = (0, 13, 0)
 
 
 def _parse_lizyml_version(raw: str) -> tuple[int, ...]:

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -876,6 +876,10 @@ class LizyMLAdapter:
     ) -> PredictionSummary:
         import numpy as np
 
+        # P-030: lizyml>=0.10 returns ``result.pred`` already decoded back to
+        # the original target dtype (e.g. "Adelie" rather than int code 2)
+        # via ``FitResult.target_encoder``. Pandas preserves that dtype when
+        # we wrap it directly, so no extra conversion is needed here.
         result = model.predict(data, return_shap=return_shap)
         df = pd.DataFrame({"pred": result.pred})
 

--- a/src/lizyml_widget/adapter_contract.py
+++ b/src/lizyml_widget/adapter_contract.py
@@ -108,6 +108,8 @@ def build_ui_schema(all_metrics_by_task: dict[str, list[str]]) -> dict[str, Any]
                     "rmse",
                     "quantile",
                     "mape",
+                    "smape",
+                    "wape",
                     "huber",
                     "fair",
                     "poisson",

--- a/src/lizyml_widget/adapter_params.py
+++ b/src/lizyml_widget/adapter_params.py
@@ -50,6 +50,9 @@ MODEL_METRIC_TO_EVAL: Mapping[str, str] = _types.MappingProxyType(
         "rmse": "rmse",
         "r2": "r2",
         "rmsle": "rmsle",
+        # P-030: zero-tolerant percentage-style metrics added in lizyml 0.11.
+        "smape": "smape",
+        "wape": "wape",
         # Regression native metrics without LizyML eval equivalent — map to
         # nearest eval metric for tune direction resolution (all minimize)
         "fair": "mae",
@@ -197,10 +200,11 @@ def get_eval_metrics_by_task() -> dict[str, list[str]]:
                 task: _sort_with_preferred(list(ms), task) for task, ms in _TASK_METRICS.items()
             }
         except (ImportError, AttributeError, TypeError):
-            # Fallback for older LizyML versions without _TASK_METRICS
+            # Fallback for older LizyML versions without _TASK_METRICS.
+            # P-030: smape / wape were added in lizyml 0.11.
             metrics = {
                 "regression": _sort_with_preferred(
-                    ["mae", "mape", "rmse", "huber", "r2", "rmsle"], "regression"
+                    ["mae", "mape", "rmse", "huber", "r2", "rmsle", "smape", "wape"], "regression"
                 ),
                 "binary": _sort_with_preferred(
                     [

--- a/tests/test_adapter_core.py
+++ b/tests/test_adapter_core.py
@@ -88,12 +88,13 @@ def _capture_log(logger: logging.Logger, level: int = logging.WARNING):
 class TestInfo:
     # P-027: adapter.__init__ now asserts lizyml is in the supported range,
     # so the sentinel version must fall within LIZYML_MIN/MAX.
-    @patch.dict("sys.modules", {"lizyml": MagicMock(__version__="0.9.1")})
+    # P-030: window bumped to >=0.10.0,<0.13.0.
+    @patch.dict("sys.modules", {"lizyml": MagicMock(__version__="0.12.0")})
     def test_info(self) -> None:
         adapter = LizyMLAdapter()
         info = adapter.info
         assert info.name == "lizyml"
-        assert info.version == "0.9.1"
+        assert info.version == "0.12.0"
 
 
 class TestConfigContractValidation:

--- a/tests/test_model_metric_validity.py
+++ b/tests/test_model_metric_validity.py
@@ -30,6 +30,9 @@ EXPECTED_REGRESSION = {
     # LizyML feval
     "r2",
     "rmsle",
+    # P-030: zero-tolerant percentage-style metrics added in lizyml 0.11.
+    "smape",
+    "wape",
 }
 
 EXPECTED_BINARY = {

--- a/tests/test_reg_112_smape_wape.py
+++ b/tests/test_reg_112_smape_wape.py
@@ -1,0 +1,86 @@
+"""Regression test for #112 / P-030: lizyml 0.11 smape / wape regression metrics.
+
+Two seams to lock down so users can pick the new metrics from the Widget UI:
+
+1. The ``model_metric.regression`` option set in ``BackendContract.ui_schema``
+   exposes ``smape`` and ``wape`` so they appear as metric chips in
+   Search Space / Model tab.
+2. ``MODEL_METRIC_TO_EVAL`` carries identity mappings for both names so tune
+   direction resolution (``minimize``) works when ``model.params.metric``
+   is set to ``smape`` or ``wape``.
+
+These cover the bookkeeping side. End-to-end propagation through
+``Model.fit(metric=['smape', 'wape'])`` -> ``eval_history`` is already
+covered by lizyml's own test suite; we only assert the Widget passes the
+metric name through to the LightGBM bridge without mangling it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.adapter_params import MODEL_METRIC_TO_EVAL
+
+
+@pytest.fixture()
+def adapter() -> LizyMLAdapter:
+    return LizyMLAdapter()
+
+
+class TestModelMetricOptionSet:
+    """smape / wape must be selectable as model.params.metric for regression."""
+
+    def test_smape_in_regression_model_metric(self, adapter: LizyMLAdapter) -> None:
+        contract = adapter.get_backend_contract()
+        regression = contract.ui_schema["option_sets"]["model_metric"]["regression"]
+        assert "smape" in regression
+
+    def test_wape_in_regression_model_metric(self, adapter: LizyMLAdapter) -> None:
+        contract = adapter.get_backend_contract()
+        regression = contract.ui_schema["option_sets"]["model_metric"]["regression"]
+        assert "wape" in regression
+
+
+class TestEvalMetricMapping:
+    """smape / wape need identity mappings so tune direction resolves correctly."""
+
+    def test_smape_identity_mapping(self) -> None:
+        assert MODEL_METRIC_TO_EVAL.get("smape") == "smape"
+
+    def test_wape_identity_mapping(self) -> None:
+        assert MODEL_METRIC_TO_EVAL.get("wape") == "wape"
+
+
+class TestRegressionFitWithSmapeWape:
+    """End-to-end: fit a regression model with metric=['smape', 'wape']."""
+
+    def _make_regression_df(self, *, seed: int = 42, n: int = 80) -> pd.DataFrame:
+        rng = np.random.default_rng(seed)
+        x1 = rng.normal(size=n)
+        x2 = rng.normal(size=n)
+        y = 2.0 * x1 + 0.5 * x2 + rng.normal(scale=0.1, size=n)
+        return pd.DataFrame({"x1": x1, "x2": x2, "y": y})
+
+    def test_smape_wape_appear_in_eval_history(self, adapter: LizyMLAdapter) -> None:
+        df = self._make_regression_df()
+        config = adapter.initialize_config(task="regression")
+        config["task"] = "regression"
+        config["data"] = {"target": "y"}
+        config["model"]["params"]["n_estimators"] = 5
+        config["model"]["params"]["verbose"] = -1
+        config["model"]["params"]["metric"] = ["smape", "wape"]
+        config["training"] = {"seed": 42}
+
+        run_config = adapter.prepare_run_config(config, job_type="fit", task="regression")
+        model = adapter.create_model(run_config, df)
+        adapter.fit(model)
+
+        history = model.fit_result.history[0].get("eval_history", {})
+        all_metrics: set[str] = set()
+        for ds_metrics in history.values():
+            all_metrics.update(ds_metrics.keys())
+        assert "smape" in all_metrics, f"smape missing from eval_history; got {all_metrics}"
+        assert "wape" in all_metrics, f"wape missing from eval_history; got {all_metrics}"

--- a/tests/test_reg_112_target_encoder_roundtrip.py
+++ b/tests/test_reg_112_target_encoder_roundtrip.py
@@ -1,0 +1,106 @@
+"""Regression test for #112 / P-030: lizyml 0.10 target_encoder round-trip.
+
+Ensures the Adapter passes non-numeric classification labels through
+``Model.fit`` -> ``Model.predict`` while preserving the original label
+dtype, leveraging lizyml 0.10's ``FitResult.target_encoder``.
+
+Two failure modes this guards against:
+
+1. The Adapter could accidentally coerce ``result.pred`` to numeric int
+   codes (loses dtype). Exercises the ``LizyMLAdapter.predict`` path
+   end-to-end with a real lizyml backend.
+2. ``task='regression'`` with a non-numeric target must surface the new
+   ``TARGET_NOT_NUMERIC`` error code from lizyml as a Widget
+   ``BACKEND_ERROR`` (no silent failure or generic LightGBM crash).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+
+
+def _make_classification_df(*, seed: int = 42, n: int = 80) -> pd.DataFrame:
+    """Toy multiclass dataset with non-numeric (object) labels."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "x1": rng.normal(size=n),
+            "x2": rng.normal(size=n),
+            "species": rng.choice(["Adelie", "Chinstrap", "Gentoo"], size=n),
+        }
+    )
+
+
+@pytest.fixture()
+def adapter() -> LizyMLAdapter:
+    return LizyMLAdapter()
+
+
+class TestNonNumericLabelRoundTrip:
+    """LizyML 0.10 + non-numeric classification labels: predict preserves dtype."""
+
+    def test_multiclass_predict_returns_original_label_dtype(self, adapter: LizyMLAdapter) -> None:
+        df = _make_classification_df()
+        config = adapter.initialize_config(task="multiclass")
+        config["task"] = "multiclass"
+        config["data"] = {"target": "species"}
+        config["model"]["params"]["n_estimators"] = 5
+        config["model"]["params"]["verbose"] = -1
+        config["training"] = {"seed": 42}
+
+        run_config = adapter.prepare_run_config(config, job_type="fit", task="multiclass")
+        model = adapter.create_model(run_config, df)
+        adapter.fit(model)
+
+        # target_encoder is the lizyml 0.10 marker — must exist and carry classes_
+        encoder = getattr(model.fit_result, "target_encoder", None)
+        assert encoder is not None, "FitResult.target_encoder missing (lizyml<0.10?)"
+        classes = list(getattr(encoder, "classes_", ()) or ())
+        assert {"Adelie", "Chinstrap", "Gentoo"} <= set(classes)
+
+        # Predict — pred column should hold the *original* string labels,
+        # not the integer codes used internally.
+        result = adapter.predict(model, df.drop(columns=["species"]))
+        pred_col = result.predictions["pred"]
+        sample = pred_col.iloc[:5].tolist()
+        assert all(isinstance(v, str) for v in sample), (
+            f"expected str-typed predictions, got {[type(v).__name__ for v in sample]}"
+        )
+        assert set(sample) <= {"Adelie", "Chinstrap", "Gentoo"}, (
+            f"unexpected label outside training set: {sample}"
+        )
+
+
+class TestTargetNotNumericRaisesBackendError:
+    """LizyML 0.10 raises TARGET_NOT_NUMERIC for regression on non-numeric y."""
+
+    def test_regression_with_string_target_raises_backend_error(
+        self, adapter: LizyMLAdapter
+    ) -> None:
+        from lizyml.core.exceptions import LizyMLError
+
+        df = _make_classification_df()
+        config = adapter.initialize_config(task="regression")
+        config["task"] = "regression"
+        config["data"] = {"target": "species"}
+        config["model"]["params"]["n_estimators"] = 5
+        config["model"]["params"]["verbose"] = -1
+        config["training"] = {"seed": 42}
+
+        run_config = adapter.prepare_run_config(config, job_type="fit", task="regression")
+        model = adapter.create_model(run_config, df)
+        with pytest.raises(LizyMLError) as excinfo:
+            adapter.fit(model)
+
+        # Code attribute carries the new error tag introduced in lizyml 0.10.
+        code: Any = getattr(excinfo.value, "code", None)
+        # Code may be an Enum (ErrorCode.TARGET_NOT_NUMERIC) or a bare string —
+        # accept both shapes so this test survives lizyml-side refactors.
+        code_str = getattr(code, "name", None) or str(code)
+        assert "TARGET_NOT_NUMERIC" in code_str

--- a/tests/test_retune_monitoring.py
+++ b/tests/test_retune_monitoring.py
@@ -43,13 +43,17 @@ class TestVersionGuard:
         assert _parse_lizyml_version("0.9") == (0, 9, 0)
 
     def test_version_range_constants(self) -> None:
-        assert LIZYML_MIN_VERSION == (0, 9, 0)
-        assert LIZYML_MAX_VERSION == (0, 10, 0)
+        # P-030: lizyml 0.10–0.12 compat window. Lower bound bumped to 0.10.0
+        # because the Adapter assumes target_encoder-driven label dtype
+        # preservation (a 0.10+ feature). Upper bound is exclusive 0.13 so
+        # 0.12.x patches are still admitted without a guard bump.
+        assert LIZYML_MIN_VERSION == (0, 10, 0)
+        assert LIZYML_MAX_VERSION == (0, 13, 0)
 
     def test_check_passes_for_supported_version(self) -> None:
         with patch.dict(
             "sys.modules",
-            {"lizyml": MagicMock(__version__="0.9.5")},
+            {"lizyml": MagicMock(__version__="0.12.0")},
         ):
             _check_lizyml_version()  # must not raise
 
@@ -57,9 +61,9 @@ class TestVersionGuard:
         with (
             patch.dict(
                 "sys.modules",
-                {"lizyml": MagicMock(__version__="0.7.3")},
+                {"lizyml": MagicMock(__version__="0.9.1")},
             ),
-            pytest.raises(ImportError, match=r"lizyml>=0\.9\.0,<0\.10\.0"),
+            pytest.raises(ImportError, match=r"lizyml>=0\.10\.0,<0\.13\.0"),
         ):
             _check_lizyml_version()
 
@@ -67,9 +71,9 @@ class TestVersionGuard:
         with (
             patch.dict(
                 "sys.modules",
-                {"lizyml": MagicMock(__version__="0.10.0")},
+                {"lizyml": MagicMock(__version__="0.13.0")},
             ),
-            pytest.raises(ImportError, match=r"lizyml>=0\.9\.0,<0\.10\.0"),
+            pytest.raises(ImportError, match=r"lizyml>=0\.10\.0,<0\.13\.0"),
         ):
             _check_lizyml_version()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1452,7 +1452,7 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.9.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -1466,9 +1466,9 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/74/3a4275bb82da96109e881496dc9929eb37ab298209d35027d7a22151bb90/lizyml-0.9.0.tar.gz", hash = "sha256:11648172e0e9ec7b96eb2837159ef58a9c8265b085d934c91e8dc0842b448eda", size = 633317, upload-time = "2026-04-11T15:58:33.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/df/06d74bfea3920dfc7e78d59f8b434d889c610ddcc270caac54819ca006e1/lizyml-0.12.0.tar.gz", hash = "sha256:ee8e09f253571e471b903b58a72c0f8cd090938ba9c0b170bf37cec2ec983ef8", size = 666099, upload-time = "2026-05-06T06:38:55.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/ac/07abdfa6b62bf132b60398ec42fe8d7ff553c7ec9011bd3cc17659731ff0/lizyml-0.9.0-py3-none-any.whl", hash = "sha256:e8eaacde5efd50b3a7c10f7431f69edbd378bd725117cd24b2454abf8ec9f49a", size = 151674, upload-time = "2026-04-11T15:58:31.921Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a7/e1bb82e0c03255861a6fe2e97c2677fba3284e4321a3d00fc61e6971f561/lizyml-0.12.0-py3-none-any.whl", hash = "sha256:3b6f8ba39d635678fd46534dffb31df8a3dfcc3f3efa1915a4c9fc1d821bcd5b", size = 158117, upload-time = "2026-05-06T06:38:54.15Z" },
 ]
 
 [package.optional-dependencies]
@@ -1543,8 +1543,8 @@ requires-dist = [
     { name = "anywidget", specifier = ">=0.9" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jupyterlab", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'dev'", specifier = ">=0.9.0,<0.10" },
-    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'lizyml'", specifier = ">=0.9.0,<0.10" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'dev'", specifier = ">=0.10.0,<0.13" },
+    { name = "lizyml", extras = ["calibration", "explain", "plots", "tuning"], marker = "extra == 'lizyml'", specifier = ">=0.10.0,<0.13" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pandas", specifier = ">=1.5" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.0" },
@@ -1561,7 +1561,7 @@ provides-extras = ["dev", "lizyml"]
 dev = [
     { name = "ipykernel", specifier = ">=6.0" },
     { name = "jupyterlab", specifier = ">=4.0" },
-    { name = "lizyml", extras = ["plots", "tuning", "calibration", "explain"], specifier = ">=0.9.0,<0.10" },
+    { name = "lizyml", extras = ["plots", "tuning", "calibration", "explain"], specifier = ">=0.10.0,<0.13" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pandas-stubs", specifier = ">=2.0" },
     { name = "playwright", specifier = ">=1.58.0" },


### PR DESCRIPTION
## Summary

Closes #112. Bumps the widget's lizyml compatibility window from `>=0.9.0,<0.10` to `>=0.10.0,<0.13`, picking up lizyml 0.10 / 0.11 / 0.12 in a single phased PR. Per Proposal **P-030** in [HISTORY.md](HISTORY.md):

- **Phase 0**: Proposal P-030 recorded with full impact / alternatives / acceptance criteria.
- **Phase 1**: `LIZYML_MIN_VERSION = (0, 10, 0)` / `LIZYML_MAX_VERSION = (0, 13, 0)`. `pyproject.toml` extras + dev group + `uv.lock` regenerated. `docs/VERSION_COMPAT.md` matrix and trouble-shooting examples refreshed.
- **Phase 2**: lizyml 0.10's non-numeric classification target round-trip is now contractually guaranteed. The Adapter requires no behavioural change — `result.pred` already arrives back in original label dtype via `FitResult.target_encoder`. Locked in by [test_reg_112_target_encoder_roundtrip.py](tests/test_reg_112_target_encoder_roundtrip.py); also asserts `task='regression'` with non-numeric `y` raises `LizyMLError(code=TARGET_NOT_NUMERIC)` so the Widget's existing `BACKEND_ERROR` classifier surfaces it.
- **Phase 3**: lizyml 0.11's `smape` / `wape` regression metrics added to the BackendContract `model_metric.regression` option set, with identity mappings in `MODEL_METRIC_TO_EVAL` so tune direction resolution routes them to `minimize`. Verified end-to-end through `eval_history` in [test_reg_112_smape_wape.py](tests/test_reg_112_smape_wape.py).
- **Phase 4**: lizyml 0.12 resumable-tuning storage **deferred** to a follow-up Proposal (P-031, design needed for SQLite path lifecycle / kernel-restart-spanning study sharing).

Lower bound is intentionally raised to 0.10.0 because the Adapter now relies on `target_encoder` semantics; 0.9.x users must upgrade alongside the widget. Documented in CHANGELOG `[0.9.0]` and VERSION_COMPAT.md.

## Test plan

- [x] `uv run pytest -q` — **868 passed** under lizyml 0.12.0
- [x] `uv run ruff check .` / `ruff format --check .` — green
- [x] `uv run mypy src/lizyml_widget/` — no issues in 12 source files
- [x] `pnpm test` (vitest, frontend) — **175 passed**
- [x] `pnpm lint` (eslint) — green
- [x] Pre-existing `tsc --noEmit` errors in `StickyTabs.test.tsx` / `ConfigTab.tsx` unchanged (out of scope)
- [x] Smoke: `LizyWidget` end-to-end Fit + Predict on a multiclass DataFrame with string labels (`Adelie` / `Chinstrap` / `Gentoo`) returns predictions in original `str` dtype
- [x] Smoke: regression + `metric=["smape", "wape"]` reaches `eval_history` for both metrics
- [ ] CI matrix (Python 3.10 / 3.11 / 3.12) — pending CI run on this PR
