### PR TITLE
fix(quality): close HIGH-tier code-review findings (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Code quality**: Closed two HIGH-tier code-review findings ([#115](https://github.com/nbx-liz/LizyML-Widget/issues/115)).
+  - `LizyWidget.model_info` now routes through a new `WidgetService.model_info(model)`
+    delegate instead of reaching into `Service._adapter` private state.
+  - Bare `except Exception: pass` blocks in `WidgetService._default_strategy_for_task`,
+    `WidgetService._default_cv_state`, and `_job_worker`'s tune-only fit-summary
+    fallback have been narrowed to documented exception types and now leave a
+    `_log.debug` breadcrumb instead of swallowing silently.
+
 ## [0.9.0] - 2026-05-08
 
 ### Changed

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -740,6 +740,10 @@ class WidgetService:
         with self._model_lock:
             return self._model
 
+    def model_info(self, model: Any) -> dict[str, Any]:
+        """Return adapter-side metadata for the given model."""
+        return self._adapter.model_info(model)
+
     def classify_best_params(
         self, params: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
@@ -905,8 +909,8 @@ class WidgetService:
             defaults = contract.capabilities.get("cv_default_strategy", {})
             if task in defaults:
                 return str(defaults[task])
-        except Exception:
-            pass
+        except (AttributeError, KeyError, TypeError) as exc:
+            _log.debug("cv_default_strategy contract read failed: %s", exc)
         # Fallback
         return "stratified_kfold" if task in ("binary", "multiclass") else "kfold"
 
@@ -917,8 +921,8 @@ class WidgetService:
         try:
             contract = self._adapter.get_backend_contract()
             cv_defaults = contract.capabilities.get("cv_defaults", {})
-        except Exception:
-            pass
+        except (AttributeError, KeyError, TypeError) as exc:
+            _log.debug("cv_defaults contract read failed: %s", exc)
 
         return {
             "strategy": strategy,

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -293,8 +293,9 @@ class LizyWidget(anywidget.AnyWidget):
         if model is None:
             return None
         try:
-            return self._service._adapter.model_info(model)  # noqa: SLF001
-        except Exception:
+            return self._service.model_info(model)
+        except Exception as exc:
+            _log.debug("model_info delegate failed, returning minimal info: %s", exc)
             return {"loaded": True}
 
     def load_inference(self, df: pd.DataFrame) -> LizyWidget:
@@ -1082,8 +1083,12 @@ class LizyWidget(anywidget.AnyWidget):
                             "fold_details": fold_details,
                             "params": [],
                         }
-                except Exception:
-                    pass  # Tune-only: no fit results available
+                except (AttributeError, RuntimeError, ValueError) as exc:
+                    # Tune-only path: lizyml raises RuntimeError("Model has not been fitted")
+                    # when evaluate_table is called on an unfitted model (P-004 R3).
+                    # AttributeError/ValueError cover related "not fitted" surfaces.
+                    # Anything else propagates to the outer handler.
+                    _log.debug("Tune-only fit_summary skipped (model not fitted): %s", exc)
 
             self.available_plots = self._service.get_available_plots()
             self.elapsed_sec = round(time.monotonic() - start, 1)

--- a/tests/test_contract_cv.py
+++ b/tests/test_contract_cv.py
@@ -163,12 +163,13 @@ class TestServiceCvDelegation:
         # Task not in contract defaults -> fallback
         assert svc._default_strategy_for_task("unknown_task") == "kfold"
 
-    def test_default_strategy_fallback_on_adapter_error(self) -> None:
+    def test_default_strategy_fallback_on_contract_shape_error(self) -> None:
+        """KeyError/AttributeError on contract -> fall back silently (with debug log)."""
         from lizyml_widget.service import WidgetService
 
         adapter = MagicMock()
         adapter.info = {"name": "test", "version": "0.0.0"}
-        adapter.get_backend_contract.side_effect = RuntimeError("no contract")
+        adapter.get_backend_contract.side_effect = AttributeError("missing field")
         adapter.initialize_config.return_value = {
             "model": {"name": "lgbm", "params": {}},
             "training": {},
@@ -177,6 +178,23 @@ class TestServiceCvDelegation:
         assert svc._default_strategy_for_task("binary") == "stratified_kfold"
         assert svc._default_strategy_for_task("regression") == "kfold"
 
+    def test_default_strategy_propagates_unexpected_error(self) -> None:
+        """Non-shape errors (e.g., RuntimeError) must propagate, not silently fall back."""
+        import pytest
+
+        from lizyml_widget.service import WidgetService
+
+        adapter = MagicMock()
+        adapter.info = {"name": "test", "version": "0.0.0"}
+        adapter.get_backend_contract.side_effect = RuntimeError("backend dead")
+        adapter.initialize_config.return_value = {
+            "model": {"name": "lgbm", "params": {}},
+            "training": {},
+        }
+        svc = WidgetService(adapter)
+        with pytest.raises(RuntimeError, match="backend dead"):
+            svc._default_strategy_for_task("binary")
+
     def test_default_cv_state_from_contract(self, service_with_adapter: Any) -> None:
         svc = service_with_adapter
         state = svc._default_cv_state(strategy="kfold", n_splits=3)
@@ -184,12 +202,13 @@ class TestServiceCvDelegation:
         assert state["shuffle"] is False
         assert state["gap"] == 5
 
-    def test_default_cv_state_fallback_on_error(self) -> None:
+    def test_default_cv_state_fallback_on_contract_shape_error(self) -> None:
+        """KeyError/AttributeError on contract -> fall back to documented defaults."""
         from lizyml_widget.service import WidgetService
 
         adapter = MagicMock()
         adapter.info = {"name": "test", "version": "0.0.0"}
-        adapter.get_backend_contract.side_effect = RuntimeError("no contract")
+        adapter.get_backend_contract.side_effect = KeyError("cv_defaults")
         adapter.initialize_config.return_value = {
             "model": {"name": "lgbm", "params": {}},
             "training": {},
@@ -200,6 +219,23 @@ class TestServiceCvDelegation:
         assert state["random_state"] == 42
         assert state["shuffle"] is True
         assert state["gap"] == 0
+
+    def test_default_cv_state_propagates_unexpected_error(self) -> None:
+        """Non-shape errors must propagate, not be silently swallowed."""
+        import pytest
+
+        from lizyml_widget.service import WidgetService
+
+        adapter = MagicMock()
+        adapter.info = {"name": "test", "version": "0.0.0"}
+        adapter.get_backend_contract.side_effect = RuntimeError("backend dead")
+        adapter.initialize_config.return_value = {
+            "model": {"name": "lgbm", "params": {}},
+            "training": {},
+        }
+        svc = WidgetService(adapter)
+        with pytest.raises(RuntimeError, match="backend dead"):
+            svc._default_cv_state(strategy="kfold", n_splits=5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_load_model.py
+++ b/tests/test_load_model.py
@@ -77,3 +77,17 @@ class TestModelInfo:
         w._service._adapter.model_info = MagicMock(side_effect=RuntimeError("boom"))
         info = w.model_info
         assert info == {"loaded": True}
+
+    def test_model_info_routes_through_service_delegate(self) -> None:
+        """Widget must call WidgetService.model_info, not Service._adapter directly."""
+        w = _make_widget()
+        mock_model = MagicMock()
+        w._service._model = mock_model
+        # Replace the service-level delegate; if widget routes through it,
+        # the call signature here is what gets exercised.
+        w._service.model_info = MagicMock(  # type: ignore[method-assign]
+            return_value={"loaded": True, "task": "regression"}
+        )
+        info = w.model_info
+        w._service.model_info.assert_called_once_with(mock_model)
+        assert info == {"loaded": True, "task": "regression"}


### PR DESCRIPTION
## Summary
Closes #115. Two HIGH-severity findings from the post-P-030 code review.

### H-1: Drop Widget -> Service._adapter private access
- New `WidgetService.model_info(model)` transparent delegate.
- `LizyWidget.model_info` now calls the delegate; `noqa: SLF001` on this line removed.

### H-4: Narrow silent `except Exception: pass` blocks
| Site | Caught now | Behaviour |
|---|---|---|
| `service.py:_default_strategy_for_task` | `(AttributeError, KeyError, TypeError)` | logs `debug`; unexpected errors propagate |
| `service.py:_default_cv_state` | same | same |
| `widget.py:_job_worker` tune-only fit_summary | `(AttributeError, RuntimeError, ValueError)` | `RuntimeError` stays — lizyml raises `RuntimeError("Model has not been fitted")` from `evaluate_table` on unfitted models (P-004 R3); other paths covered too |

`adapter.py:746-750` (cancel-path thread abandon) is explicitly out of scope per the issue.

## Test plan
- [x] `uv run pytest --ignore=tests/e2e -q` -> 871 passed (+3 new, replacing 2 updated fixtures)
- [x] `uv run ruff check .` -> clean
- [x] `uv run ruff format --check .` -> clean
- [x] `uv run mypy src/lizyml_widget/` -> clean
- [x] Existing `test_model_info_falls_back_on_adapter_error` still passes (defensive widget-level fallback retained for unexpected adapter errors)
- [x] New `test_model_info_routes_through_service_delegate` asserts the call site uses the delegate
- [x] New `test_default_strategy_propagates_unexpected_error` and `test_default_cv_state_propagates_unexpected_error` lock in non-swallow behaviour

Refs: code review thread on develop after P-030 (#113); CLAUDE.md 8 (no private access) / project rules common/coding-style.md (no silent error swallow).