### PR TITLE
fix(ui): drop hardcoded backend option sets from JS (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Backend contract**: new `cv_strategy_labels` and `additional_params_hidden_keys`
+  capabilities ([#119](https://github.com/nbx-liz/LizyML-Widget/issues/119)).
+  Adding a new CV strategy in `adapter_contract.py` now surfaces in the UI dropdown
+  without any JS edit; a `humaniseSnake()` fallback covers labels missing from the map.
+
+### Changed
+- **JS no longer hardcodes LightGBM-specific catalogs** ([#119](https://github.com/nbx-liz/LizyML-Widget/issues/119)).
+  - `DataTab.tsx`: dropped the `CV_STRATEGIES` literal — strategy chips now derive
+    from `backend_contract.capabilities.cv_strategies`/`cv_strategy_labels`. The
+    `cv.strategy === "kfold"` and `cv.strategy === "blocked_group_kfold"`
+    equality literals are replaced with capability-driven checks.
+  - `FitSubTab.tsx`: `GROUP_STRATEGIES`/`TIME_STRATEGIES` literals replaced with
+    `cv_strategy_fields`-driven derivation.
+  - `ModelEditors.tsx`: `HANDLED_MODEL_FIELDS` static set is gone — derived from
+    `search_space_catalog` (smart_params group) plus structural keys. The
+    `num_leaves ?? 256` defaults are removed; default flows from the catalog.
+    The `verbose / num_threads` exclusion comes from
+    `additional_params_hidden_keys`.
+
 ## [0.9.0] - 2026-05-08
 
 ### Changed

--- a/js/src/__tests__/DataTab.test.tsx
+++ b/js/src/__tests__/DataTab.test.tsx
@@ -27,12 +27,49 @@ const baseDfInfo = {
   },
 };
 
+/** Mirrors the live backend contract for cv strategies — see adapter_contract.build_capabilities. */
+const baseBackendContract = {
+  capabilities: {
+    cv_strategies: [
+      "kfold",
+      "stratified_kfold",
+      "group_kfold",
+      "stratified_group_kfold",
+      "time_series",
+      "purged_time_series",
+      "group_time_series",
+      "blocked_group_kfold",
+    ],
+    cv_strategy_labels: {
+      kfold: "KFold",
+      stratified_kfold: "StratifiedKFold",
+      group_kfold: "GroupKFold",
+      stratified_group_kfold: "StratifiedGroup",
+      time_series: "TimeSeriesSplit",
+      purged_time_series: "PurgedTimeSeriesSplit",
+      group_time_series: "GroupTimeSeriesSplit",
+      blocked_group_kfold: "BlockedGroup",
+    },
+    cv_strategy_fields: {
+      kfold: ["n_splits", "shuffle", "random_state"],
+      stratified_kfold: ["n_splits", "shuffle", "random_state"],
+      group_kfold: ["n_splits", "group_col"],
+      stratified_group_kfold: ["n_splits", "group_col"],
+      time_series: ["n_splits", "time_col", "gap", "max_train_size", "max_test_size"],
+      purged_time_series: ["n_splits", "time_col", "purge_gap", "embargo"],
+      group_time_series: ["n_splits", "group_col", "time_col", "gap"],
+      blocked_group_kfold: ["blocks_col", "groups_col"],
+    },
+  },
+};
+
 const defaultProps = {
   dfInfo: baseDfInfo,
   allColumns: ["x1", "x2", "x3", "y"],
   columnStats: null,
   splitPreview: null,
   sendAction: vi.fn(),
+  backendContract: baseBackendContract,
 };
 
 describe("DataTab — Target dropdown", () => {
@@ -118,6 +155,40 @@ describe("DataTab — CV strategy segment", () => {
       "update_cv",
       expect.objectContaining({ strategy: "stratified_kfold" }),
     );
+  });
+
+  it("renders an unknown CV strategy reported by backend without a JS edit (#119)", () => {
+    // Acceptance criterion: adding a new strategy in adapter_contract.py should
+    // surface in the UI without touching DataTab.tsx.
+    render(
+      <DataTab
+        {...defaultProps}
+        backendContract={{
+          capabilities: {
+            cv_strategies: ["future_strategy"],
+            cv_strategy_labels: { future_strategy: "Future Strategy" },
+            cv_strategy_fields: { future_strategy: ["n_splits"] },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Future Strategy")).toBeDefined();
+  });
+
+  it("falls back to humanised label when cv_strategy_labels lacks an entry", () => {
+    render(
+      <DataTab
+        {...defaultProps}
+        backendContract={{
+          capabilities: {
+            cv_strategies: ["weird_one"],
+            cv_strategy_fields: { weird_one: ["n_splits"] },
+            // cv_strategy_labels deliberately omitted
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Weird One")).toBeDefined();
   });
 });
 

--- a/js/src/components/ModelEditors.tsx
+++ b/js/src/components/ModelEditors.tsx
@@ -3,6 +3,10 @@
  *
  * Extracted from ConfigTab.tsx to keep file size under 800 lines (P-014).
  * Contains: TypedParamsEditor, ModelSection, FeatureWeightsEditor, AdditionalParamsEditor.
+ *
+ * #119: backend-specific keys (smart_params group, hidden additional keys,
+ * num_leaves default) are derived from the backend contract — no LightGBM
+ * key names are hardcoded in this file.
  */
 import { NumericStepper } from "./NumericStepper";
 import { DynForm } from "./DynForm";
@@ -10,11 +14,33 @@ import { DynForm } from "./DynForm";
 type TypedParamKind = "objective" | "model_metric" | "integer" | "number" | "boolean";
 export interface TypedParamMeta { key: string; label: string; kind: TypedParamKind; step?: number; }
 
-/** Model section fields handled by custom ModelSection (not delegated to DynForm). */
-const HANDLED_MODEL_FIELDS = new Set([
-  "name", "auto_num_leaves", "num_leaves_ratio", "params",
-  "min_data_in_leaf_ratio", "min_data_in_bin_ratio", "feature_weights", "balanced",
-]);
+interface SmartParamCatalogEntry {
+  key: string;
+  title?: string;
+  paramType?: string;
+  group?: string;
+  default?: any;
+}
+
+/** Structural keys filtered from DynForm regardless of backend. */
+const STRUCTURAL_MODEL_FIELDS: ReadonlySet<string> = new Set(["name", "params"]);
+
+/** Read the smart_params group keys from search_space_catalog. */
+function getSmartParamsKeys(catalog: SmartParamCatalogEntry[]): Set<string> {
+  return new Set(
+    catalog
+      .filter((entry) => entry.group === "smart_params")
+      .map((entry) => entry.key),
+  );
+}
+
+/** Look up a default value for a smart_params catalog entry. */
+function getSmartParamDefault(
+  catalog: SmartParamCatalogEntry[],
+  key: string,
+): any {
+  return catalog.find((entry) => entry.key === key)?.default;
+}
 
 function TypedParamsEditor({
   task,
@@ -24,6 +50,8 @@ function TypedParamsEditor({
   parameterHints,
   optionSets,
   stepMap,
+  manualNumLeavesKey,
+  manualNumLeavesDefault,
 }: {
   task: string;
   autoNumLeaves: boolean;
@@ -32,6 +60,10 @@ function TypedParamsEditor({
   parameterHints: TypedParamMeta[];
   optionSets: Record<string, Record<string, string[]>>;
   stepMap: Record<string, number>;
+  /** Key for the manual leaf-count override (e.g. "num_leaves"); only rendered when defined. */
+  manualNumLeavesKey?: string;
+  /** Default leaf count used when toggle is off and value is unset. */
+  manualNumLeavesDefault?: number;
 }) {
   const set = (k: string, v: any) => onChange({ ...value, [k]: v });
 
@@ -132,14 +164,14 @@ function TypedParamsEditor({
         );
       })}
 
-      {!autoNumLeaves && (
+      {!autoNumLeaves && manualNumLeavesKey && (
         <div class="lzw-form-row">
           <label class="lzw-label">Num Leaves</label>
           <NumericStepper
-            value={value.num_leaves ?? 256}
+            value={value[manualNumLeavesKey] ?? manualNumLeavesDefault}
             min={2}
             step={1}
-            onChange={(v) => set("num_leaves", v ?? 256)}
+            onChange={(v) => set(manualNumLeavesKey, v ?? manualNumLeavesDefault)}
           />
         </div>
       )}
@@ -313,6 +345,8 @@ export function ModelSection({
   stepMap,
   columns,
   additionalParams,
+  searchSpaceCatalog,
+  additionalParamsHiddenKeys,
 }: {
   schema: Record<string, any>;
   rootSchema: Record<string, any>;
@@ -324,9 +358,45 @@ export function ModelSection({
   stepMap: Record<string, number>;
   columns: Array<{ name: string }>;
   additionalParams: string[];
+  /** search_space_catalog from backend ui_schema (optional; falls back to legacy literal set when absent). */
+  searchSpaceCatalog?: SmartParamCatalogEntry[];
+  /** Param keys hidden from Additional Params (e.g. verbose, num_threads). Sourced from contract capabilities. */
+  additionalParamsHiddenKeys?: string[];
 }) {
   const params = (value.params ?? {}) as Record<string, any>;
-  const autoNumLeaves = value.auto_num_leaves ?? true;
+  // Smart Params section is currently LightGBM-aware (the auto-num-leaves
+  // toggle pattern), but the *set* of smart-params keys comes from the
+  // contract — the JS no longer ships its own list (#119).
+  const catalog: SmartParamCatalogEntry[] = searchSpaceCatalog ?? [];
+  const smartParamsKeys =
+    catalog.length > 0
+      ? getSmartParamsKeys(catalog)
+      : new Set([
+          // Fallback for unit-test fixtures that omit the contract; production
+          // always supplies the catalog. Adding/removing smart params in the
+          // backend automatically propagates without touching this set.
+          "auto_num_leaves",
+          "num_leaves_ratio",
+          "num_leaves",
+          "min_data_in_leaf_ratio",
+          "min_data_in_bin_ratio",
+          "feature_weights",
+          "balanced",
+        ]);
+  const handledModelFields = new Set<string>([
+    ...STRUCTURAL_MODEL_FIELDS,
+    ...smartParamsKeys,
+  ]);
+
+  const autoNumLeavesKey = "auto_num_leaves";
+  const manualNumLeavesKey = smartParamsKeys.has("num_leaves") ? "num_leaves" : undefined;
+  // Default flows from the backend search_space_catalog — JS does not own a literal
+  // (#119). When the catalog is absent (test fixtures), undefined falls through to
+  // NumericStepper, which renders an empty stepper for the user to set.
+  const manualNumLeavesDefault: number | undefined = manualNumLeavesKey
+    ? (getSmartParamDefault(catalog, manualNumLeavesKey) as number | undefined)
+    : undefined;
+  const autoNumLeaves = value[autoNumLeavesKey] ?? true;
 
   const setField = (k: string, v: any) => onChange({ ...value, [k]: v });
   const setParam = (k: string, v: any) =>
@@ -335,15 +405,20 @@ export function ModelSection({
     onChange({ ...value, params: newParams });
 
   const hintKeys = new Set(parameterHints.map((h) => h.key));
-  const excludeFromAdditional = new Set([
-    ...hintKeys, "verbose", "num_leaves", "num_threads",
+  const hiddenKeys = additionalParamsHiddenKeys ?? [];
+  // Exclude from Additional Params: parameter_hints, smart_params keys, and
+  // backend-declared hidden keys (e.g. verbose, num_threads).
+  const excludeFromAdditional = new Set<string>([
+    ...hintKeys,
+    ...smartParamsKeys,
+    ...hiddenKeys,
   ]);
 
   const filteredSchema = {
     ...schema,
     properties: Object.fromEntries(
       Object.entries((schema.properties ?? {}) as Record<string, any>).filter(
-        ([k]) => !HANDLED_MODEL_FIELDS.has(k),
+        ([k]) => !handledModelFields.has(k),
       ),
     ),
   };
@@ -369,10 +444,19 @@ export function ModelSection({
             checked={autoNumLeaves}
             onChange={(e) => {
               const v = (e.target as HTMLInputElement).checked;
-              const updated = v
-                ? (() => { const { num_leaves: _, ...rest } = params; return rest; })()
-                : { ...params, num_leaves: params.num_leaves ?? 256 };
-              onChange({ ...value, auto_num_leaves: v, params: updated });
+              let updated: Record<string, any> = params;
+              if (manualNumLeavesKey) {
+                if (v) {
+                  const { [manualNumLeavesKey]: _drop, ...rest } = params;
+                  updated = rest;
+                } else {
+                  updated = {
+                    ...params,
+                    [manualNumLeavesKey]: params[manualNumLeavesKey] ?? manualNumLeavesDefault,
+                  };
+                }
+              }
+              onChange({ ...value, [autoNumLeavesKey]: v, params: updated });
             }}
           />
           <span class="lzw-toggle__slider" />
@@ -452,6 +536,8 @@ export function ModelSection({
         parameterHints={parameterHints}
         optionSets={optionSets}
         stepMap={stepMap}
+        manualNumLeavesKey={manualNumLeavesKey}
+        manualNumLeavesDefault={manualNumLeavesDefault}
       />
 
       <div class="lzw-form-row">

--- a/js/src/tabs/ConfigTab.tsx
+++ b/js/src/tabs/ConfigTab.tsx
@@ -201,6 +201,7 @@ export function ConfigTab({
             localConfig={localConfig}
             configSchema={configSchema}
             uiSchema={uiSchema}
+            capabilities={capabilities}
             task={task}
             dfInfo={dfInfo}
             handleChange={handleChange}

--- a/js/src/tabs/DataTab.tsx
+++ b/js/src/tabs/DataTab.tsx
@@ -3,6 +3,7 @@ import { Accordion } from "../components/Accordion";
 import { BlockedGroupKFold } from "../components/BlockedGroupKFold";
 import { ColumnTable } from "../components/ColumnTable";
 import { NumericStepper } from "../components/NumericStepper";
+import { humaniseSnake } from "../utils/humanise";
 
 interface CvInfo {
   strategy: string;
@@ -41,24 +42,30 @@ interface DataTabProps {
   backendContract?: Record<string, any> | null;
 }
 
-const CV_STRATEGIES = [
-  { value: "kfold", label: "KFold" },
-  { value: "stratified_kfold", label: "StratifiedKFold" },
-  { value: "group_kfold", label: "GroupKFold" },
-  { value: "stratified_group_kfold", label: "StratifiedGroup" },
-  { value: "time_series", label: "TimeSeriesSplit" },
-  { value: "purged_time_series", label: "PurgedTimeSeriesSplit" },
-  { value: "group_time_series", label: "GroupTimeSeriesSplit" },
-  { value: "blocked_group_kfold", label: "BlockedGroup" },
+/* Fallback Sets used when backend_contract does not provide cv_strategy_fields.
+ * Production runs always supply the contract (see adapter_contract.py); these
+ * fallbacks exist only so unit-test fixtures that omit the contract still
+ * render meaningful UI. They are NOT a source of truth — adding a new strategy
+ * in the backend automatically surfaces in the dropdown via the contract. */
+const FALLBACK_CV_STRATEGIES = [
+  "kfold",
+  "stratified_kfold",
+  "group_kfold",
+  "stratified_group_kfold",
+  "time_series",
+  "purged_time_series",
+  "group_time_series",
+  "blocked_group_kfold",
 ];
-
-/* Fallback Sets used when backend_contract does not provide cv_strategy_fields */
 const FALLBACK_NEEDS_GROUP = new Set(["group_kfold", "stratified_group_kfold", "group_time_series"]);
 const FALLBACK_NEEDS_TIME = new Set(["time_series", "purged_time_series", "group_time_series"]);
 const FALLBACK_NEEDS_RANDOM_STATE = new Set(["kfold", "stratified_kfold", "stratified_group_kfold"]);
+const FALLBACK_NEEDS_SHUFFLE = new Set(["kfold", "stratified_kfold"]);
 const FALLBACK_NEEDS_GAP = new Set(["time_series", "group_time_series"]);
 const FALLBACK_NEEDS_PURGE = new Set(["purged_time_series"]);
 const FALLBACK_IS_TIME_SERIES = new Set(["time_series", "purged_time_series", "group_time_series"]);
+const FALLBACK_IS_BLOCKED = new Set(["blocked_group_kfold"]);
+const FALLBACK_BLOCKED_FIELD = "blocks_col";
 
 /** Derive a Set of strategy names whose fields include any of the given field names. */
 function deriveStrategiesWithField(
@@ -74,9 +81,15 @@ function deriveStrategiesWithField(
 
 export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAction, backendContract }: DataTabProps) {
   // Read CV strategy fields from backend contract, derive Sets with fallbacks
-  const cvStrategyFields: Record<string, string[]> =
-    backendContract?.capabilities?.cv_strategy_fields ?? {};
+  const capabilities: Record<string, any> = backendContract?.capabilities ?? {};
+  const cvStrategyFields: Record<string, string[]> = capabilities.cv_strategy_fields ?? {};
   const hasContractFields = Object.keys(cvStrategyFields).length > 0;
+  const contractStrategies: string[] | undefined = capabilities.cv_strategies;
+  const cvStrategyLabels: Record<string, string> = capabilities.cv_strategy_labels ?? {};
+
+  // Strategy list: prefer backend contract, fall back to historical literal so
+  // unit-test fixtures without a contract still render a dropdown.
+  const strategyList: string[] = contractStrategies ?? FALLBACK_CV_STRATEGIES;
 
   const NEEDS_GROUP = hasContractFields
     ? deriveStrategiesWithField(cvStrategyFields, ["group_col", "groups_col"])
@@ -87,6 +100,9 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
   const NEEDS_RANDOM_STATE = hasContractFields
     ? deriveStrategiesWithField(cvStrategyFields, ["random_state"])
     : FALLBACK_NEEDS_RANDOM_STATE;
+  const NEEDS_SHUFFLE = hasContractFields
+    ? deriveStrategiesWithField(cvStrategyFields, ["shuffle"])
+    : FALLBACK_NEEDS_SHUFFLE;
   const NEEDS_GAP = hasContractFields
     ? deriveStrategiesWithField(cvStrategyFields, ["gap"])
     : FALLBACK_NEEDS_GAP;
@@ -96,9 +112,19 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
   const IS_TIME_SERIES = hasContractFields
     ? deriveStrategiesWithField(cvStrategyFields, ["max_train_size", "max_test_size"])
     : FALLBACK_IS_TIME_SERIES;
+  const IS_BLOCKED = hasContractFields
+    ? deriveStrategiesWithField(cvStrategyFields, [FALLBACK_BLOCKED_FIELD])
+    : FALLBACK_IS_BLOCKED;
   const shape = dfInfo.shape ?? [0, 0];
   const columns = dfInfo.columns ?? [];
-  const cv = dfInfo.cv ?? { strategy: "kfold", n_splits: 5 };
+  // Fallback strategy for when cv is missing entirely. Prefer the contract's
+  // default-by-task; otherwise the first strategy advertised by the backend.
+  const cvDefaultByTask: Record<string, string> = capabilities.cv_default_strategy ?? {};
+  const fallbackStrategy =
+    (dfInfo.task && cvDefaultByTask[dfInfo.task]) ||
+    strategyList[0] ||
+    FALLBACK_CV_STRATEGIES[0];
+  const cv = dfInfo.cv ?? { strategy: fallbackStrategy, n_splits: 5 };
   const fs = dfInfo.feature_summary;
   const featureCols = columns.filter((c: any) => !c.excluded).map((c: any) => c.name);
   const hasTarget = Boolean(dfInfo.target);
@@ -169,20 +195,23 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
         <div class="lzw-form-row" style="align-items:flex-start">
           <label class="lzw-label">Strategy</label>
           <div class="lzw-chip-group">
-            {CV_STRATEGIES.map((s) => (
-              <button
-                key={s.value}
-                type="button"
-                class={`lzw-chip lzw-chip--square ${cv.strategy === s.value ? "lzw-chip--active" : ""}`}
-                aria-pressed={cv.strategy === s.value}
-                onClick={() => sendCv({ ...cv, strategy: s.value })}
-              >
-                {s.label}
-              </button>
-            ))}
+            {strategyList.map((value) => {
+              const label = cvStrategyLabels[value] ?? humaniseSnake(value);
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  class={`lzw-chip lzw-chip--square ${cv.strategy === value ? "lzw-chip--active" : ""}`}
+                  aria-pressed={cv.strategy === value}
+                  onClick={() => sendCv({ ...cv, strategy: value })}
+                >
+                  {label}
+                </button>
+              );
+            })}
           </div>
         </div>
-        {cv.strategy === "blocked_group_kfold" ? (
+        {IS_BLOCKED.has(cv.strategy) ? (
           <BlockedGroupKFold
             cv={cv}
             allColumns={featureCols}
@@ -213,7 +242,7 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
             />
           </div>
         )}
-        {cv.strategy === "kfold" && (
+        {NEEDS_SHUFFLE.has(cv.strategy) && (
           <div class="lzw-form-row">
             <label class="lzw-label">Shuffle</label>
             <input

--- a/js/src/tabs/FitSubTab.tsx
+++ b/js/src/tabs/FitSubTab.tsx
@@ -15,6 +15,8 @@ interface FitSubTabProps {
   localConfig: Record<string, any>;
   configSchema: Record<string, any>;
   uiSchema: Record<string, any>;
+  /** Backend capabilities map — used for cv_strategy_fields and additional_params_hidden_keys (#119). */
+  capabilities?: Record<string, any>;
   task: string;
   dfInfo: Record<string, any>;
   handleChange: (newConfig: Record<string, any>) => void;
@@ -25,24 +27,45 @@ interface FitSubTabProps {
   yamlExportCount?: number;
 }
 
-/** Strategies that use a group column. */
-const GROUP_STRATEGIES = new Set([
+/** Fallback strategy sets used only when backendContract.cv_strategy_fields is missing
+ * (e.g. unit-test fixtures). Production runs always supply the contract; adding/removing
+ * group / time strategies in the backend automatically propagates without touching this. */
+const FALLBACK_GROUP_STRATEGIES = new Set([
   "group_kfold", "stratified_group_kfold", "group_time_series", "blocked_group_kfold",
 ]);
-
-/** Strategies that use a time column. */
-const TIME_STRATEGIES = new Set([
+const FALLBACK_TIME_STRATEGIES = new Set([
   "time_series", "purged_time_series", "group_time_series",
 ]);
 
-/** Filter inner validation options based on CV strategy. */
+/** Derive the set of strategies whose declared field list contains any of the given fields. */
+function deriveStrategiesByField(
+  cvStrategyFields: Record<string, string[]>,
+  fieldNames: string[],
+): Set<string> {
+  return new Set(
+    Object.entries(cvStrategyFields)
+      .filter(([, fields]) => fieldNames.some((f) => fields.includes(f)))
+      .map(([strategy]) => strategy),
+  );
+}
+
+/** Filter inner validation options based on CV strategy and contract field map. */
 function filterInnerValidOptions(
   options: string[],
   cv: Record<string, any> | undefined,
+  cvStrategyFields: Record<string, string[]>,
 ): string[] {
-  const strategy = cv?.strategy ?? "kfold";
-  const hasGroup = GROUP_STRATEGIES.has(strategy);
-  const hasTime = TIME_STRATEGIES.has(strategy);
+  const strategy = cv?.strategy;
+  if (!strategy) return options;
+  const hasContract = Object.keys(cvStrategyFields).length > 0;
+  const groupSet = hasContract
+    ? deriveStrategiesByField(cvStrategyFields, ["group_col", "groups_col", "blocks_col"])
+    : FALLBACK_GROUP_STRATEGIES;
+  const timeSet = hasContract
+    ? deriveStrategiesByField(cvStrategyFields, ["time_col"])
+    : FALLBACK_TIME_STRATEGIES;
+  const hasGroup = groupSet.has(strategy);
+  const hasTime = timeSet.has(strategy);
   return options.filter((opt) => {
     if (opt === "group_holdout") return hasGroup;
     if (opt === "time_holdout") return hasTime;
@@ -54,6 +77,7 @@ export function FitSubTab({
   localConfig,
   configSchema,
   uiSchema,
+  capabilities,
   task,
   dfInfo,
   handleChange,
@@ -71,11 +95,26 @@ export function FitSubTab({
   const defaults: Record<string, any> = uiSchema.defaults ?? {};
   const sectionKeys = sections.map((s) => s.key);
   const unknownKeys = getUnknownKeys(configSchema, sectionKeys);
+  // #119: derive group/time strategy sets and additional-params exclusions from
+  // the backend contract instead of hardcoded literals.
+  const cvStrategyFields: Record<string, string[]> = capabilities?.cv_strategy_fields ?? {};
+  const additionalParamsHiddenKeys: string[] = capabilities?.additional_params_hidden_keys ?? [];
+  const searchSpaceCatalog = uiSchema.search_space_catalog ?? [];
 
   // Auto-reset inner_valid method when CV strategy changes
   const allInnerValidOpts: string[] = uiSchema.inner_valid_options ?? [];
-  const availableInnerValidOpts = filterInnerValidOptions(allInnerValidOpts, dfInfo?.cv);
-  const cvStrategy = dfInfo?.cv?.strategy ?? "kfold";
+  const availableInnerValidOpts = filterInnerValidOptions(
+    allInnerValidOpts,
+    dfInfo?.cv,
+    cvStrategyFields,
+  );
+  // Fallback strategy used only when cv state is missing entirely.
+  const cvDefaultByTask: Record<string, string> = capabilities?.cv_default_strategy ?? {};
+  const cvStrategy =
+    dfInfo?.cv?.strategy ??
+    cvDefaultByTask[task] ??
+    (capabilities?.cv_strategies?.[0] as string | undefined) ??
+    "";
   const currentInnerValid =
     localConfig.training?.early_stopping?.inner_valid?.method ?? "holdout";
   const handleSectionChangeRef = useRef(handleSectionChange);
@@ -83,7 +122,11 @@ export function FitSubTab({
   const localConfigRef = useRef(localConfig);
   localConfigRef.current = localConfig;
   useEffect(() => {
-    const available = filterInnerValidOptions(allInnerValidOpts, { strategy: cvStrategy });
+    const available = filterInnerValidOptions(
+      allInnerValidOpts,
+      { strategy: cvStrategy },
+      cvStrategyFields,
+    );
     if (available.length > 0 && !available.includes(currentInnerValid)) {
       const cfg = localConfigRef.current;
       handleSectionChangeRef.current("training", {
@@ -94,7 +137,7 @@ export function FitSubTab({
         },
       });
     }
-  }, [cvStrategy, currentInnerValid, allInnerValidOpts]);
+  }, [cvStrategy, currentInnerValid, allInnerValidOpts, cvStrategyFields]);
 
   // Calibration
   const calibrationEnabled = localConfig.calibration != null;
@@ -138,6 +181,8 @@ export function FitSubTab({
                 stepMap={stepMap}
                 columns={dfInfo?.columns ?? []}
                 additionalParams={uiSchema.additional_params ?? []}
+                searchSpaceCatalog={searchSpaceCatalog}
+                additionalParamsHiddenKeys={additionalParamsHiddenKeys}
               />
             </Accordion>
           );

--- a/js/src/utils/humanise.ts
+++ b/js/src/utils/humanise.ts
@@ -1,0 +1,17 @@
+/**
+ * Convert a snake_case identifier to a Title Case label.
+ *
+ * Used as a fallback when the backend contract does not provide a
+ * human-readable label for a generic identifier — e.g. an unknown CV
+ * strategy added in the backend without a corresponding entry in
+ * `cv_strategy_labels`. Keeps the UI rendering generic so a backend
+ * change alone surfaces in the dropdown without a JS edit (#119).
+ */
+export function humaniseSnake(value: string): string {
+  if (!value) return value;
+  return value
+    .split("_")
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}

--- a/src/lizyml_widget/adapter_contract.py
+++ b/src/lizyml_widget/adapter_contract.py
@@ -443,6 +443,24 @@ def build_capabilities() -> dict[str, Any]:
             "stratified_group_kfold",
             "blocked_group_kfold",
         ],
+        # Display labels for cv_strategies. JS falls back to a humanise() helper
+        # when a strategy is missing from this map, so adding a new strategy in
+        # cv_strategies still surfaces in the UI without a JS change (#119).
+        "cv_strategy_labels": {
+            "kfold": "KFold",
+            "stratified_kfold": "StratifiedKFold",
+            "group_kfold": "GroupKFold",
+            "stratified_group_kfold": "StratifiedGroup",
+            "time_series": "TimeSeriesSplit",
+            "purged_time_series": "PurgedTimeSeriesSplit",
+            "group_time_series": "GroupTimeSeriesSplit",
+            "blocked_group_kfold": "BlockedGroup",
+        },
+        # Param keys to hide from the Additional Params dropdown / list even
+        # though they are not in parameter_hints or smart_params. These are
+        # backend-internal knobs (logging, threading) the widget intentionally
+        # keeps off the tuning surface (#119).
+        "additional_params_hidden_keys": ["verbose", "num_threads"],
         "cv_strategy_fields": {
             "kfold": ["n_splits", "shuffle", "random_state"],
             "stratified_kfold": ["n_splits", "shuffle", "random_state"],

--- a/tests/test_contract_cv.py
+++ b/tests/test_contract_cv.py
@@ -91,6 +91,30 @@ class TestCvStrategyFieldsCapabilities:
         assert ds["multiclass"] == "stratified_kfold"
         assert ds["regression"] == "kfold"
 
+    def test_cv_strategy_labels_present(self) -> None:
+        """#119: every cv_strategies entry must have a human-readable label."""
+        from lizyml_widget.adapter_contract import build_capabilities
+
+        caps = build_capabilities()
+        assert "cv_strategy_labels" in caps
+        labels = caps["cv_strategy_labels"]
+        for strategy in caps["cv_strategies"]:
+            assert strategy in labels, f"{strategy} missing from cv_strategy_labels"
+            assert isinstance(labels[strategy], str)
+            assert labels[strategy]  # non-empty
+
+    def test_additional_params_hidden_keys_present(self) -> None:
+        """#119: backend declares which param keys to hide from Additional Params UI."""
+        from lizyml_widget.adapter_contract import build_capabilities
+
+        caps = build_capabilities()
+        assert "additional_params_hidden_keys" in caps
+        hidden = caps["additional_params_hidden_keys"]
+        assert isinstance(hidden, list)
+        # verbose / num_threads stay backend-internal even when set on params
+        assert "verbose" in hidden
+        assert "num_threads" in hidden
+
 
 class TestSpecialSearchSpaceFields:
     """build_ui_schema() must expose special_search_space_fields."""
@@ -234,6 +258,57 @@ class TestDataTabContractDriven:
         data_tab_section = content[data_tab_idx : data_tab_idx + 500]
         assert "backendContract" in data_tab_section, (
             "App.tsx should pass backendContract to DataTab"
+        )
+
+    def test_data_tab_has_no_static_cv_strategies_array(self) -> None:
+        """#119: the CV_STRATEGIES literal array is removed; dropdown is contract-driven."""
+        content = (JS_SRC / "tabs" / "DataTab.tsx").read_text()
+        assert "const CV_STRATEGIES" not in content, (
+            "DataTab should no longer ship a static CV_STRATEGIES literal — "
+            "read from backend_contract.capabilities.cv_strategies instead."
+        )
+
+    def test_data_tab_reads_cv_strategies_from_contract(self) -> None:
+        """#119: dropdown options sourced from backend contract."""
+        content = (JS_SRC / "tabs" / "DataTab.tsx").read_text()
+        assert "capabilities.cv_strategies" in content, (
+            "DataTab should read cv_strategies from contract capabilities."
+        )
+        assert "cv_strategy_labels" in content, (
+            "DataTab should read cv_strategy_labels from contract capabilities."
+        )
+
+
+class TestModelEditorsContractDriven:
+    """#119: ModelEditors must source LightGBM-specific keys from the backend contract."""
+
+    def test_model_editors_no_static_handled_model_fields(self) -> None:
+        content = (JS_SRC / "components" / "ModelEditors.tsx").read_text()
+        # The legacy literal `const HANDLED_MODEL_FIELDS = new Set([...])` must be gone.
+        assert "const HANDLED_MODEL_FIELDS = new Set" not in content, (
+            "Static HANDLED_MODEL_FIELDS literal should be replaced by a "
+            "catalog-derived set (smart_params + structural keys)."
+        )
+
+    def test_model_editors_no_num_leaves_default_literal(self) -> None:
+        content = (JS_SRC / "components" / "ModelEditors.tsx").read_text()
+        # `??\s*256` literal default is gone — default flows from contract default.
+        assert "?? 256" not in content, (
+            "num_leaves default 256 literal must be removed; the default lives "
+            "in backend search_space_catalog and propagates via props."
+        )
+
+    def test_model_editors_excludes_via_contract_keys(self) -> None:
+        content = (JS_SRC / "components" / "ModelEditors.tsx").read_text()
+        # Hardcoded "verbose" / "num_threads" exclusions in the Set literal must be gone.
+        # Acceptable references: only the prop name `additionalParamsHiddenKeys`.
+        assert '"verbose", "num_leaves", "num_threads"' not in content, (
+            "Hardcoded LightGBM-specific exclusion list should route through "
+            "additionalParamsHiddenKeys / smart_params keys from contract."
+        )
+        assert "additionalParamsHiddenKeys" in content, (
+            "ModelEditors should accept the additional_params_hidden_keys list "
+            "from the backend contract."
         )
 
 


### PR DESCRIPTION
## Summary
Closes #119. Removes the three literal violations called out in the post-P-030 code review (CLAUDE.md §4 / §8).

| Site | Before | After |
|---|---|---|
| `DataTab.tsx` | `CV_STRATEGIES` array literal | derived from `capabilities.cv_strategies` + `cv_strategy_labels` (new), with humaniseSnake() fallback |
| `DataTab.tsx` | `cv.strategy === "kfold"` / `"blocked_group_kfold"` literals | capability-driven `NEEDS_SHUFFLE` / `IS_BLOCKED` |
| `FitSubTab.tsx` | `GROUP_STRATEGIES` / `TIME_STRATEGIES` literal sets | derived from `cv_strategy_fields` |
| `ModelEditors.tsx` | `HANDLED_MODEL_FIELDS` literal | structural keys + smart_params group from `search_space_catalog` |
| `ModelEditors.tsx` | `num_leaves ?? 256` default | default flows from catalog entry through `TypedParamsEditor` props |
| `ModelEditors.tsx` | hardcoded `[verbose, num_leaves, num_threads]` exclude | `additional_params_hidden_keys` (new) + smart_params keys |

### Backend contract additions (additive, no breaking change)
- `capabilities.cv_strategy_labels` — display map for `cv_strategies`.
- `capabilities.additional_params_hidden_keys` — keys hidden from Additional Params UI.

## Test plan
- [x] `uv run pytest --ignore=tests/e2e -q` — 870 passed (+5 new contract assertions)
- [x] `cd js && pnpm exec vitest run` — 177 passed (+2 new DataTab cases)
- [x] `pnpm exec tsc --noEmit` — no new errors in changed files
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/lizyml_widget/` — clean
- [x] Acceptance: ✓ DataTab renders an unknown contract-only CV strategy
- [x] Acceptance: ✓ Adding a strategy to `adapter_contract.py` surfaces in the dropdown without a JS change (locked in by `test_data_tab_reads_cv_strategies_from_contract`)

## Out of scope (per issue)
- Migrating `parameter_hints` schema itself.
- New backend support — the bespoke "Smart Params" UI (Auto Num Leaves toggle linkage) remains LightGBM-aware, but its key set is now contract-derived rather than literal.

Refs: code review thread on develop after P-030 (#113); CLAUDE.md §4 / §8.