### PR TITLE
refactor(adapter): introduce LMResultView typed boundary (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Adapter boundary typed via `LMResultView`** ([#116](https://github.com/nbx-liz/LizyML-Widget/issues/116)).
+  All `getattr(...)` reads on lizyml result objects are consolidated into a
+  new `adapter_views.py` module (`view_fit_result`, `view_tuning_result`,
+  `view_tune_progress`, `view_prediction_result`, `view_boundary_report`,
+  `view_rounds`). Each view raises `LizyMLContractError` on a missing
+  required field, giving the version guard real teeth — a renamed field
+  in a future lizyml minor fails fast at the boundary rather than
+  silently degrading to `None` / `[]` deeper in the widget.
+- **Removed `model._widget_config` private write** ([#116](https://github.com/nbx-liz/LizyML-Widget/issues/116)).
+  `LizyMLAdapter.create_model` no longer monkey-patches the lizyml model
+  with a widget-specific attribute. Configs now live in an adapter-side
+  registry keyed by `id(model)`, and the legacy `_cfg.task` / fallback
+  config read is centralised in a single `_task_for_model(model)`
+  helper used by both `available_plots()` and `model_info()`.
+
 ### Added
 - **E2E test coverage Phase B** ([#114](https://github.com/nbx-liz/LizyML-Widget/issues/114)).
   Four new test files plus a Tune→Apply→Re-tune extension to the existing

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -26,6 +26,14 @@ from .adapter_schema import (
     prepare_tune_overrides,
     strip_for_backend,
 )
+from .adapter_views import (
+    LMBoundaryReportView,
+    LMRoundView,
+    view_fit_result,
+    view_prediction_result,
+    view_tune_progress,
+    view_tuning_result,
+)
 from .types import (
     BackendContract,
     BackendInfo,
@@ -220,8 +228,8 @@ def _serialize_trials(trials: Any) -> list[dict[str, Any]]:
     return out
 
 
-def _serialize_rounds(rounds: Any) -> list[dict[str, Any]]:
-    """Convert a tuple of ``RoundSummary`` into plain dicts.
+def _serialize_rounds(rounds: Sequence[LMRoundView]) -> list[dict[str, Any]]:
+    """Convert a tuple of typed round views into JSON-serialisable dicts.
 
     ``space_snapshot`` is stripped because each entry is a dataclass
     (``FloatDim`` / ``IntDim`` / ``CategoricalDim``) that anywidget cannot
@@ -229,42 +237,40 @@ def _serialize_rounds(rounds: Any) -> list[dict[str, Any]]:
     (scores, expanded dim names); full space snapshots can be retrieved
     from ``boundary_report`` if needed in a future iteration.
     """
-    out: list[dict[str, Any]] = []
-    for r in rounds or ():
-        out.append(
-            {
-                "round": int(getattr(r, "round", 0)),
-                "n_trials": int(getattr(r, "n_trials", 0)),
-                "best_score_before": getattr(r, "best_score_before", None),
-                "best_score_after": float(getattr(r, "best_score_after", 0.0)),
-                "expanded_dims": list(getattr(r, "expanded_dims", ()) or ()),
-            }
-        )
-    return out
+    return [
+        {
+            "round": r.round,
+            "n_trials": r.n_trials,
+            "best_score_before": r.best_score_before,
+            "best_score_after": r.best_score_after,
+            "expanded_dims": list(r.expanded_dims),
+        }
+        for r in rounds
+    ]
 
 
-def _serialize_boundary_report(report: Any) -> dict[str, Any] | None:
-    """Convert ``BoundaryReport`` into a JSON-friendly dict (or None)."""
+def _serialize_boundary_report(
+    report: LMBoundaryReportView | None,
+) -> dict[str, Any] | None:
+    """Convert a typed boundary-report view into a JSON-friendly dict (or None)."""
     if report is None:
         return None
-    dims_out: list[dict[str, Any]] = []
-    for d in getattr(report, "dims", ()) or ():
-        dims_out.append(
-            {
-                "name": getattr(d, "name", ""),
-                "best_value": getattr(d, "best_value", None),
-                "low": getattr(d, "low", None),
-                "high": getattr(d, "high", None),
-                "position_pct": getattr(d, "position_pct", None),
-                "edge": getattr(d, "edge", ""),
-                "expanded": bool(getattr(d, "expanded", False)),
-                "new_low": getattr(d, "new_low", None),
-                "new_high": getattr(d, "new_high", None),
-            }
-        )
     return {
-        "dims": dims_out,
-        "expanded_names": list(getattr(report, "expanded_names", ()) or ()),
+        "dims": [
+            {
+                "name": d.name,
+                "best_value": d.best_value,
+                "low": d.low,
+                "high": d.high,
+                "position_pct": d.position_pct,
+                "edge": d.edge,
+                "expanded": d.expanded,
+                "new_low": d.new_low,
+                "new_high": d.new_high,
+            }
+            for d in report.dims
+        ],
+        "expanded_names": list(report.expanded_names),
     }
 
 
@@ -274,6 +280,11 @@ class LizyMLAdapter:
     def __init__(self) -> None:
         _check_lizyml_version()
         self._last_worker_thread: threading.Thread | None = None
+        # #116: Adapter-side config registry keyed by ``id(model)``. Replaces
+        # the previous ``model._widget_config`` private write. Used as the
+        # fallback path when reading task off lizyml's internal ``_cfg``
+        # also fails (e.g. an older / mocked model that lacks ``_cfg``).
+        self._model_configs: dict[int, dict[str, Any]] = {}
 
     @property
     def info(self) -> BackendInfo:
@@ -697,8 +708,34 @@ class LizyMLAdapter:
         from lizyml.core.model import Model
 
         model = Model(config, data=dataframe)
-        model._widget_config = copy.deepcopy(config)  # type: ignore[attr-defined]  # noqa: SLF001
+        # #116: register the config in the adapter rather than writing a
+        # private attr onto the lizyml object. The fallback in
+        # ``_task_for_model`` reads from this registry when ``model._cfg``
+        # is unavailable.
+        self._model_configs[id(model)] = copy.deepcopy(config)
         return model
+
+    def _task_for_model(self, model: Any) -> str:
+        """Return the task ('binary'/'multiclass'/'regression') for *model*.
+
+        #116: centralises the legacy ``_cfg.task`` private read with a
+        graceful fallback to the adapter-side config registry. Returns ""
+        if no source can be resolved (caller treats this as "unknown task").
+        """
+        # 1. Try lizyml's internal _cfg.task (the public path on supported
+        #    minors). Suppressed because mocked / loaded models may not
+        #    expose _cfg.
+        try:
+            return str(model._cfg.task)  # noqa: SLF001
+        except AttributeError:
+            pass
+        # 2. Fallback: adapter-side registry populated by create_model.
+        cfg = self._model_configs.get(id(model))
+        if cfg is not None:
+            task = cfg.get("task", "")
+            if isinstance(task, str):
+                return task
+        return ""
 
     def _run_with_cancel_polling(
         self,
@@ -764,9 +801,10 @@ class LizyMLAdapter:
             lambda: model.fit(params=params),
             on_progress,
         )
+        view = view_fit_result(result)
         return FitSummary(
-            metrics=result.metrics,
-            fold_count=len(getattr(getattr(result, "splits", None), "outer", [])),
+            metrics=view.metrics,
+            fold_count=view.fold_count,
             params=model.params_table().reset_index().to_dict(orient="records"),
         )
 
@@ -808,27 +846,20 @@ class LizyMLAdapter:
         if on_progress is not None:
 
             def progress_cb(info: TuneProgressInfo) -> None:
-                msg = f"Trial {info.current_trial}/{info.total_trials}"
-                if info.best_score is not None:
-                    msg += f" (best: {info.best_score:.4f})"
-                # Re-tune fields (lizyml>=0.9.0 only).  Default to sane
-                # single-round values so the widget traitlet can assume the
-                # keys are always present.
-                round_no = int(getattr(info, "round", 1) or 1)
-                cumulative = int(
-                    getattr(info, "cumulative_trials", info.current_trial) or info.current_trial
-                )
-                expanded = tuple(getattr(info, "expanded_dims", ()) or ())
+                view = view_tune_progress(info)
+                msg = f"Trial {view.current_trial}/{view.total_trials}"
+                if view.best_score is not None:
+                    msg += f" (best: {view.best_score:.4f})"
                 on_progress(
-                    info.current_trial,
-                    info.total_trials,
+                    view.current_trial,
+                    view.total_trials,
                     msg,
-                    round=round_no,
-                    cumulative_trials=cumulative,
-                    expanded_dims=list(expanded),
-                    latest_score=info.latest_score,
-                    latest_state=info.latest_state,
-                    best_score=info.best_score,
+                    round=view.round,
+                    cumulative_trials=view.cumulative_trials,
+                    expanded_dims=list(view.expanded_dims),
+                    latest_score=view.latest_score,
+                    latest_state=view.latest_state,
+                    best_score=view.best_score,
                 )
 
         def _cancel_only(_c: int, _t: int, _m: str) -> None:
@@ -856,15 +887,16 @@ class LizyMLAdapter:
             lambda: model.tune(**tune_kwargs),
             _cancel_only,
         )
+        view = view_tuning_result(result)
 
         return TuningSummary(
-            best_params=result.best_params,
-            best_score=result.best_score,
-            trials=_serialize_trials(result.trials),
-            metric_name=result.metric_name,
-            direction=result.direction,
-            rounds=_serialize_rounds(getattr(result, "rounds", ())),
-            boundary_report=_serialize_boundary_report(getattr(result, "boundary_report", None)),
+            best_params=view.best_params,
+            best_score=view.best_score,
+            trials=_serialize_trials(view.raw_trials),
+            metric_name=view.metric_name,
+            direction=view.direction,
+            rounds=_serialize_rounds(view.rounds),
+            boundary_report=_serialize_boundary_report(view.boundary_report),
         )
 
     def predict(
@@ -881,11 +913,12 @@ class LizyMLAdapter:
         # via ``FitResult.target_encoder``. Pandas preserves that dtype when
         # we wrap it directly, so no extra conversion is needed here.
         result = model.predict(data, return_shap=return_shap)
-        df = pd.DataFrame({"pred": result.pred})
+        view = view_prediction_result(result)
+        df = pd.DataFrame({"pred": view.pred})
 
         # Proba: expand 2D (multiclass) into per-class columns
-        if result.proba is not None:
-            proba = np.asarray(result.proba)
+        if view.proba is not None:
+            proba = np.asarray(view.proba)
             if proba.ndim == 2:
                 for i in range(proba.shape[1]):
                     df[f"proba_{i}"] = proba[:, i]
@@ -893,16 +926,15 @@ class LizyMLAdapter:
                 df["proba"] = proba
 
         # SHAP values: include if available
-        shap_values = getattr(result, "shap_values", None)
-        if shap_values is not None:
-            shap_arr = np.asarray(shap_values)
+        if view.shap_values is not None:
+            shap_arr = np.asarray(view.shap_values)
             if shap_arr.ndim == 2:
                 feature_names = list(data.columns)
                 for i, name in enumerate(feature_names):
                     if i < shap_arr.shape[1]:
                         df[f"shap_{name}"] = shap_arr[:, i]
 
-        return PredictionSummary(predictions=df, warnings=result.warnings)
+        return PredictionSummary(predictions=df, warnings=view.warnings)
 
     def evaluate_table(self, model: Any) -> list[dict[str, Any]]:
         df: pd.DataFrame = model.evaluate_table()
@@ -944,13 +976,9 @@ class LizyMLAdapter:
         return PlotData(plotly_json=fig.to_json())
 
     def available_plots(self, model: Any) -> list[str]:
-        # Extract task safely: try _cfg (LizyML internal), then widget fallback
-        task: str = ""
-        try:
-            task = model._cfg.task  # noqa: SLF001
-        except AttributeError:
-            cfg = getattr(model, "_widget_config", {})
-            task = cfg.get("task", "")
+        # #116: task lookup centralised in _task_for_model (registry-backed
+        # fallback replaces the legacy ``_widget_config`` private read).
+        task = self._task_for_model(model)
 
         # Check if model has been fitted (not just tuned) — P-004 R4
         is_fitted = False
@@ -961,7 +989,12 @@ class LizyMLAdapter:
         with contextlib.suppress(Exception):
             has_calibration = is_fitted and model.fit_result.calibrator is not None
 
-        has_tuning = getattr(model, "_tuning_result", None) is not None
+        # Feature-detection probe — model._tuning_result is a private slot
+        # lizyml exposes for tuning state. The presence check is intentional
+        # and does not read data off the value, so it is allowed by #116.
+        has_tuning = (
+            hasattr(model, "_tuning_result") and model._tuning_result is not None  # noqa: SLF001
+        )
 
         plots: list[str] = []
 
@@ -1066,8 +1099,9 @@ class LizyMLAdapter:
             if params_df is not None:
                 info["params"] = params_df.reset_index().to_dict(orient="records")
 
-        # Extract task from config
-        with contextlib.suppress(Exception):
-            info["task"] = model._cfg.task  # noqa: SLF001
+        # #116: task lookup centralised in _task_for_model.
+        task = self._task_for_model(model)
+        if task:
+            info["task"] = task
 
         return info

--- a/src/lizyml_widget/adapter_views.py
+++ b/src/lizyml_widget/adapter_views.py
@@ -1,0 +1,246 @@
+"""Typed views over lizyml result objects (#116).
+
+This module is the **only** place in the widget that reads internal
+attributes off lizyml result types. The rest of the adapter consumes
+``LM*View`` dataclasses, which means a contract drift in lizyml fails
+loudly (``LizyMLContractError``) at the boundary instead of silently
+degrading to ``None`` / ``[]`` deeper in the stack.
+
+The views deliberately enumerate exactly the fields the widget consumes.
+If a future widget feature needs another field, add it here in a single
+place rather than spreading new ``getattr(result, "...", default)``
+chains across ``adapter.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "LMBoundaryDimView",
+    "LMBoundaryReportView",
+    "LMFitResultView",
+    "LMPredictionResultView",
+    "LMRoundView",
+    "LMTuneProgressView",
+    "LMTuningResultView",
+    "LizyMLContractError",
+    "view_boundary_report",
+    "view_fit_result",
+    "view_prediction_result",
+    "view_rounds",
+    "view_tune_progress",
+    "view_tuning_result",
+]
+
+
+class LizyMLContractError(RuntimeError):
+    """Raised when a lizyml result object is missing a required field.
+
+    The version guard in ``adapter.py`` (``LIZYML_MIN_VERSION`` /
+    ``LIZYML_MAX_VERSION``) only catches major-version drift. Field-level
+    contract changes between supported minors surface here as a fail-fast
+    error rather than silent ``None``s deeper in the widget.
+    """
+
+
+def _require(obj: Any, name: str, *, optional: bool = False) -> Any:
+    """Read ``obj.<name>``; raise ``LizyMLContractError`` if missing."""
+    if not hasattr(obj, name):
+        if optional:
+            return None
+        msg = (
+            f"lizyml object {type(obj).__name__!r} is missing required "
+            f"attribute {name!r} — backend contract drift?"
+        )
+        raise LizyMLContractError(msg)
+    return getattr(obj, name)
+
+
+# ── Tune ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LMRoundView:
+    """One Round entry from a ``TuningResult.rounds`` sequence."""
+
+    round: int
+    n_trials: int
+    best_score_before: float | None
+    best_score_after: float
+    expanded_dims: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LMBoundaryDimView:
+    """One dimension entry from a ``BoundaryReport.dims`` sequence."""
+
+    name: str
+    best_value: Any
+    low: Any
+    high: Any
+    position_pct: float | None
+    edge: str
+    expanded: bool
+    new_low: Any
+    new_high: Any
+
+
+@dataclass(frozen=True)
+class LMBoundaryReportView:
+    """Wraps lizyml's ``BoundaryReport`` for the widget.
+
+    INV (#118): every dim in :attr:`dims` is unique by ``name``. Construction
+    here does not enforce uniqueness — that's a backend invariant — but the
+    field-level type makes it explicit so a future invariant test can lock
+    it in.
+    """
+
+    dims: tuple[LMBoundaryDimView, ...]
+    expanded_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LMTuneProgressView:
+    """Per-trial progress info from ``TuneProgressInfo``."""
+
+    current_trial: int
+    total_trials: int
+    round: int
+    cumulative_trials: int
+    expanded_dims: tuple[str, ...]
+    latest_score: float | None
+    latest_state: str | None
+    best_score: float | None
+
+
+@dataclass(frozen=True)
+class LMTuningResultView:
+    """Wraps lizyml's ``TuningResult``."""
+
+    best_params: dict[str, Any]
+    best_score: float
+    metric_name: str
+    direction: str
+    rounds: tuple[LMRoundView, ...]
+    boundary_report: LMBoundaryReportView | None
+    raw_trials: Any  # opaque — passed through to _serialize_trials
+
+
+# ── Fit / Prediction ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LMFitResultView:
+    """Wraps lizyml's ``FitResult`` for the fields the widget uses."""
+
+    metrics: dict[str, Any]
+    fold_count: int
+
+
+@dataclass(frozen=True)
+class LMPredictionResultView:
+    """Wraps lizyml's ``PredictionResult``."""
+
+    pred: Any
+    proba: Any | None
+    shap_values: Any | None
+    warnings: list[str] = field(default_factory=list)
+
+
+# ── Factory functions ───────────────────────────────────────────────────
+
+
+def view_rounds(rounds: Any) -> tuple[LMRoundView, ...]:
+    """Wrap a tuple of ``RoundSummary`` into ``LMRoundView`` instances."""
+    if not rounds:
+        return ()
+    out: list[LMRoundView] = []
+    for r in rounds:
+        out.append(
+            LMRoundView(
+                round=int(_require(r, "round")),
+                n_trials=int(_require(r, "n_trials")),
+                best_score_before=_require(r, "best_score_before", optional=True),
+                best_score_after=float(_require(r, "best_score_after")),
+                expanded_dims=tuple(_require(r, "expanded_dims") or ()),
+            )
+        )
+    return tuple(out)
+
+
+def view_boundary_report(report: Any) -> LMBoundaryReportView | None:
+    """Wrap a ``BoundaryReport`` (or None) into ``LMBoundaryReportView``."""
+    if report is None:
+        return None
+    raw_dims = _require(report, "dims") or ()
+    dims = tuple(
+        LMBoundaryDimView(
+            name=str(_require(d, "name")),
+            best_value=_require(d, "best_value", optional=True),
+            low=_require(d, "low", optional=True),
+            high=_require(d, "high", optional=True),
+            position_pct=_require(d, "position_pct", optional=True),
+            edge=str(_require(d, "edge", optional=True) or ""),
+            expanded=bool(_require(d, "expanded", optional=True) or False),
+            new_low=_require(d, "new_low", optional=True),
+            new_high=_require(d, "new_high", optional=True),
+        )
+        for d in raw_dims
+    )
+    expanded_names = tuple(_require(report, "expanded_names", optional=True) or ())
+    return LMBoundaryReportView(dims=dims, expanded_names=expanded_names)
+
+
+def view_tune_progress(info: Any) -> LMTuneProgressView:
+    """Wrap a ``TuneProgressInfo`` per-trial event."""
+    current_trial = int(_require(info, "current_trial"))
+    total_trials = int(_require(info, "total_trials"))
+    # Re-tune fields are optional on older minors but lizyml>=0.9.0 always
+    # supplies them. Default to single-round values when absent so the
+    # widget traitlet contract stays stable.
+    round_no = int(_require(info, "round", optional=True) or 1)
+    cumulative = int(_require(info, "cumulative_trials", optional=True) or current_trial)
+    return LMTuneProgressView(
+        current_trial=current_trial,
+        total_trials=total_trials,
+        round=round_no,
+        cumulative_trials=cumulative,
+        expanded_dims=tuple(_require(info, "expanded_dims", optional=True) or ()),
+        latest_score=_require(info, "latest_score", optional=True),
+        latest_state=_require(info, "latest_state", optional=True),
+        best_score=_require(info, "best_score", optional=True),
+    )
+
+
+def view_tuning_result(result: Any) -> LMTuningResultView:
+    """Wrap a ``TuningResult`` into the typed widget view."""
+    return LMTuningResultView(
+        best_params=dict(_require(result, "best_params")),
+        best_score=float(_require(result, "best_score")),
+        metric_name=str(_require(result, "metric_name")),
+        direction=str(_require(result, "direction")),
+        rounds=view_rounds(_require(result, "rounds", optional=True) or ()),
+        boundary_report=view_boundary_report(_require(result, "boundary_report", optional=True)),
+        raw_trials=_require(result, "trials"),
+    )
+
+
+def view_fit_result(result: Any) -> LMFitResultView:
+    """Wrap a ``FitResult`` for the fields the widget uses."""
+    metrics = _require(result, "metrics")
+    splits = _require(result, "splits", optional=True)
+    outer = _require(splits, "outer", optional=True) if splits is not None else None
+    fold_count = len(outer) if outer is not None else 0
+    return LMFitResultView(metrics=metrics, fold_count=fold_count)
+
+
+def view_prediction_result(result: Any) -> LMPredictionResultView:
+    """Wrap a ``PredictionResult`` into the typed widget view."""
+    return LMPredictionResultView(
+        pred=_require(result, "pred"),
+        proba=_require(result, "proba", optional=True),
+        shap_values=_require(result, "shap_values", optional=True),
+        warnings=list(_require(result, "warnings", optional=True) or []),
+    )

--- a/tests/test_adapter_core.py
+++ b/tests/test_adapter_core.py
@@ -469,11 +469,17 @@ class TestAvailablePlots:
         assert "optimization-history" in plots
 
     def test_available_plots_fallback_when_no_cfg(self) -> None:
+        """#116: when model lacks `_cfg`, the adapter falls back to its own
+        config registry (no longer to a `_widget_config` attribute on the model).
+        """
         adapter = LizyMLAdapter()
-        mock_model = MagicMock(spec=[])
-        mock_model._widget_config = {"task": "binary"}
+        mock_model = MagicMock(spec=["fit_result"])
         mock_model.fit_result = MagicMock()
         mock_model.fit_result.calibrator = None
+        # Seed the adapter-side config registry directly to simulate the
+        # path where `create_model` ran but `model._cfg` is absent (e.g. a
+        # mocked or a partially-loaded model).
+        adapter._model_configs[id(mock_model)] = {"task": "binary"}
 
         plots = adapter.available_plots(mock_model)
         assert "roc-curve" in plots
@@ -743,10 +749,10 @@ class TestShapOutput:
         assert shap_cols == []
 
 
-class TestCreateModelWidgetConfig:
-    """create_model should attach _widget_config to the model."""
+class TestCreateModelConfigRegistry:
+    """#116: create_model registers the config in the adapter (no private write to model)."""
 
-    def test_widget_config_attached(self) -> None:
+    def test_config_registered_in_adapter(self) -> None:
         adapter = LizyMLAdapter()
         config = adapter.initialize_config(task="binary")
         config.update(
@@ -759,10 +765,32 @@ class TestCreateModelWidgetConfig:
         )
         df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
         model = adapter.create_model(config, df)
-        assert hasattr(model, "_widget_config")
-        assert model._widget_config["task"] == "binary"
-        # Should be a deep copy, not the same object
-        assert model._widget_config is not config
+
+        # The config must be retrievable from the adapter via id(model).
+        registered = adapter._model_configs[id(model)]
+        assert registered["task"] == "binary"
+        # Deep copy invariant: mutating the registry copy must not touch
+        # the caller's config dict.
+        registered["task"] = "regression"
+        assert config["task"] == "binary"
+
+    def test_no_private_attribute_on_model(self) -> None:
+        """#116: the legacy ``model._widget_config`` private attribute is gone."""
+        adapter = LizyMLAdapter()
+        config = adapter.initialize_config(task="binary")
+        config.update(
+            {
+                "task": "binary",
+                "data": {"target": "y"},
+                "features": {"categorical": [], "exclude": []},
+                "split": {"method": "kfold", "n_splits": 3, "random_state": 42},
+            }
+        )
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        model = adapter.create_model(config, df)
+        assert not hasattr(model, "_widget_config"), (
+            "create_model should no longer attach _widget_config to the model"
+        )
 
 
 class TestCancelPollingErrorPropagation:

--- a/tests/test_adapter_views.py
+++ b/tests/test_adapter_views.py
@@ -1,0 +1,220 @@
+"""Tests for adapter_views — typed views over lizyml result objects (#116).
+
+The views are the only place in the widget that read internal attributes
+off lizyml result types. Their job is to either return a typed value or
+raise ``LizyMLContractError`` when a required field is missing — silent
+``None`` fallbacks are forbidden at the boundary.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lizyml_widget.adapter_views import (
+    LizyMLContractError,
+    view_boundary_report,
+    view_fit_result,
+    view_prediction_result,
+    view_rounds,
+    view_tune_progress,
+    view_tuning_result,
+)
+
+
+class TestViewRounds:
+    def test_empty_input_returns_empty_tuple(self) -> None:
+        assert view_rounds(()) == ()
+        assert view_rounds(None) == ()
+
+    def test_wraps_round_summary(self) -> None:
+        r = SimpleNamespace(
+            round=2,
+            n_trials=30,
+            best_score_before=0.85,
+            best_score_after=0.91,
+            expanded_dims=["lr", "num_leaves"],
+        )
+        rounds = view_rounds([r])
+        assert len(rounds) == 1
+        assert rounds[0].round == 2
+        assert rounds[0].n_trials == 30
+        assert rounds[0].best_score_before == 0.85
+        assert rounds[0].best_score_after == 0.91
+        assert rounds[0].expanded_dims == ("lr", "num_leaves")
+
+    def test_missing_required_field_raises_contract_error(self) -> None:
+        r = SimpleNamespace(round=1, n_trials=10, best_score_after=0.9)
+        # best_score_before is optional; expanded_dims is required.
+        with pytest.raises(LizyMLContractError, match="expanded_dims"):
+            view_rounds([r])
+
+    def test_missing_round_raises_contract_error(self) -> None:
+        r = SimpleNamespace(n_trials=10, best_score_after=0.9, expanded_dims=())
+        with pytest.raises(LizyMLContractError, match="round"):
+            view_rounds([r])
+
+
+class TestViewBoundaryReport:
+    def test_none_returns_none(self) -> None:
+        assert view_boundary_report(None) is None
+
+    def test_empty_dims_returns_empty_tuple(self) -> None:
+        report = SimpleNamespace(dims=(), expanded_names=())
+        result = view_boundary_report(report)
+        assert result is not None
+        assert result.dims == ()
+        assert result.expanded_names == ()
+
+    def test_wraps_dims(self) -> None:
+        d = SimpleNamespace(
+            name="lr",
+            best_value=0.05,
+            low=0.001,
+            high=0.1,
+            position_pct=0.85,
+            edge="upper",
+            expanded=True,
+            new_low=0.001,
+            new_high=0.5,
+        )
+        report = SimpleNamespace(dims=[d], expanded_names=["lr"])
+        result = view_boundary_report(report)
+        assert result is not None
+        assert len(result.dims) == 1
+        dim = result.dims[0]
+        assert dim.name == "lr"
+        assert dim.expanded is True
+        assert dim.edge == "upper"
+        assert result.expanded_names == ("lr",)
+
+    def test_missing_dim_name_raises(self) -> None:
+        d = SimpleNamespace(best_value=0.05, low=0.001, high=0.1)
+        report = SimpleNamespace(dims=[d], expanded_names=())
+        with pytest.raises(LizyMLContractError, match="name"):
+            view_boundary_report(report)
+
+
+class TestViewTuneProgress:
+    def test_required_fields_only(self) -> None:
+        info = SimpleNamespace(
+            current_trial=5,
+            total_trials=50,
+        )
+        view = view_tune_progress(info)
+        assert view.current_trial == 5
+        assert view.total_trials == 50
+        # Re-tune fields default to round=1 / cumulative=current_trial.
+        assert view.round == 1
+        assert view.cumulative_trials == 5
+        assert view.expanded_dims == ()
+        assert view.latest_score is None
+        assert view.best_score is None
+
+    def test_all_fields_present(self) -> None:
+        info = SimpleNamespace(
+            current_trial=12,
+            total_trials=100,
+            round=2,
+            cumulative_trials=70,
+            expanded_dims=("lr",),
+            latest_score=0.91,
+            latest_state="COMPLETE",
+            best_score=0.92,
+        )
+        view = view_tune_progress(info)
+        assert view.round == 2
+        assert view.cumulative_trials == 70
+        assert view.expanded_dims == ("lr",)
+        assert view.latest_score == 0.91
+        assert view.latest_state == "COMPLETE"
+        assert view.best_score == 0.92
+
+    def test_missing_required_field_raises(self) -> None:
+        info = SimpleNamespace(total_trials=50)
+        with pytest.raises(LizyMLContractError, match="current_trial"):
+            view_tune_progress(info)
+
+
+class TestViewTuningResult:
+    def test_full_result(self) -> None:
+        result = SimpleNamespace(
+            best_params={"lr": 0.05},
+            best_score=0.92,
+            metric_name="auc",
+            direction="maximize",
+            rounds=[],
+            boundary_report=None,
+            trials=[],
+        )
+        view = view_tuning_result(result)
+        assert view.best_params == {"lr": 0.05}
+        assert view.best_score == 0.92
+        assert view.metric_name == "auc"
+        assert view.direction == "maximize"
+        assert view.rounds == ()
+        assert view.boundary_report is None
+
+    def test_missing_best_score_raises(self) -> None:
+        result = SimpleNamespace(
+            best_params={},
+            metric_name="auc",
+            direction="maximize",
+            rounds=[],
+            boundary_report=None,
+            trials=[],
+        )
+        with pytest.raises(LizyMLContractError, match="best_score"):
+            view_tuning_result(result)
+
+
+class TestViewFitResult:
+    def test_with_splits(self) -> None:
+        result = SimpleNamespace(
+            metrics={"auc": {"oos": 0.9}},
+            splits=SimpleNamespace(outer=[1, 2, 3, 4, 5]),
+        )
+        view = view_fit_result(result)
+        assert view.metrics == {"auc": {"oos": 0.9}}
+        assert view.fold_count == 5
+
+    def test_missing_splits_falls_back_to_zero_folds(self) -> None:
+        result = SimpleNamespace(metrics={"auc": {}})
+        # splits is optional; absent → fold_count=0.
+        view = view_fit_result(result)
+        assert view.fold_count == 0
+
+    def test_missing_metrics_raises(self) -> None:
+        result = SimpleNamespace(splits=SimpleNamespace(outer=[]))
+        with pytest.raises(LizyMLContractError, match="metrics"):
+            view_fit_result(result)
+
+
+class TestViewPredictionResult:
+    def test_full_result(self) -> None:
+        result = SimpleNamespace(
+            pred=[1, 0, 1],
+            proba=[[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]],
+            shap_values=[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+            warnings=["w1"],
+        )
+        view = view_prediction_result(result)
+        assert list(view.pred) == [1, 0, 1]
+        assert view.proba is not None
+        assert view.shap_values is not None
+        assert view.warnings == ["w1"]
+
+    def test_minimal_result(self) -> None:
+        result = SimpleNamespace(pred=[0, 1])
+        # proba / shap_values / warnings all optional.
+        view = view_prediction_result(result)
+        assert list(view.pred) == [0, 1]
+        assert view.proba is None
+        assert view.shap_values is None
+        assert view.warnings == []
+
+    def test_missing_pred_raises(self) -> None:
+        result = SimpleNamespace(proba=[[0.5, 0.5]])
+        with pytest.raises(LizyMLContractError, match="pred"):
+            view_prediction_result(result)


### PR DESCRIPTION
## Summary
Closes #116. Introduces an `LMResultView` boundary at the Adapter so a future lizyml field rename fails fast at import time instead of silently degrading to `None` / `[]` deeper in the widget.

## What changed

### New: `src/lizyml_widget/adapter_views.py`
- 7 frozen dataclasses enumerating exactly the lizyml result fields the widget consumes.
- 6 `view_*` factories that raise `LizyMLContractError` when a required field is missing.
- 100% test coverage.

### `adapter.py` (consumer side)
- `fit()` / `tune()` / `predict()` and the tune `progress_callback` now operate on views. Zero `getattr(result, ...)` reads on lizyml result types remain.
- `_serialize_rounds` and `_serialize_boundary_report` take typed views instead of raw lizyml objects.
- `create_model` no longer writes `model._widget_config` (private monkey-patch). Configs live in an adapter-side registry keyed by `id(model)`.
- New `_task_for_model(model)` helper centralises the legacy `_cfg.task` lookup with a single fallback to the registry. Used by both `available_plots()` and `model_info()`.

### Tests
- `tests/test_adapter_views.py`: 19 cases (all the views, all the contract-error paths).
- `tests/test_adapter_core.py`: legacy `test_widget_config_attached` replaced by `test_config_registered_in_adapter` + `test_no_private_attribute_on_model`. `test_available_plots_fallback_when_no_cfg` updated to seed the adapter registry rather than the deprecated `model._widget_config`.

## Acceptance criteria

- [x] `src/lizyml_widget/adapter_views.py` exists with view dataclasses + `view_*` factories
- [x] `adapter.py` has zero `getattr(...)` reads on lizyml result types — only the `view_*` factories do
- [x] `model._widget_config` private write removed (replaced by `id(model)`-keyed registry)
- [x] Unit tests assert each `view_*` raises a clear contract error when a required field is absent
- [x] Existing 898 Python tests pass; coverage on `adapter.py` does not regress (97%, was 95%)
- [x] CHANGELOG entry under `[Unreleased]` referencing this issue

## Out of scope (per issue)
- `initialize_config` deepcopy (the current signature takes only `task`, not a config — there is no input config to deepcopy)
- Submitting a PR to lizyml to expose `Model.task` / typed result types

## Test plan
- [x] `uv run pytest --ignore=tests/e2e -q` → 898 passed
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] `uv run mypy src/lizyml_widget/` → clean (13 source files)
- [x] Coverage on `adapter.py` 97%, `adapter_views.py` 100%

Refs: post-P-030 code review thread; #116. Lays the foundation for #117 (JobRunner) and #118 (invariants) — INV-F (`boundary_report.dims` uniqueness) becomes type-checkable through `LMBoundaryReportView`.