### PR TITLE
test(js): close JS unit-test coverage gap (Phase A) (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,15 @@ jobs:
       - name: JS lint (eslint)
         run: cd js && pnpm lint
 
-      - name: JS test (vitest)
-        run: cd js && pnpm test
+      - name: JS test (vitest with coverage)
+        run: cd js && pnpm test:coverage
+
+      - name: JS E2E test count
+        # #114 Phase C: surface the e2e test count in PR diffs so adds/removes
+        # are visible without spelunking through tests/e2e/.
+        run: |
+          count=$(grep -RE "^\s*def test_" tests/e2e/ | wc -l)
+          echo "tests/e2e/: $count test cases"
 
       - name: Lint (ruff check)
         run: uv run ruff check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **JS test coverage Phase A** ([#114](https://github.com/nbx-liz/LizyML-Widget/issues/114)).
+  Vitest suite expanded from 171 to 272 cases covering `App.tsx`, `Header.tsx`,
+  `configHelpers.ts`, `ModelEditors.tsx`, `TuneSubTab.tsx`, `FitSubTab.tsx`,
+  `DistributionBar.tsx`, `FoldPreview.tsx`, `PredTable.tsx`,
+  `BlockedGroupKFold.tsx`, plus the P-030 smape/wape regression chip in
+  `SearchSpace.tsx` and failed/error rendering paths in `ResultsTab.tsx`.
+  Statement coverage rose from 47% to 75%.
+- `pnpm test:coverage` script and `vitest.config.ts` `coverage.thresholds`
+  block (75% statements/lines, 70% branches, 50% functions). CI now runs
+  `pnpm test:coverage` and prints the e2e test count for visibility.
 - **Backend contract**: new `cv_strategy_labels` and `additional_params_hidden_keys`
   capabilities ([#119](https://github.com/nbx-liz/LizyML-Widget/issues/119)).
   Adding a new CV strategy in `adapter_contract.py` now surfaces in the UI dropdown

--- a/README.md
+++ b/README.md
@@ -148,10 +148,20 @@ uv run mypy src/lizyml_widget/
 # TypeScript
 cd js
 pnpm install
-pnpm dev    # watch build
-pnpm build  # production build
+pnpm dev               # watch build
+pnpm build             # production build
 pnpm lint
+pnpm test              # vitest run
+pnpm test:coverage     # vitest run --coverage (CI gate at 75% statements / 70% branches)
 ```
+
+### Test coverage targets
+
+- Python (pytest): **80% line coverage** — enforced in CI via `--cov-fail-under=80`.
+- TypeScript (vitest): **75% statements / lines, 70% branches, 50% functions** —
+  enforced via thresholds in [`js/vitest.config.ts`](js/vitest.config.ts).
+- E2E (Playwright + JupyterLab): suite under [`tests/e2e/`](tests/e2e/); CI prints
+  the test count so additions/removals are visible in PR diffs.
 
 ### Stable Notebook Launch
 

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,8 @@
     "build": "esbuild src/index.tsx --bundle --format=esm --jsx=automatic --jsx-import-source=preact --outfile=../src/lizyml_widget/static/widget.js --minify && cp src/widget.css ../src/lizyml_widget/static/widget.css",
     "lint": "eslint src/",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "preact": "^10.29.1"

--- a/js/src/__tests__/App.test.tsx
+++ b/js/src/__tests__/App.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for App — Header + tab gating + auto-switch + custom-msg routing.
+ *
+ * #114 Phase A: App had 0% statement coverage. We render it against a
+ * MockModel and assert the high-level routing rules — tab enable/disable
+ * by status, auto-switch on running, custom-message handling for
+ * column_stats / split_preview / code_export_download.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/preact";
+import { App } from "../App";
+import { createMockModel, MockModel } from "./mock-model";
+
+// jsdom does not implement matchMedia; useTheme falls back to it during init.
+beforeEach(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+function makeRootEl(): HTMLElement {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+function setupApp(modelOverrides: Record<string, any> = {}) {
+  const model = createMockModel(modelOverrides);
+  const rootEl = makeRootEl();
+  const utils = render(<App model={model} rootEl={rootEl} />);
+  return { model, rootEl, ...utils };
+}
+
+describe("App — initial render", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("starts on the Data tab when status is idle", () => {
+    const { container } = setupApp();
+    const activeBtn = container.querySelector(".lzw-tabs__btn--active");
+    expect(activeBtn?.textContent).toBe("Data");
+  });
+
+  it("renders the three tab buttons", () => {
+    setupApp();
+    expect(screen.getByText("Data")).toBeDefined();
+    expect(screen.getByText("Model")).toBeDefined();
+    expect(screen.getByText("Results")).toBeDefined();
+  });
+
+  it("renders the Header with backend info", () => {
+    setupApp({ backend_info: { name: "lizyml", version: "0.10.0" } });
+    expect(screen.getByText("lizyml v0.10.0")).toBeDefined();
+  });
+});
+
+describe("App — tab gating by status", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("disables Model and Results tabs when status is idle", () => {
+    const { container } = setupApp({ status: "idle", job_index: 0 });
+    const buttons = Array.from(container.querySelectorAll(".lzw-tabs__btn"));
+    const model = buttons.find((b) => b.textContent === "Model");
+    const results = buttons.find((b) => b.textContent === "Results");
+    expect(model?.classList.contains("lzw-tabs__btn--disabled")).toBe(true);
+    expect(results?.classList.contains("lzw-tabs__btn--disabled")).toBe(true);
+  });
+
+  it("enables Model tab once status leaves idle (data_loaded)", () => {
+    const { container } = setupApp({ status: "data_loaded" });
+    const model = Array.from(container.querySelectorAll(".lzw-tabs__btn")).find(
+      (b) => b.textContent === "Model",
+    );
+    expect(model?.classList.contains("lzw-tabs__btn--disabled")).toBe(false);
+  });
+
+  it("enables Results tab once a job has completed", () => {
+    const { container } = setupApp({ status: "completed", job_index: 1 });
+    const results = Array.from(container.querySelectorAll(".lzw-tabs__btn")).find(
+      (b) => b.textContent === "Results",
+    );
+    expect(results?.classList.contains("lzw-tabs__btn--disabled")).toBe(false);
+  });
+
+  it("ignores clicks on a disabled tab (Model when idle)", () => {
+    const { container } = setupApp({ status: "idle" });
+    const modelBtn = Array.from(container.querySelectorAll(".lzw-tabs__btn")).find(
+      (b) => b.textContent === "Model",
+    ) as HTMLButtonElement;
+    fireEvent.click(modelBtn);
+    const active = container.querySelector(".lzw-tabs__btn--active");
+    expect(active?.textContent).toBe("Data");
+  });
+});
+
+describe("App — auto-switch to Results", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("switches to Results when status transitions to running", async () => {
+    const { container, model } = setupApp({ status: "data_loaded" });
+    expect(container.querySelector(".lzw-tabs__btn--active")?.textContent).toBe("Data");
+    await act(async () => {
+      model.simulateTraitletChange("status", "running");
+    });
+    expect(container.querySelector(".lzw-tabs__btn--active")?.textContent).toBe("Results");
+  });
+
+  it("switches to Results when status transitions to completed", async () => {
+    const { container, model } = setupApp({ status: "running", job_index: 1 });
+    await act(async () => {
+      model.simulateTraitletChange("status", "completed");
+    });
+    expect(container.querySelector(".lzw-tabs__btn--active")?.textContent).toBe("Results");
+  });
+
+  it("switches to Results when status transitions to failed", async () => {
+    const { container, model } = setupApp({ status: "running", job_index: 1 });
+    await act(async () => {
+      model.simulateTraitletChange("status", "failed");
+    });
+    expect(container.querySelector(".lzw-tabs__btn--active")?.textContent).toBe("Results");
+  });
+});
+
+describe("App — custom message handling", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("routes column_stats messages without crashing", async () => {
+    const { model } = setupApp({ status: "data_loaded" });
+    // Should not throw — column_stats is consumed and stored locally.
+    await act(async () => {
+      model.simulateCustomMessage({ type: "column_stats", column: "x1" });
+    });
+    expect(true).toBe(true);
+  });
+
+  it("triggers a download for code_export_download messages", async () => {
+    const model = createMockModel({ status: "completed", job_index: 1 });
+    const rootEl = makeRootEl();
+    render(<App model={model as unknown as MockModel} rootEl={rootEl} />);
+
+    // Stub URL.createObjectURL / revokeObjectURL on the global `URL` object
+    // (jsdom does not implement them).
+    const created: string[] = [];
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => {
+      const u = `blob:mock-${created.length}`;
+      created.push(u);
+      return u;
+    });
+    URL.revokeObjectURL = vi.fn();
+
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    try {
+      const buf = new ArrayBuffer(8);
+      await act(async () => {
+        model.simulateCustomMessage(
+          { type: "code_export_download", filename: "exported.zip" },
+          [buf],
+        );
+      });
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(created[0]);
+    } finally {
+      clickSpy.mockRestore();
+      URL.createObjectURL = origCreate;
+      URL.revokeObjectURL = origRevoke;
+    }
+  });
+});

--- a/js/src/__tests__/BlockedGroupKFold.test.tsx
+++ b/js/src/__tests__/BlockedGroupKFold.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for BlockedGroupKFold — 2-axis CV configuration UI.
+ *
+ * #114 Phase A: was at 0.57% — this single render covers the bulk of the
+ * component since most code paths are conditional on cv state.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { BlockedGroupKFold } from "../components/BlockedGroupKFold";
+
+const baseProps = {
+  cv: {
+    blocks: { col: "", cutoffs: [], mode: "expanding", train_window: 1 },
+    groups: { col: "", n_splits: 3, stratify: "auto", shuffle: true },
+    min_train_rows: 10,
+    min_valid_rows: 5,
+  },
+  allColumns: ["x1", "x2", "date"],
+  columnStats: null,
+  splitPreview: null,
+  sendAction: vi.fn(),
+  sendCv: vi.fn(),
+};
+
+describe("BlockedGroupKFold — initial render (no columns selected)", () => {
+  it("renders without crashing for an empty cv state", () => {
+    const { container } = render(<BlockedGroupKFold {...baseProps} />);
+    expect(container.querySelector(".lzw-form-row")).not.toBeNull();
+  });
+
+  it("renders the period column selector", () => {
+    render(<BlockedGroupKFold {...baseProps} />);
+    expect(screen.getAllByRole("combobox").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("BlockedGroupKFold — with column stats", () => {
+  it("renders period cutoff toggles when blocks.col is set and stats are loaded", () => {
+    const { container } = render(
+      <BlockedGroupKFold
+        {...baseProps}
+        cv={{
+          ...baseProps.cv,
+          blocks: { col: "date", cutoffs: ["2025-Q2"], mode: "expanding", train_window: 1 },
+        }}
+        columnStats={{
+          column: "date",
+          unique_count: 4,
+          values: [
+            { value: "2025-Q1", count: 100 },
+            { value: "2025-Q2", count: 110 },
+            { value: "2025-Q3", count: 105 },
+            { value: "2025-Q4", count: 120 },
+          ],
+        }}
+      />,
+    );
+    // Period values should be rendered as toggleable controls
+    expect(container.textContent).toContain("2025-Q1");
+    expect(container.textContent).toContain("2025-Q4");
+  });
+
+  it("renders the group column form when groups.col is set", () => {
+    const { container } = render(
+      <BlockedGroupKFold
+        {...baseProps}
+        cv={{
+          ...baseProps.cv,
+          groups: { col: "x1", n_splits: 3, stratify: "auto", shuffle: true },
+        }}
+      />,
+    );
+    // The selected group column should be reflected in the form select.
+    const selects = container.querySelectorAll("select");
+    const values = Array.from(selects).map((s) => (s as HTMLSelectElement).value);
+    expect(values).toContain("x1");
+  });
+});
+
+describe("BlockedGroupKFold — with split preview", () => {
+  it("renders FoldPreview when a splitPreview is supplied", () => {
+    render(
+      <BlockedGroupKFold
+        {...baseProps}
+        cv={{
+          ...baseProps.cv,
+          blocks: { col: "date", cutoffs: ["2025-Q2"], mode: "expanding", train_window: 1 },
+          groups: { col: "x1", n_splits: 2, stratify: "auto", shuffle: true },
+        }}
+        splitPreview={{
+          total_folds: 4,
+          time_folds: 2,
+          group_folds: 2,
+          periods: ["P0", "P1", "P2"],
+          folds: [
+            {
+              fold: 1,
+              period_label: "P0 -> P1",
+              group_label: "G0",
+              train_size: 100,
+              valid_size: 25,
+            },
+          ],
+          mode: "expanding",
+        }}
+      />,
+    );
+    expect(screen.getByText(/Total:/)).toBeDefined();
+  });
+});

--- a/js/src/__tests__/DistributionBar.test.tsx
+++ b/js/src/__tests__/DistributionBar.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for DistributionBar — horizontal bar chart for value distribution.
+ *
+ * #114 Phase A: small pure component, was at 10% statement coverage.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { DistributionBar } from "../components/DistributionBar";
+
+describe("DistributionBar", () => {
+  it("returns null when there are no values", () => {
+    const { container } = render(<DistributionBar values={[]} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders one row per value", () => {
+    const { container } = render(
+      <DistributionBar
+        values={[
+          { value: "A", count: 30 },
+          { value: "B", count: 70 },
+          { value: "C", count: 100 },
+        ]}
+      />,
+    );
+    const rows = container.querySelectorAll(".lzw-dist-row");
+    expect(rows.length).toBe(3);
+  });
+
+  it("scales bar widths against the maximum count", () => {
+    const { container } = render(
+      <DistributionBar
+        values={[
+          { value: "A", count: 50 },
+          { value: "B", count: 100 },
+        ]}
+      />,
+    );
+    const bars = container.querySelectorAll(".lzw-dist-bar");
+    expect((bars[0] as HTMLElement).style.width).toBe("50%");
+    expect((bars[1] as HTMLElement).style.width).toBe("100%");
+  });
+
+  it("renders counts using locale formatting", () => {
+    render(
+      <DistributionBar
+        values={[
+          { value: "Big", count: 1234567 },
+        ]}
+      />,
+    );
+    // "1,234,567" (en-US) — accept any thousands separator via flexible regex.
+    expect(screen.getByText(/1[,. ]?234[,. ]?567/)).toBeDefined();
+  });
+
+  it("guards against zero-only counts (max defaults to 1)", () => {
+    const { container } = render(
+      <DistributionBar values={[{ value: "Z", count: 0 }]} />,
+    );
+    // Width should be 0% — but the row still renders.
+    expect(container.querySelectorAll(".lzw-dist-row").length).toBe(1);
+    const bar = container.querySelector(".lzw-dist-bar") as HTMLElement;
+    expect(bar.style.width).toBe("0%");
+  });
+});

--- a/js/src/__tests__/FitSubTab.test.tsx
+++ b/js/src/__tests__/FitSubTab.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for FitSubTab — Model / Evaluation / Calibration / Training sections.
+ *
+ * #114 Phase A: was at 43% — smoke + behaviour tests pull it well above target.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { FitSubTab } from "../tabs/FitSubTab";
+
+beforeEach(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false,
+        media: q,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+const baseConfigSchema = {
+  type: "object",
+  properties: {
+    model: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        params: { type: "object" },
+      },
+    },
+    training: {
+      type: "object",
+      properties: {
+        seed: { type: "integer" },
+      },
+    },
+    calibration: { type: "object" },
+    evaluation: { type: "object" },
+  },
+};
+
+const baseUiSchema = {
+  sections: [
+    { key: "model", title: "Model" },
+    { key: "training", title: "Training" },
+    { key: "calibration", title: "Calibration" },
+    { key: "evaluation", title: "Evaluation" },
+  ],
+  option_sets: {
+    objective: { binary: ["binary"] },
+    model_metric: { binary: ["auc", "binary_logloss"] },
+    metric: { binary: ["auc", "binary_logloss", "binary_error"] },
+  },
+  parameter_hints: [
+    { key: "objective", label: "Objective", kind: "objective" },
+    { key: "metric", label: "Metric", kind: "model_metric" },
+    { key: "n_estimators", label: "N Estimators", kind: "integer", step: 100 },
+  ],
+  step_map: {},
+  conditional_visibility: { calibration: { task: ["binary"] } },
+  defaults: { calibration: { method: "platt", params: {} } },
+  inner_valid_options: ["holdout", "group_holdout", "time_holdout"],
+  search_space_catalog: [
+    { key: "auto_num_leaves", title: "Auto Num Leaves", paramType: "boolean", group: "smart_params", default: true },
+    { key: "balanced", title: "Balanced", paramType: "boolean", group: "smart_params", default: true },
+  ],
+  additional_params: ["min_child_samples"],
+};
+
+const baseProps = {
+  localConfig: {
+    model: { name: "lgbm", params: { objective: "binary", metric: ["auc"] }, balanced: true },
+    training: { seed: 1 },
+    evaluation: { metrics: ["auc"], params: {} },
+  },
+  configSchema: baseConfigSchema,
+  uiSchema: baseUiSchema,
+  capabilities: {
+    cv_strategy_fields: {
+      kfold: ["n_splits", "shuffle", "random_state"],
+      group_kfold: ["n_splits", "group_col"],
+    },
+    additional_params_hidden_keys: ["verbose", "num_threads"],
+    cv_default_strategy: { binary: "kfold", regression: "kfold" },
+    cv_strategies: ["kfold", "group_kfold"],
+  },
+  task: "binary",
+  dfInfo: {
+    target: "y",
+    columns: [{ name: "x1" }, { name: "x2" }],
+    cv: { strategy: "kfold", n_splits: 5 },
+  },
+  handleChange: vi.fn(),
+  handleSectionChange: vi.fn(),
+  sendAction: vi.fn(),
+  rawYaml: null,
+  setRawYaml: vi.fn(),
+};
+
+describe("FitSubTab — section structure", () => {
+  it("renders the four contract-driven sections", () => {
+    render(<FitSubTab {...baseProps} />);
+    expect(screen.getByText("Model")).toBeDefined();
+    expect(screen.getAllByText("Training").length).toBeGreaterThan(0);
+    expect(screen.getByText("Calibration")).toBeDefined();
+    expect(screen.getAllByText("Evaluation").length).toBeGreaterThan(0);
+  });
+
+  it("renders the Calibration accordion only for tasks listed in conditional_visibility", () => {
+    const { rerender } = render(<FitSubTab {...baseProps} task="binary" />);
+    expect(screen.getByText("Calibration")).toBeDefined();
+    rerender(<FitSubTab {...baseProps} task="regression" />);
+    expect(screen.queryByText("Calibration")).toBeNull();
+  });
+});
+
+describe("FitSubTab — Calibration toggle", () => {
+  it("calls handleChange to set calibration to its default when toggled on", () => {
+    const handleChange = vi.fn();
+    render(
+      <FitSubTab
+        {...baseProps}
+        handleChange={handleChange}
+        localConfig={{ ...baseProps.localConfig, calibration: null }}
+      />,
+    );
+    const checkbox = screen.getByLabelText("Enable calibration") as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(handleChange).toHaveBeenCalled();
+    const updated = handleChange.mock.calls.at(-1)![0];
+    expect(updated.calibration).not.toBeNull();
+    expect(updated.calibration.method).toBe("platt");
+  });
+
+  it("calls handleChange to clear calibration when toggled off", () => {
+    const handleChange = vi.fn();
+    render(
+      <FitSubTab
+        {...baseProps}
+        handleChange={handleChange}
+        localConfig={{
+          ...baseProps.localConfig,
+          calibration: { method: "isotonic", params: {} },
+        }}
+      />,
+    );
+    const checkbox = screen.getByLabelText("Enable calibration") as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(handleChange).toHaveBeenCalled();
+    const updated = handleChange.mock.calls.at(-1)![0];
+    expect(updated.calibration).toBeNull();
+  });
+});
+
+describe("FitSubTab — Evaluation metrics", () => {
+  it("renders metric chips from the option set for the current task", () => {
+    const { container } = render(<FitSubTab {...baseProps} />);
+    const evalAccordion = Array.from(container.querySelectorAll(".lzw-chip-group"));
+    const allChips = evalAccordion.flatMap((g) => Array.from(g.children).map((c) => c.textContent));
+    expect(allChips).toEqual(expect.arrayContaining(["auc", "binary_logloss", "binary_error"]));
+  });
+});

--- a/js/src/__tests__/FoldPreview.test.tsx
+++ b/js/src/__tests__/FoldPreview.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for FoldPreview — fold preview visualization.
+ *
+ * #114 Phase A: was at 1.98% — fold rendering logic is pure.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/preact";
+import { FoldPreview } from "../components/FoldPreview";
+
+describe("FoldPreview — empty state", () => {
+  it("shows placeholder text when no folds are present", () => {
+    render(
+      <FoldPreview
+        totalFolds={0}
+        timeFolds={0}
+        groupFolds={0}
+        periods={[]}
+        folds={[]}
+        mode="time"
+      />,
+    );
+    expect(screen.getByText(/Configure blocks and groups/)).toBeDefined();
+  });
+
+  it("renders the summary badge with totals", () => {
+    render(
+      <FoldPreview
+        totalFolds={6}
+        timeFolds={3}
+        groupFolds={2}
+        periods={[]}
+        folds={[]}
+        mode="time"
+      />,
+    );
+    expect(screen.getByText(/Total:/)).toBeDefined();
+    expect(screen.getByText(/3 time x 2 groups/)).toBeDefined();
+  });
+});
+
+describe("FoldPreview — populated state", () => {
+  const sampleFolds = [
+    {
+      fold: 1,
+      period_label: "P0 -> P1",
+      group_label: "G0",
+      train_size: 100,
+      valid_size: 25,
+    },
+    {
+      fold: 2,
+      period_label: "P0+P1 -> P2",
+      group_label: "G1",
+      train_size: 200,
+      valid_size: 30,
+    },
+  ];
+
+  it("renders one row per fold", () => {
+    const { container } = render(
+      <FoldPreview
+        totalFolds={2}
+        timeFolds={2}
+        groupFolds={1}
+        periods={["P0", "P1", "P2"]}
+        folds={sampleFolds}
+        mode="time"
+      />,
+    );
+    const dataRows = container.querySelectorAll(".lzw-fold-line");
+    // Header row + 2 data rows
+    expect(dataRows.length).toBe(3);
+  });
+
+  it("renders period blocks for each row", () => {
+    const { container } = render(
+      <FoldPreview
+        totalFolds={2}
+        timeFolds={2}
+        groupFolds={1}
+        periods={["P0", "P1", "P2"]}
+        folds={sampleFolds}
+        mode="time"
+      />,
+    );
+    const blocks = container.querySelectorAll(".lzw-period-block");
+    expect(blocks.length).toBeGreaterThan(0);
+    const trainBlocks = container.querySelectorAll(".lzw-period-block--train");
+    const validBlocks = container.querySelectorAll(".lzw-period-block--valid");
+    expect(trainBlocks.length).toBeGreaterThan(0);
+    expect(validBlocks.length).toBeGreaterThan(0);
+  });
+
+  it("formats large train/valid sizes with locale separators", () => {
+    render(
+      <FoldPreview
+        totalFolds={1}
+        timeFolds={1}
+        groupFolds={1}
+        periods={["P0", "P1"]}
+        folds={[
+          {
+            fold: 1,
+            period_label: "P0 -> P1",
+            group_label: "",
+            train_size: 12345,
+            valid_size: 6789,
+          },
+        ]}
+        mode="time"
+      />,
+    );
+    expect(screen.getByText(/12[,. ]?345/)).toBeDefined();
+    expect(screen.getByText(/6[,. ]?789/)).toBeDefined();
+  });
+});

--- a/js/src/__tests__/Header.test.tsx
+++ b/js/src/__tests__/Header.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for Header — backend badge + status indicator + theme toggle.
+ *
+ * #114 Phase A: Header had 0% coverage but is small and pure.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { Header } from "../components/Header";
+
+const baseProps = {
+  backendInfo: { name: "lizyml", version: "0.10.0" },
+  status: "idle",
+  theme: "light" as const,
+  onToggleTheme: vi.fn(),
+};
+
+describe("Header — backend badge", () => {
+  it("renders the backend name and version when both are present", () => {
+    render(<Header {...baseProps} />);
+    expect(screen.getByText("lizyml v0.10.0")).toBeDefined();
+  });
+
+  it("hides the backend badge when name is missing", () => {
+    const { container } = render(
+      <Header {...baseProps} backendInfo={{ name: undefined, version: "0.10.0" }} />,
+    );
+    expect(container.textContent).not.toContain("v0.10.0");
+  });
+});
+
+describe("Header — status indicator", () => {
+  it.each([
+    ["idle", "Idle"],
+    ["data_loaded", "Data Loaded"],
+    ["running", "Running"],
+    ["completed", "Completed"],
+    ["failed", "Failed"],
+  ])("renders the %s status label", (status, expected) => {
+    render(<Header {...baseProps} status={status} />);
+    expect(screen.getByText(new RegExp(expected))).toBeDefined();
+  });
+
+  it("falls back to the idle badge for an unknown status", () => {
+    render(<Header {...baseProps} status="surprise" />);
+    expect(screen.getByText(/Idle/)).toBeDefined();
+  });
+
+  it("uses the success class for completed", () => {
+    const { container } = render(<Header {...baseProps} status="completed" />);
+    const badge = container.querySelector(".lzw-badge--success");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("Completed");
+  });
+});
+
+describe("Header — theme toggle", () => {
+  it("displays the moon glyph when light is active", () => {
+    render(<Header {...baseProps} theme="light" />);
+    expect(screen.getByRole("button").textContent).toContain("🌙");
+  });
+
+  it("displays the sun glyph when dark is active", () => {
+    render(<Header {...baseProps} theme="dark" />);
+    expect(screen.getByRole("button").textContent).toContain("☀️");
+  });
+
+  it("aria-pressed reflects dark mode", () => {
+    const { rerender } = render(<Header {...baseProps} theme="light" />);
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("false");
+    rerender(<Header {...baseProps} theme="dark" />);
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("invokes onToggleTheme on click", () => {
+    const onToggleTheme = vi.fn();
+    render(<Header {...baseProps} onToggleTheme={onToggleTheme} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onToggleTheme).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/src/__tests__/ModelEditors.test.tsx
+++ b/js/src/__tests__/ModelEditors.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Tests for ModelEditors — Smart Params, typed params, additional params.
+ *
+ * #114 Phase A: ModelEditors was at 0.69% coverage; smoke + behaviour tests
+ * pull it well over the 75% target since the file is mostly render code.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { ModelSection } from "../components/ModelEditors";
+import type { TypedParamMeta } from "../components/ModelEditors";
+
+const parameterHints: TypedParamMeta[] = [
+  { key: "objective", label: "Objective", kind: "objective" },
+  { key: "metric", label: "Metric", kind: "model_metric" },
+  { key: "n_estimators", label: "N Estimators", kind: "integer", step: 100 },
+  { key: "learning_rate", label: "Learning Rate", kind: "number", step: 0.001 },
+  { key: "first_metric_only", label: "First Metric Only", kind: "boolean" },
+];
+
+const optionSets = {
+  objective: { binary: ["binary", "cross_entropy"] },
+  model_metric: { binary: ["auc", "binary_logloss"] },
+};
+
+const searchSpaceCatalog = [
+  { key: "auto_num_leaves", title: "Auto Num Leaves", paramType: "boolean", group: "smart_params", default: true },
+  { key: "num_leaves_ratio", title: "Num Leaves Ratio", paramType: "number", group: "smart_params", default: 1.0 },
+  { key: "num_leaves", title: "Num Leaves", paramType: "integer", group: "smart_params", default: 256 },
+  { key: "min_data_in_leaf_ratio", title: "Min Data In Leaf Ratio", paramType: "number", group: "smart_params", default: 0.01 },
+  { key: "min_data_in_bin_ratio", title: "Min Data In Bin Ratio", paramType: "number", group: "smart_params", default: 0.01 },
+  { key: "feature_weights", title: "Feature Weights", paramType: "object", group: "smart_params", default: null },
+  { key: "balanced", title: "Balanced", paramType: "boolean", group: "smart_params", default: true },
+];
+
+const baseSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    auto_num_leaves: { type: "boolean" },
+    num_leaves_ratio: { type: "number" },
+    feature_weights: { type: "object" },
+    balanced: { type: "boolean" },
+    params: { type: "object" },
+    min_data_in_leaf_ratio: { type: "number" },
+    min_data_in_bin_ratio: { type: "number" },
+  },
+};
+
+const baseValue = {
+  name: "lgbm",
+  auto_num_leaves: true,
+  num_leaves_ratio: 1.0,
+  min_data_in_leaf_ratio: 0.01,
+  min_data_in_bin_ratio: 0.01,
+  balanced: true,
+  feature_weights: null,
+  params: {
+    objective: "binary",
+    metric: ["auc"],
+    n_estimators: 1500,
+    learning_rate: 0.001,
+    first_metric_only: false,
+  },
+};
+
+const baseProps = {
+  schema: baseSchema,
+  rootSchema: baseSchema,
+  value: baseValue,
+  onChange: vi.fn(),
+  task: "binary",
+  parameterHints,
+  optionSets,
+  stepMap: {},
+  columns: [{ name: "x1" }, { name: "x2" }, { name: "x3" }],
+  additionalParams: ["min_child_samples", "subsample"],
+  searchSpaceCatalog,
+  additionalParamsHiddenKeys: ["verbose", "num_threads"],
+};
+
+describe("ModelEditors.ModelSection — smoke", () => {
+  it("renders Model Type tag with the model name", () => {
+    render(<ModelSection {...baseProps} />);
+    expect(screen.getByText("lgbm")).toBeDefined();
+  });
+
+  it("renders the Smart Params section title", () => {
+    render(<ModelSection {...baseProps} />);
+    expect(screen.getByText("Smart Params")).toBeDefined();
+  });
+
+  it("renders the Model Params section title", () => {
+    render(<ModelSection {...baseProps} />);
+    expect(screen.getByText("Model Params")).toBeDefined();
+  });
+
+  it("renders the Additional Params section title", () => {
+    render(<ModelSection {...baseProps} />);
+    expect(screen.getByText("Additional Params")).toBeDefined();
+  });
+
+  it("renders typed parameter rows from parameterHints", () => {
+    render(<ModelSection {...baseProps} />);
+    expect(screen.getByText("Objective")).toBeDefined();
+    expect(screen.getByText("Metric")).toBeDefined();
+    expect(screen.getByText("Learning Rate")).toBeDefined();
+  });
+
+  it("renders the warning tag when model.name is missing", () => {
+    render(<ModelSection {...baseProps} value={{ ...baseValue, name: "" }} />);
+    expect(screen.getByText(/model.name missing/)).toBeDefined();
+  });
+});
+
+describe("ModelEditors.ModelSection — Smart Params toggle", () => {
+  it("hides the manual Num Leaves stepper when auto is on", () => {
+    const { container } = render(<ModelSection {...baseProps} />);
+    expect(container.textContent).toContain("Num Leaves Ratio");
+    // The bespoke "Num Leaves" stepper appears only when auto is off.
+    // When auto is on, we still see the smart-params keys in additional
+    // exclusion lists, but the manual stepper row is not rendered.
+    const numLeavesRow = Array.from(container.querySelectorAll(".lzw-form-row")).find(
+      (row) => row.textContent?.startsWith("Num Leaves") && !row.textContent?.includes("Ratio"),
+    );
+    expect(numLeavesRow).toBeUndefined();
+  });
+
+  it("shows the manual Num Leaves stepper when auto is off", () => {
+    const onChange = vi.fn();
+    render(
+      <ModelSection
+        {...baseProps}
+        value={{
+          ...baseValue,
+          auto_num_leaves: false,
+          params: { ...baseValue.params, num_leaves: 128 },
+        }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText("Num Leaves")).toBeDefined();
+  });
+
+  it("flips auto_num_leaves and sets/removes params.num_leaves on toggle", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ModelSection {...baseProps} onChange={onChange} />,
+    );
+    // First toggle: find by parent row with "Auto Num Leaves" label.
+    const autoRow = Array.from(container.querySelectorAll(".lzw-form-row")).find(
+      (r) => r.textContent?.startsWith("Auto Num Leaves"),
+    ) as HTMLElement;
+    const checkbox = autoRow.querySelector("input[type='checkbox']") as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1)![0];
+    expect(last.auto_num_leaves).toBe(false);
+    // num_leaves should now be present in params (default flowed from catalog).
+    expect(last.params.num_leaves).toBeDefined();
+  });
+});
+
+describe("ModelEditors.ModelSection — Feature Weights toggle", () => {
+  it("renders the toggle in disabled state when feature_weights is null", () => {
+    const { container } = render(<ModelSection {...baseProps} />);
+    const fwRow = Array.from(container.querySelectorAll(".lzw-form-row")).find((r) =>
+      r.textContent?.startsWith("Feature Weights"),
+    ) as HTMLElement;
+    const checkbox = fwRow.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("turns the toggle on when feature_weights is an object", () => {
+    const { container } = render(
+      <ModelSection
+        {...baseProps}
+        value={{ ...baseValue, feature_weights: { x1: 1.5 } }}
+      />,
+    );
+    const fwRow = Array.from(container.querySelectorAll(".lzw-form-row")).find((r) =>
+      r.textContent?.startsWith("Feature Weights"),
+    ) as HTMLElement;
+    const checkbox = fwRow.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+});
+
+describe("ModelEditors.ModelSection — Additional Params hidden keys", () => {
+  it("does not render verbose / num_threads in Additional Params even when present in params", () => {
+    const { container } = render(
+      <ModelSection
+        {...baseProps}
+        value={{
+          ...baseValue,
+          params: {
+            ...baseValue.params,
+            verbose: -1,
+            num_threads: 4,
+          },
+        }}
+      />,
+    );
+    // These should NOT appear as Additional Params rows since they're in
+    // additionalParamsHiddenKeys.
+    const additionalSection = Array.from(container.querySelectorAll(".lzw-dynform__section-title"))
+      .find((el) => el.textContent === "Additional Params")?.parentElement;
+    expect(additionalSection?.textContent).not.toMatch(/verbose/);
+    expect(additionalSection?.textContent).not.toMatch(/num_threads/);
+  });
+});
+
+describe("ModelEditors.ModelSection — backend-driven smart_params", () => {
+  it("falls back to the legacy smart_params set when searchSpaceCatalog is empty", () => {
+    // Even without a catalog, we must still render the Smart Params section
+    // (test fixtures sometimes omit the catalog).
+    const { container } = render(
+      <ModelSection {...baseProps} searchSpaceCatalog={[]} />,
+    );
+    expect(container.textContent).toContain("Smart Params");
+    expect(container.textContent).toContain("Auto Num Leaves");
+  });
+});

--- a/js/src/__tests__/PredTable.test.tsx
+++ b/js/src/__tests__/PredTable.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for PredTable — paginated prediction results table with CSV download.
+ *
+ * #114 Phase A: was at 60% — pull pagination, download, formatCell paths.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { PredTable } from "../components/PredTable";
+
+describe("PredTable — empty state", () => {
+  it("renders the placeholder when data is empty", () => {
+    render(<PredTable data={[]} />);
+    expect(screen.getByText(/No predictions available/)).toBeDefined();
+  });
+});
+
+describe("PredTable — table rendering", () => {
+  it("renders one row per data entry and a column header per key", () => {
+    const data = [
+      { pred: 0.7, label: "A" },
+      { pred: 0.4, label: "B" },
+      { pred: 0.9, label: "C" },
+    ];
+    const { container } = render(<PredTable data={data} />);
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3);
+    const headers = container.querySelectorAll("thead th");
+    // # + pred + label
+    expect(headers.length).toBe(3);
+  });
+
+  it("displays the row count in the toolbar", () => {
+    render(<PredTable data={[{ pred: 0.5 }]} />);
+    expect(screen.getByText(/1 rows/)).toBeDefined();
+  });
+
+  it("formats integer numbers without decimals", () => {
+    render(<PredTable data={[{ pred: 5, label: "A" }]} />);
+    expect(screen.getByText("5")).toBeDefined();
+  });
+
+  it("formats float numbers with 4 decimals", () => {
+    render(<PredTable data={[{ pred: 0.123456789, label: "A" }]} />);
+    expect(screen.getByText("0.1235")).toBeDefined();
+  });
+
+  it("renders dash for null/undefined cells", () => {
+    const { container } = render(
+      <PredTable data={[{ pred: null, label: undefined }]} />,
+    );
+    expect(container.textContent).toContain("-");
+  });
+});
+
+describe("PredTable — pagination", () => {
+  const makeData = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ pred: i / 10, idx: i }));
+
+  it("hides pagination when data fits in a single page", () => {
+    const { container } = render(<PredTable data={makeData(20)} pageSize={50} />);
+    expect(container.querySelector(".lzw-pred-table__pagination")).toBeNull();
+  });
+
+  it("shows Prev/Next when data spans multiple pages", () => {
+    render(<PredTable data={makeData(120)} pageSize={50} />);
+    expect(screen.getByText("Prev")).toBeDefined();
+    expect(screen.getByText("Next")).toBeDefined();
+    expect(screen.getByText("1 / 3")).toBeDefined();
+  });
+
+  it("disables Prev on the first page", () => {
+    render(<PredTable data={makeData(120)} pageSize={50} />);
+    expect((screen.getByText("Prev") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("advances the page on Next click and re-enables Prev", () => {
+    render(<PredTable data={makeData(120)} pageSize={50} />);
+    fireEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("2 / 3")).toBeDefined();
+    expect((screen.getByText("Prev") as HTMLButtonElement).disabled).toBe(false);
+  });
+});
+
+describe("PredTable — Download CSV", () => {
+  beforeEach(() => {
+    if (!URL.createObjectURL) {
+      Object.defineProperty(URL, "createObjectURL", {
+        value: vi.fn().mockReturnValue("blob:test"),
+        writable: true,
+      });
+    }
+    if (!URL.revokeObjectURL) {
+      Object.defineProperty(URL, "revokeObjectURL", {
+        value: vi.fn(),
+        writable: true,
+      });
+    }
+  });
+
+  it("creates a blob URL and triggers a download on click", () => {
+    const create = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    try {
+      render(<PredTable data={[{ pred: 0.5, label: "A" }]} />);
+      fireEvent.click(screen.getByText("Download CSV"));
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(click).toHaveBeenCalledTimes(1);
+      expect(revoke).toHaveBeenCalledWith("blob:mock");
+    } finally {
+      click.mockRestore();
+      create.mockRestore();
+      revoke.mockRestore();
+    }
+  });
+});

--- a/js/src/__tests__/ResultsTab-guards.test.tsx
+++ b/js/src/__tests__/ResultsTab-guards.test.tsx
@@ -272,3 +272,58 @@ describe("ResultsTab — Best Score null guard", () => {
     expect(screen.getByText(/auc: 0\.9123/)).toBeDefined();
   });
 });
+
+// ── #114 Phase A: failed-state error UI ──
+
+describe("ResultsTab — failed status error UI", () => {
+  it("renders BACKEND_ERROR message and Re-run button", () => {
+    const sendAction = vi.fn();
+    render(
+      <ResultsTab
+        {...defaultProps}
+        status="failed"
+        jobType="fit"
+        fitSummary={{}}
+        sendAction={sendAction}
+        error={{ code: "BACKEND_ERROR", message: "Model has not been fitted" }}
+      />,
+    );
+    expect(screen.getByText(/BACKEND_ERROR/)).toBeDefined();
+    expect(screen.getByText(/Model has not been fitted/)).toBeDefined();
+    const rerun = screen.getByText(/Re-run|Retry/i);
+    expect(rerun).toBeDefined();
+  });
+
+  it("dispatches the original job_type when Re-run is clicked", () => {
+    const sendAction = vi.fn();
+    render(
+      <ResultsTab
+        {...defaultProps}
+        status="failed"
+        jobType="tune"
+        fitSummary={{}}
+        sendAction={sendAction}
+        error={{ code: "INTERNAL_ERROR", message: "boom" }}
+      />,
+    );
+    fireEvent.click(screen.getByText(/Re-run|Retry/i));
+    expect(sendAction).toHaveBeenCalled();
+    // The first argument should be either "tune" (re-run same job) or
+    // contain a re-run hint — either way, the tune job should be invoked.
+    const calls = sendAction.mock.calls.map((c) => c[0]);
+    expect(calls.some((c: string) => c === "tune" || c.includes("retry") || c.includes("rerun"))).toBe(
+      true,
+    );
+  });
+
+  it("does not show the Re-run button when status is completed", () => {
+    render(
+      <ResultsTab
+        {...defaultProps}
+        status="completed"
+        jobType="fit"
+      />,
+    );
+    expect(screen.queryByText(/Re-run/i)).toBeNull();
+  });
+});

--- a/js/src/__tests__/SearchSpace.test.tsx
+++ b/js/src/__tests__/SearchSpace.test.tsx
@@ -163,6 +163,69 @@ describe("SearchSpace — Bug 7: metric Fixed→Choice mode switch", () => {
   });
 });
 
+// ── #114 Phase A: regression metric option set must include smape / wape (P-030) ──
+
+describe("SearchSpace — P-030 regression metric chips", () => {
+  const regressionUiSchema = {
+    option_sets: {
+      objective: { regression: ["huber", "mse"] },
+      // P-030: smape / wape are first-class regression metrics in lizyml 0.11.
+      // The widget must surface them through the contract; SearchSpace renders
+      // them as choice chips when the user picks the metric row.
+      model_metric: { regression: ["rmse", "mae", "smape", "wape"] },
+    },
+    step_map: {},
+    search_space_catalog: [
+      {
+        key: "metric",
+        title: "Metric",
+        paramType: "string",
+        modes: ["fixed", "choice"],
+        group: "model_params",
+      },
+    ],
+    special_search_space_fields: { metric: "model_metric" },
+    additional_params: [],
+    conditional_visibility: {},
+  };
+
+  it("renders smape and wape chips for the regression metric option set", () => {
+    render(
+      <SearchSpace
+        {...defaultProps}
+        task="regression"
+        uiSchema={regressionUiSchema}
+        fixedModelParams={{ metric: ["rmse"] }}
+        modelConfig={{ params: { metric: ["rmse"] } }}
+      />,
+    );
+    expect(screen.getByText("smape")).toBeDefined();
+    expect(screen.getByText("wape")).toBeDefined();
+  });
+
+  it("toggles smape into the fixed metric list when the chip is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <SearchSpace
+        {...defaultProps}
+        task="regression"
+        uiSchema={regressionUiSchema}
+        fixedModelParams={{ metric: ["rmse"] }}
+        modelConfig={{ params: { metric: ["rmse"] } }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("smape"));
+    expect(onChange).toHaveBeenCalled();
+    // The most-recent invocation should now contain smape in the fixed metric.
+    const calls = onChange.mock.calls;
+    const last = calls[calls.length - 1][0];
+    const fixedMetric = last.fixedModelParams?.metric;
+    expect(Array.isArray(fixedMetric)).toBe(true);
+    expect(fixedMetric).toContain("smape");
+  });
+});
+
 // ── Bug 8: boolean Fixed→Choice should include both true and false ──
 
 describe("SearchSpace — Bug 8: boolean Fixed→Choice mode switch", () => {

--- a/js/src/__tests__/TuneSubTab.test.tsx
+++ b/js/src/__tests__/TuneSubTab.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for TuneSubTab — Search Space + Tuning Settings + Evaluation.
+ *
+ * #114 Phase A: was at 1.38% — small file, mostly composition over SearchSpace.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { TuneSubTab } from "../tabs/TuneSubTab";
+
+const baseUiSchema = {
+  option_sets: {
+    objective: { binary: ["binary"] },
+    metric: { binary: ["auc", "binary_logloss", "binary_error"] },
+    model_metric: { binary: ["auc", "binary_logloss"] },
+  },
+  step_map: {},
+  search_space_catalog: [
+    {
+      key: "learning_rate",
+      title: "Learning Rate",
+      paramType: "number",
+      modes: ["fixed", "range"],
+      group: "model_params",
+    },
+  ],
+  additional_params: [],
+  conditional_visibility: {},
+};
+
+const baseProps = {
+  localConfig: {
+    model: { name: "lgbm", params: {} },
+    training: {},
+    tuning: { optuna: { space: {}, params: { n_trials: 10 } } },
+  },
+  uiSchema: baseUiSchema,
+  task: "binary",
+  dfInfo: { columns: [] },
+  handleChange: vi.fn(),
+  sendAction: vi.fn(),
+  rawYaml: null,
+  setRawYaml: vi.fn(),
+};
+
+describe("TuneSubTab — section structure", () => {
+  it("renders the three accordion sections", () => {
+    render(<TuneSubTab {...baseProps} />);
+    expect(screen.getByText("Tuning Settings")).toBeDefined();
+    expect(screen.getByText("Search Space")).toBeDefined();
+    expect(screen.getByText("Evaluation")).toBeDefined();
+  });
+
+  it("shows the n_trials stepper", () => {
+    render(<TuneSubTab {...baseProps} />);
+    expect(screen.getByText("n_trials")).toBeDefined();
+  });
+});
+
+describe("TuneSubTab — Optimization Metric segment", () => {
+  it("renders the segment button row with all metrics", () => {
+    const { container } = render(<TuneSubTab {...baseProps} />);
+    const segmentBtns = Array.from(
+      container.querySelectorAll(".lzw-segment .lzw-segment__btn"),
+    ).map((b) => b.textContent);
+    expect(segmentBtns).toEqual(
+      expect.arrayContaining(["auc", "binary_logloss", "binary_error"]),
+    );
+  });
+
+  it("marks the first configured metric as the optimization metric", () => {
+    const { container } = render(
+      <TuneSubTab
+        {...baseProps}
+        localConfig={{
+          ...baseProps.localConfig,
+          tuning: {
+            ...baseProps.localConfig.tuning,
+            evaluation: { metrics: ["binary_logloss"] },
+          },
+        }}
+      />,
+    );
+    // Scope to the Optimization Metric row (avoids SearchSpace's Fixed/Range
+    // segment which is also rendered above).
+    const activeBtns = Array.from(
+      container.querySelectorAll(".lzw-segment__btn--active"),
+    ).map((b) => b.textContent);
+    expect(activeBtns).toContain("binary_logloss");
+  });
+
+  it("fires handleChange when a different optimization metric is selected", () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <TuneSubTab
+        {...baseProps}
+        handleChange={handleChange}
+        localConfig={{
+          ...baseProps.localConfig,
+          tuning: {
+            ...baseProps.localConfig.tuning,
+            evaluation: { metrics: ["auc"] },
+          },
+        }}
+      />,
+    );
+    const segmentBtn = Array.from(
+      container.querySelectorAll(".lzw-segment .lzw-segment__btn"),
+    ).find((b) => b.textContent === "binary_logloss") as HTMLButtonElement;
+    fireEvent.click(segmentBtn);
+    expect(handleChange).toHaveBeenCalled();
+    const updated = handleChange.mock.calls.at(-1)![0];
+    // First metric in the array is the optimization metric.
+    expect(updated.tuning.evaluation.metrics[0]).toBe("binary_logloss");
+  });
+});
+
+describe("TuneSubTab — Additional Metrics chips", () => {
+  it("excludes the active optimization metric from the additional chip list", () => {
+    const { container } = render(
+      <TuneSubTab
+        {...baseProps}
+        localConfig={{
+          ...baseProps.localConfig,
+          tuning: {
+            ...baseProps.localConfig.tuning,
+            evaluation: { metrics: ["auc"] },
+          },
+        }}
+      />,
+    );
+    // The Additional Metrics chip group should NOT contain the active "auc" chip.
+    const chips = container.querySelectorAll(".lzw-chip-group .lzw-chip");
+    const labels = Array.from(chips).map((c) => c.textContent);
+    expect(labels).not.toContain("auc");
+    expect(labels).toContain("binary_logloss");
+  });
+
+  it("toggles an additional metric on click", () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <TuneSubTab
+        {...baseProps}
+        handleChange={handleChange}
+        localConfig={{
+          ...baseProps.localConfig,
+          tuning: {
+            ...baseProps.localConfig.tuning,
+            evaluation: { metrics: ["auc"] },
+          },
+        }}
+      />,
+    );
+    // Click the chip-group instance of binary_logloss (additional metric).
+    const chipBtn = Array.from(
+      container.querySelectorAll(".lzw-chip-group .lzw-chip"),
+    ).find((c) => c.textContent === "binary_logloss") as HTMLButtonElement;
+    fireEvent.click(chipBtn);
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/js/src/__tests__/configHelpers.test.ts
+++ b/js/src/__tests__/configHelpers.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for configHelpers — pure schema utilities.
+ *
+ * #114 Phase A: configHelpers had 48% statement coverage; the helpers are
+ * pure and trivial to exercise so they should be near-100%.
+ */
+import { describe, it, expect } from "vitest";
+import { getSectionSchema, getUnknownKeys, diffToPatchOps } from "../tabs/configHelpers";
+
+describe("getSectionSchema", () => {
+  it("returns null when the requested section is missing", () => {
+    const root = { properties: { other: { type: "object" } } };
+    expect(getSectionSchema(root, "model")).toBeNull();
+  });
+
+  it("returns the section sub-schema for a top-level property", () => {
+    const root = {
+      properties: {
+        model: { type: "object", properties: { name: { type: "string" } } },
+      },
+    };
+    const result = getSectionSchema(root, "model");
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("object");
+    expect(result?.properties?.name).toEqual({ type: "string" });
+  });
+
+  it("resolves a $ref pointer at the root level", () => {
+    const root = {
+      $ref: "#/$defs/Root",
+      $defs: {
+        Root: {
+          properties: { model: { type: "object" } },
+        },
+      },
+    };
+    expect(getSectionSchema(root, "model")).toEqual({ type: "object" });
+  });
+
+  it("resolves a $ref on a section property", () => {
+    const root = {
+      properties: { model: { $ref: "#/$defs/Model" } },
+      $defs: { Model: { type: "object", title: "Model" } },
+    };
+    const result = getSectionSchema(root, "model");
+    expect(result?.title).toBe("Model");
+  });
+
+  it("collapses a single-element allOf wrapping a $ref", () => {
+    const root = {
+      properties: {
+        model: { allOf: [{ $ref: "#/$defs/Model" }], description: "wrapped" },
+      },
+      $defs: { Model: { type: "object", title: "Model" } },
+    };
+    const result = getSectionSchema(root, "model");
+    // Outer description must override inner schema (rest spread last)
+    expect(result?.description).toBe("wrapped");
+    expect(result?.title).toBe("Model");
+  });
+
+  it("ignores forbidden $ref segments (__proto__, constructor, prototype)", () => {
+    const root = {
+      properties: { model: { $ref: "#/__proto__/polluted" } },
+    };
+    expect(getSectionSchema(root, "model")).toEqual({});
+  });
+});
+
+describe("getUnknownKeys", () => {
+  it("excludes known sections, data tab keys, tuning, config_version, and task", () => {
+    const root = {
+      properties: {
+        model: {},
+        training: {},
+        data: {},
+        features: {},
+        split: {},
+        tuning: {},
+        config_version: {},
+        task: {},
+        custom_extra: {},
+      },
+    };
+    expect(getUnknownKeys(root, ["model", "training"])).toEqual(["custom_extra"]);
+  });
+
+  it("returns an empty list when nothing is unknown", () => {
+    const root = { properties: { model: {}, data: {} } };
+    expect(getUnknownKeys(root, ["model"])).toEqual([]);
+  });
+
+  it("handles a missing properties block gracefully", () => {
+    expect(getUnknownKeys({}, [])).toEqual([]);
+  });
+});
+
+describe("diffToPatchOps", () => {
+  it("emits a 'set' op when a value changes", () => {
+    const ops = diffToPatchOps({ a: 1 }, { a: 2 });
+    expect(ops).toEqual([{ op: "set", path: "a", value: 2 }]);
+  });
+
+  it("emits 'set' for a newly added key", () => {
+    const ops = diffToPatchOps({}, { a: 1 });
+    expect(ops).toEqual([{ op: "set", path: "a", value: 1 }]);
+  });
+
+  it("emits 'unset' for a removed key", () => {
+    const ops = diffToPatchOps({ a: 1, b: 2 }, { a: 1 });
+    expect(ops).toEqual([{ op: "unset", path: "b", value: null }]);
+  });
+
+  it("returns no ops when configs are deeply equal", () => {
+    const a = { a: 1, b: { c: [1, 2] } };
+    const b = { a: 1, b: { c: [1, 2] } };
+    expect(diffToPatchOps(a, b)).toEqual([]);
+  });
+
+  it("treats deep object differences as a single top-level set", () => {
+    const ops = diffToPatchOps({ b: { c: 1 } }, { b: { c: 2 } });
+    expect(ops).toEqual([{ op: "set", path: "b", value: { c: 2 } }]);
+  });
+});

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -4,6 +4,26 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/__tests__/**",
+        // Bootstrap entry — exercised at runtime in the browser, no logic to
+        // unit-test in JSDOM.
+        "src/index.tsx",
+      ],
+      reporter: ["text", "html"],
+      // #114 Phase C: enforce 75% line/statement coverage and 70% branch
+      // coverage so regressions are caught at PR time.
+      thresholds: {
+        statements: 75,
+        lines: 75,
+        functions: 50,
+        branches: 70,
+      },
+    },
   },
   esbuild: {
     jsx: "automatic",


### PR DESCRIPTION
## Summary
Closes Phase A of #114. Brings JS unit-test coverage from **47% statements → 75.45%** by adding focused test files for the 0%/low-coverage components and tabs.

## What changed

### New test files (10 files / 101 new cases)

| File | Cases | Why |
|---|---:|---|
| `App.test.tsx` | 12 | Tab gating, auto-switch on running/completed/failed, custom-msg routing |
| `Header.test.tsx` | 13 | Status label per state, theme toggle, backend badge |
| `configHelpers.test.ts` | 14 | `$ref` resolution + `__proto__` guard, `getUnknownKeys`, `diffToPatchOps` |
| `ModelEditors.test.tsx` | 13 | Smart Params toggle wiring, additional-params hidden keys filtering |
| `TuneSubTab.test.tsx` | 7 | Optimization-metric segment + additional-metric chips |
| `FitSubTab.test.tsx` | 5 | Section visibility + Calibration enable/disable |
| `BlockedGroupKFold.test.tsx` | 5 | Smoke render covers 84% of the file |
| `DistributionBar.test.tsx` | 5 | Pure component → 100% coverage |
| `FoldPreview.test.tsx` | 5 | Pure component → 100% coverage |
| `PredTable.test.tsx` | 11 | Pagination + CSV download → 100% coverage |

### Existing tests extended

| File | Change |
|---|---|
| `SearchSpace.test.tsx` | Locks in P-030 smape / wape regression metric chips (issue Phase A acceptance) |
| `ResultsTab-guards.test.tsx` | Adds failed-status `BACKEND_ERROR` rendering + Re-run dispatch |

### Phase C tooling
- `vitest.config.ts`: `coverage.thresholds = { statements: 75, lines: 75, branches: 70, functions: 50 }`. `index.tsx` (bootstrap entry) excluded.
- `js/package.json`: new `pnpm test:coverage` script.
- `.github/workflows/ci.yml`: CI now runs `pnpm test:coverage` (threshold-enforced) and prints the e2e test count for PR diff visibility.
- `README.md`: documents the coverage targets in the Development section.

## Coverage delta

```
Before:  All files | 47.37% stmts | 67.05% branch | 50.31% funcs | 47.37% lines
After:   All files | 75.45% stmts | 74.73% branch | 51.94% funcs | 75.45% lines
```

## Test plan
- [x] `cd js && pnpm test:coverage` → 272 passed (was 171), thresholds met
- [x] `cd js && pnpm exec eslint src/__tests__/` → clean
- [x] `cd js && pnpm exec tsc --noEmit` → no new errors in changed files
- [x] `uv run pytest --ignore=tests/e2e -q` → 878 passed (unchanged)

## Out of scope
- **Phase B (E2E coverage)** — `test_p030_compat.py`, inference flow, error-flow E2E. Tracked in this same issue and will land in a follow-up PR so the structural refactor PRs (#117) have a richer E2E safety net.
- `index.tsx` (bootstrap) is excluded from coverage; runtime-only.
- `PlotViewer.tsx` stays at 22% — Plotly dynamic loader is exercised manually.

Refs: #114 Phase A + Phase C tooling.