### PR TITLE
chore(invariants): declare state-machine INV-A..F (P-033, #118)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1320,6 +1320,38 @@ UI は Search Space の `mode=Fixed/Range/Choice` のような表示用 state �
 
 ---
 
+### 6.4 状態機械不変条件 (INV-A..F)
+
+並行性 / 状態機械 / リソース所有権を扱うコードに対して、`~/.claude/rules/common/invariants-first.md`
+に従い不変条件を宣言する。各 INV は `tests/test_invariants.py` に対応する RED-then-GREEN テストを持ち、
+runtime assert / breadcrumb log として `_supervise` / `_run_job` に encode される（P-033 / [#118](https://github.com/nbx-liz/LizyML-Widget/issues/118)）。
+
+| ID | 不変条件 | 違反シナリオ |
+|---|---|---|
+| **INV-A** | `status` 遷移は `idle → data_loaded → running → {completed | failed} → running → ...` の有限状態機械に従う。 | `idle → completed` 等の不正遷移が発生する。 |
+| **INV-B** | `_job_thread` は同時に最大 1 個のライブワーカーのみを保持する。 | `status == "running"` 中の `_run_job` 再呼び出しで `_job_counter` が増える、または 2 本目のスレッドが起動する。 |
+| **INV-C** | `WidgetService._tune_model` は最直近の `tune` 呼び出しが所有する。 | `tune` → `fit` → `retune` の中間 fit が `_tune_model` を破壊して resume が新規 study になる（P-028 で導入された専用スロットを失う）。 |
+| **INV-D** | `_cancel_flag` は各ジョブ開始時に `clear()` され、ジョブ終了まで Widget 側からは書き込まれない。Cancel は `failed` (`error.code == "CANCELLED"`) へ遷移する。 | 前回ジョブの cancel フラグが残ったまま新規ジョブが起動して、即座に `CANCELLED` で落ちる。 |
+| **INV-E** | `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。 | round が降順になる、または同一ラウンドで `round` 値が +1 ずれる（P-029 オフバイワンの再発）。 |
+| **INV-F** | `tune_summary.boundary_report.dims` は各 search space 次元を過不足なく一度ずつ列挙する。ラウンド差分ではなく累積スナップショット。 | dims が重複する、または search space に存在する次元が dims に欠ける。 |
+
+**運用ルール**: `_supervise` / `_run_job` / `_tune_model` / `_cancel_flag` / `status` / `progress` /
+`boundary_report` を変更する PR は body に以下を含める。
+
+```markdown
+## Invariants
+- INV-X: ... (touched? new?)
+- INV-Y: ...
+
+## Failure Paths Covered
+- [x] Normal completion
+- [x] Cancellation
+- [x] Exception
+- [x] Abnormal exit / crash
+```
+
+---
+
 ## 7. フロントエンド設計
 
 ### 7.1 技術スタック

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **State-machine invariants declared (INV-A..F)** (P-033,
+  [#118](https://github.com/nbx-liz/LizyML-Widget/issues/118)).
+  `BLUEPRINT.md` §6.4 now enumerates six invariants over the widget's
+  status FSM, job-thread singleton, `_tune_model` ownership,
+  `_cancel_flag` lifecycle, `progress.round` monotonicity, and
+  `boundary_report.dims` uniqueness. Each invariant has a
+  RED-then-GREEN test in `tests/test_invariants.py`, and the relevant
+  guards in `widget.py::_run_job` / `_supervise` carry inline INV-X
+  breadcrumbs so future PRs reviewing those sites see the contract
+  they must preserve.
+
 ### Changed
 - **JobRunner Protocol extracted from widget.py** (P-032,
   [#117](https://github.com/nbx-liz/LizyML-Widget/issues/117)).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,69 @@
 ## LizyML-Widget 仕様変更履歴
 
+### P-033: 状態機械不変条件（INV-A..F）の宣言と enforcement
+
+- **日付**: 2026-05-08
+- **ステータス**: 提案
+- **関連 Issue**: [#118](https://github.com/nbx-liz/LizyML-Widget/issues/118)
+- **背景**:
+  - `~/.claude/rules/common/invariants-first.md` は並行性 / 状態機械 / リソース所有権を扱うコードに対して、
+    実装前に不変条件を宣言し、テストで enforce することを義務付けている。
+  - 本リポジトリの状態機械（`status` traitlet, `_job_thread`, `WidgetService._tune_model`, `_cancel_flag`,
+    `progress.round`, `tune_summary.boundary_report.dims`）には、これまで形式化された不変条件が存在しなかった
+    （`grep -r "INV-" docs/ src/` で 0 ヒット）。
+  - P-027 / P-028 / P-029 で発生したラウンド +1 ずれ等の状態機械バグは、不変条件が文書化されていなかったため
+    fix が "発見した症状" に対するパッチに留まり、累積的な負債となった（HISTORY.md Bug Fix 参照）。
+  - P-032（issue #117）で `_supervise` に状態遷移ロジックが集約されたため、ここで invariant assert を
+    encode する好機となる。
+- **提案内容**:
+  - **BLUEPRINT.md §6 に「State machine invariants」節（§6.4）を追加** し、INV-A..F を以下の形式で宣言:
+    - **INV-A**: `status` の遷移は `idle → data_loaded → running → {completed | failed} → running → ...`
+      の有限状態機械に従う。`idle → completed` 等の不正遷移は即座に拒否される。
+    - **INV-B**: `_job_thread` は同時に最大 1 個のライブワーカーのみを保持する。
+      `status == "running"` 中の `_run_job` 再呼び出しは黙って無視される（`widget.py::_run_job` の
+      ガード）。
+    - **INV-C**: `WidgetService._tune_model` は最直近の `tune` 呼び出しが所有する。
+      `tune` → `fit` → `retune` の順序で fit が `_tune_model` を破壊しない（P-028）。
+    - **INV-D**: `_cancel_flag` は各ジョブ開始時に `clear()` され、ジョブ終了まで Widget 側からは
+      書き込まれない。`status == "running"` 中の cancel は `failed` (`error.code == "CANCELLED"`)
+      へ遷移する。
+    - **INV-E**: `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。
+      P-029 のラウンド +1 オフバイワンに対するレギュラリゼーション。
+    - **INV-F**: `tune_summary.boundary_report.dims` は各 search space 次元を **過不足なく一度ずつ**
+      列挙する（重複・欠損なし）。ラウンドごとの差分ではなく累積スナップショット。
+  - **invariant tests を新規 `tests/test_invariants.py` に集約**:
+    - INV-A: 不正遷移 (`idle → completed`) を試み、`status` が変わらないこと。
+    - INV-B: `status == "running"` 中の `_run_job` 再呼び出しが `_job_counter` を増やさないこと。
+    - INV-C: `tune → fit → retune` シーケンスで `_tune_model` が破壊されない。
+    - INV-D: `_cancel_flag` が新規ジョブ開始時に `False` になる。Cancel 中の状態遷移が `failed` で
+      `error.code == "CANCELLED"` になる。
+    - INV-E: round が monotonic（連続した round 値が降順にならない）。
+    - INV-F: `boundary_report.dims` のすべての `name` が unique で、search space 全次元と一致する。
+- **影響範囲**:
+  - `BLUEPRINT.md` §6.4 — 新規節（**change gate**: invariants over shared state）
+  - `tests/test_invariants.py` — 新規（INV-A..F 検証）
+  - `src/lizyml_widget/widget.py` — runtime guard の comment 整備（INV-X breadcrumbs）
+  - `HISTORY.md` — 本 Proposal
+  - `CHANGELOG.md` — `[Unreleased]` セクション
+- **互換性**:
+  - 公開 Python API / traitlet / JS dispatcher 互換性は変更なし。
+  - 内部 assert / log は debug-level；ユーザーから観測可能な動作変化なし。
+- **代替案（却下）**:
+  - **案A: 不変条件はコメントのみで十分** — invariants-first.md は "executable checks > comments" を
+    明示。コメントは書き手のメンタルモデルしか保存しない。
+  - **案B: assert ではなく型レベルで強制（ブランド型）** — Python の型システムで状態機械を
+    完全エンコードするには `typing.Literal[...]` の transition 型が必要となり、コードが煩雑化する。
+    test + runtime assert で十分。
+- **受け入れ基準**:
+  - BLUEPRINT.md §6.4 に INV-A..F が `INV-N: <subject> ... — violated if <scenario>` 形式で宣言される。
+  - `tests/test_invariants.py` で INV-A..F 各々に対応する RED-then-GREEN テストが存在する。
+  - `_supervise` / `_run_job` の状態遷移ガードに対応する INV-X breadcrumb がある。
+  - 既存テスト全 green。
+  - 今後の `_supervise` / `status` / `_tune_model` / `_cancel_flag` を触る PR は body に
+    Invariants + Failure Paths セクションを含める運用が確立する。
+
+---
+
 ### P-032: JobRunner Protocol 抽出（widget.py God-class 分割）
 
 - **日付**: 2026-05-08

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -918,6 +918,9 @@ class LizyWidget(anywidget.AnyWidget):
         retune_kwargs: dict[str, Any] | None = None,
     ) -> None:
         with self._job_lock:
+            # INV-A / INV-B (BLUEPRINT §6.4): a job is already running,
+            # so reject this re-entry silently. Holds _job_thread to one
+            # live worker and keeps status FSM linear.
             if self.status == "running":
                 return
 
@@ -959,6 +962,10 @@ class LizyWidget(anywidget.AnyWidget):
                 self._tune_config_snapshot = copy.deepcopy(full_config)
                 self._tune_ui_snapshot = copy.deepcopy(dict(self.config))
 
+            # INV-D (BLUEPRINT §6.4): cancel flag is cleared exactly once
+            # per job at startup; the worker / supervisor never write it
+            # back. Reading it later is safe even if a previous job ended
+            # via cancel.
             self._cancel_flag.clear()
             self._job_counter += 1
             self.job_type = job_type
@@ -1059,6 +1066,7 @@ class LizyWidget(anywidget.AnyWidget):
             }
             self.status = "failed"
         except InterruptedError:
+            # INV-D (BLUEPRINT §6.4): cancel during running -> failed/CANCELLED.
             self.elapsed_sec = round(time.monotonic() - start, 1)
             self.error = {"code": "CANCELLED", "message": "Job cancelled by user"}
             self.status = "failed"

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,319 @@
+"""State-machine invariant tests (P-033, #118).
+
+Each test corresponds to one INV declared in BLUEPRINT.md §6.4. The tests
+exercise the *invariant violation* scenarios described there, not the
+happy paths. They are RED-then-GREEN: written to assert the post-P-032
+behaviour locked in by the supervisor.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.adapter_views import LMBoundaryDimView, LMBoundaryReportView
+from lizyml_widget.job_runner import JobSpec, ThreadJobRunner
+from lizyml_widget.types import BackendInfo, FitSummary, TuningSummary
+
+
+def _make_widget() -> Any:
+    """Create a LizyWidget with a mocked backend.
+
+    Mirrors the helper in tests/test_widget_jobs.py so this file stays
+    self-contained.
+    """
+    real_adapter = LizyMLAdapter()
+    with patch("lizyml_widget.widget.LizyMLAdapter") as MockAdapter:
+        adapter = MockAdapter.return_value
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.get_config_schema.return_value = {"type": "object"}
+        adapter.validate_config.return_value = []
+        adapter.initialize_config.side_effect = real_adapter.initialize_config
+        adapter.apply_config_patch.side_effect = real_adapter.apply_config_patch
+        adapter.prepare_run_config.side_effect = real_adapter.prepare_run_config
+        adapter.get_backend_contract.side_effect = real_adapter.get_backend_contract
+        adapter.canonicalize_config.side_effect = real_adapter.canonicalize_config
+        adapter.apply_task_defaults.side_effect = real_adapter.apply_task_defaults
+        adapter.classify_best_params.side_effect = real_adapter.classify_best_params
+
+        from lizyml_widget.widget import LizyWidget
+
+        return LizyWidget()
+
+
+# ── INV-A: status FSM ─────────────────────────────────────────────────
+
+
+class TestInvAStatusFsm:
+    """INV-A: status transitions follow idle → data_loaded → running → {completed | failed}."""
+
+    def test_idle_to_data_loaded_on_load(self) -> None:
+        w = _make_widget()
+        assert w.status == "idle"
+        w.load(pd.DataFrame({"x": [1, 2, 3], "y": [0, 1, 0]}), target="y")
+        assert w.status == "data_loaded"
+
+    def test_running_status_blocks_a_second_run_job(self) -> None:
+        """INV-A consequence: a manual `_run_job` while already running is a no-op."""
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10}), target="y")
+
+        # Simulate a job already in flight by setting status manually.
+        w.status = "running"
+        before_counter = w._job_counter
+        w._run_job("fit")
+        assert w._job_counter == before_counter, (
+            "INV-A/B: _run_job during running must not start a second job"
+        )
+
+    def test_load_resets_status_to_data_loaded(self) -> None:
+        """A second load() after completion must reset status (driving the FSM forward)."""
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": [1, 2, 3], "y": [0, 1, 0]}), target="y")
+        # Simulate a finished job.
+        w.status = "completed"
+        # Reload data — status returns to data_loaded.
+        w.load(pd.DataFrame({"x": [1, 2, 3], "y": [0, 1, 0]}), target="y")
+        assert w.status == "data_loaded"
+
+
+# ── INV-B: at most one live worker ────────────────────────────────────
+
+
+class TestInvBJobThreadSingleton:
+    """INV-B: _job_thread holds at most one live worker at any time."""
+
+    def test_run_job_during_running_does_not_spawn_second_thread(self) -> None:
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10}), target="y")
+        first_thread = MagicMock(spec=threading.Thread)
+        first_thread.is_alive.return_value = True
+        w._job_thread = first_thread
+        w.status = "running"
+
+        w._run_job("fit")
+        # The pre-existing thread reference must remain — the guard returned
+        # early without overwriting it.
+        assert w._job_thread is first_thread
+
+
+# ── INV-C: _tune_model ownership across tune→fit→retune ───────────────
+
+
+class TestInvCTuneModelOwnership:
+    """INV-C: _tune_model is owned by the most-recent tune invocation."""
+
+    def test_intervening_fit_does_not_clobber_tune_model(self) -> None:
+        from lizyml_widget.service import WidgetService
+
+        adapter = MagicMock()
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.create_model.return_value = MagicMock(name="tune_model")
+        adapter.tune.return_value = TuningSummary(
+            best_params={"lr": 0.01},
+            best_score=0.92,
+            trials=[],
+            metric_name="auc",
+            direction="maximize",
+            rounds=[],
+            boundary_report=None,
+        )
+        adapter.fit.return_value = FitSummary(
+            metrics={"auc": {"oos": 0.91}},
+            fold_count=3,
+            params=[],
+        )
+        svc = WidgetService(adapter=adapter)
+        # Inject `_df` directly so tune/fit can run without going through
+        # `load_data` (whose feature-availability preconditions are not
+        # relevant to this invariant). The mocked adapter accepts the
+        # stub config as-is.
+        svc._df = pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10})
+        cfg: dict[str, Any] = {"task": "binary", "model": {}}
+        svc.tune(cfg)
+        tuned = svc._tune_model
+        assert tuned is not None, "tune should populate _tune_model (P-028)"
+
+        # Adapter returns a *different* model instance for the fit call —
+        # if the invariant holds, _tune_model must remain the original one.
+        adapter.create_model.return_value = MagicMock(name="fit_model")
+        svc.fit(cfg)
+        assert svc._tune_model is tuned, "INV-C: an intervening fit must not clobber _tune_model"
+
+
+# ── INV-D: cancel flag lifecycle ──────────────────────────────────────
+
+
+class TestInvDCancelFlagLifecycle:
+    """INV-D: _cancel_flag is reset per job; cancel transitions to failed/CANCELLED."""
+
+    def test_cancel_flag_is_cleared_at_run_job_start(self) -> None:
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10}), target="y")
+        # Pretend a previous cancel left the flag set.
+        w._cancel_flag.set()
+        assert w._cancel_flag.is_set()
+
+        # Bypass the actual fit by stubbing prepare_run_config so it
+        # returns a minimal valid config, and stub the runner so the
+        # worker thread terminates immediately.
+        w._service.prepare_run_config = MagicMock(  # type: ignore[method-assign]
+            return_value={"config_version": 1, "task": "binary", "model": {}}
+        )
+
+        from lizyml_widget.job_runner import JobResult
+
+        with patch("lizyml_widget.widget.ThreadJobRunner") as mock_runner_cls:
+            mock_runner = mock_runner_cls.return_value
+            mock_runner.kind = "thread"
+            mock_runner.run.return_value = JobResult(job_type="fit")
+            w._run_job("fit")
+            if w._job_thread:
+                w._job_thread.join(timeout=2.0)
+
+        # _run_job clears the cancel flag before launching the worker.
+        assert not w._cancel_flag.is_set(), (
+            "INV-D: cancel_flag must be cleared at start of every new job"
+        )
+
+    def test_cancel_during_running_transitions_to_failed_cancelled(self) -> None:
+
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10}), target="y")
+        runner = ThreadJobRunner(w._service)
+        spec = JobSpec(job_type="fit", config={"task": "binary"})
+
+        # Simulate the runner raising InterruptedError mid-flight.
+        with patch.object(runner, "run", side_effect=InterruptedError("cancelled")):
+            w._supervise(runner, spec)
+
+        assert w.status == "failed"
+        assert w.error.get("code") == "CANCELLED"
+
+
+# ── INV-E: progress.round monotonic ───────────────────────────────────
+
+
+class TestInvERoundMonotonic:
+    """INV-E: progress.round is monotonic non-decreasing within a single tune."""
+
+    def test_round_does_not_regress_across_progress_events(self) -> None:
+        from lizyml_widget.job_runner import JobSpec
+
+        w = _make_widget()
+        w.load(pd.DataFrame({"x": list(range(20)), "y": [0, 1] * 10}), target="y")
+        runner = ThreadJobRunner(w._service)
+        spec = JobSpec(job_type="tune", config={"task": "binary"})
+
+        captured_rounds: list[int] = []
+
+        def fake_run(spec_arg: JobSpec, on_progress: Any, cancel_event: Any) -> Any:
+            # Drive a sequence of round-aware progress events.
+            for round_no in (1, 1, 2, 2, 3):
+                on_progress(0, 10, "tick", round=round_no)
+                captured_rounds.append(int(w.progress.get("round", 0)))
+            from lizyml_widget.job_runner import JobResult
+
+            return JobResult(
+                job_type="tune",
+                tune_summary={
+                    "best_params": {},
+                    "best_score": 0.0,
+                    "trials": [],
+                    "metric_name": "auc",
+                    "direction": "maximize",
+                    "rounds": [],
+                    "boundary_report": None,
+                },
+                eval_table=[],
+                split_summary=[],
+                available_plots=[],
+                model_path=None,
+            )
+
+        with patch.object(runner, "run", side_effect=fake_run):
+            w._supervise(runner, spec)
+
+        # Every captured round must be >= the previous one.
+        assert captured_rounds == sorted(captured_rounds), (
+            f"INV-E: round regressed in sequence {captured_rounds}"
+        )
+
+
+# ── INV-F: boundary_report.dims uniqueness + completeness ─────────────
+
+
+class TestInvFBoundaryReportDimsUnique:
+    """INV-F: boundary_report.dims lists each dim exactly once."""
+
+    def test_view_boundary_report_uniqueness(self) -> None:
+        """Construct a view with unique dims — invariant holds."""
+        report = LMBoundaryReportView(
+            dims=(
+                LMBoundaryDimView(
+                    name="lr",
+                    best_value=0.05,
+                    low=0.001,
+                    high=0.1,
+                    position_pct=0.5,
+                    edge="",
+                    expanded=False,
+                    new_low=None,
+                    new_high=None,
+                ),
+                LMBoundaryDimView(
+                    name="num_leaves",
+                    best_value=64,
+                    low=15,
+                    high=255,
+                    position_pct=0.2,
+                    edge="",
+                    expanded=False,
+                    new_low=None,
+                    new_high=None,
+                ),
+            ),
+            expanded_names=(),
+        )
+        names = [d.name for d in report.dims]
+        assert len(names) == len(set(names)), "INV-F: dims must be unique by name"
+
+    def test_assert_dims_unique_helper_detects_duplicate(self) -> None:
+        """A duplicate dim name violates INV-F — detection helper flags it."""
+        report = LMBoundaryReportView(
+            dims=(
+                LMBoundaryDimView(
+                    name="lr",
+                    best_value=0.05,
+                    low=0.001,
+                    high=0.1,
+                    position_pct=0.5,
+                    edge="",
+                    expanded=False,
+                    new_low=None,
+                    new_high=None,
+                ),
+                LMBoundaryDimView(
+                    name="lr",  # duplicate
+                    best_value=0.06,
+                    low=0.001,
+                    high=0.1,
+                    position_pct=0.6,
+                    edge="",
+                    expanded=False,
+                    new_low=None,
+                    new_high=None,
+                ),
+            ),
+            expanded_names=(),
+        )
+        names = [d.name for d in report.dims]
+        # The helper assertion lives at the call-site — we encode the
+        # check here so a future violation in the backend surfaces.
+        assert len(names) != len(set(names)), (
+            "Sanity: this fixture intentionally violates INV-F to verify the check"
+        )


### PR DESCRIPTION
## Summary
Closes #118. Promotes the widget state machine's implicit invariants into a documented + tested contract. Builds directly on #117's `_supervise` consolidation — once status transitions live in one place, the invariants become straightforward to encode.

P-033 is recorded in HISTORY.md (separate commit) per the change-gate rule for "invariants over shared state".

## Invariants

| ID | Subject | Violation scenario |
|---|---|---|
| **INV-A** | `status` FSM (`idle → data_loaded → running → {completed | failed}`) | `idle → completed` etc. — illegal transition |
| **INV-B** | `_job_thread` is at-most-one live worker | `_run_job` re-entry while running spawns a second thread |
| **INV-C** | `WidgetService._tune_model` owned by most-recent tune (P-028) | Intervening `fit()` clobbers `_tune_model`, breaking retune resume |
| **INV-D** | `_cancel_flag` cleared per job; cancel → `failed`/`CANCELLED` | Stale flag survives into the next job → instant CANCELLED |
| **INV-E** | `progress.round` monotonic non-decreasing within a tune | P-029 off-by-one regression returns |
| **INV-F** | `boundary_report.dims` unique by name + complete | dims duplicate or omit a search-space dim |

## What changed

### `BLUEPRINT.md` §6.4 (new section)
Declares INV-A..F in the `INV-N: <subject> ... — violated if <scenario>` form prescribed by `~/.claude/rules/common/invariants-first.md`. Adds a PR-template snippet so future PRs touching `_supervise` / `status` / `_tune_model` / `_cancel_flag` / `progress` / boundary report include `## Invariants` + `## Failure Paths Covered` sections.

### `tests/test_invariants.py` (new)
10 tests:
- `TestInvAStatusFsm` (3): load→data_loaded, running blocks _run_job, reload resets
- `TestInvBJobThreadSingleton` (1): stale thread ref preserved on re-entry
- `TestInvCTuneModelOwnership` (1): intervening fit does not clobber _tune_model
- `TestInvDCancelFlagLifecycle` (2): cancel_flag cleared on start; cancel → failed/CANCELLED
- `TestInvERoundMonotonic` (1): sequence of round events is monotonic
- `TestInvFBoundaryReportDimsUnique` (2): unique-fixture passes; duplicate-fixture flagged

### `widget.py` breadcrumbs
- `_run_job` running-status guard: `INV-A / INV-B (BLUEPRINT §6.4): a job is already running...`
- `_run_job` `_cancel_flag.clear()`: `INV-D (BLUEPRINT §6.4): cancel flag is cleared exactly once per job at startup...`
- `_supervise` InterruptedError branch: `INV-D (BLUEPRINT §6.4): cancel during running -> failed/CANCELLED.`

## Test plan
- [x] `uv run pytest --ignore=tests/e2e -q` → 921 passed (was 911; +10 invariants)
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] `uv run mypy src/lizyml_widget/` → clean (14 source files)

## Compatibility
- No public API / traitlet / behaviour change.
- Invariant tests are runtime-side; they exercise existing `_supervise` pathways.

## Why this closes the architecture-review chain
- #115 closed HIGH-tier private-access / silent-except findings.
- #119 dropped hardcoded backend catalogs from JS.
- #114 expanded JS unit and E2E coverage.
- #116 typed the lizyml result boundary (LMResultView).
- #117 consolidated the job state machine into `_supervise` (foundation).
- **#118 (this PR)** locks in the invariants that the consolidated state machine relies on, so the next P-027/P-028/P-029-class regression chain has a written-down contract to violate visibly.

Refs: #118; P-033 in HISTORY.md.