### PR TITLE
fix(ui): cancel ConfigTab debounce on traitlet config sync (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **ConfigTab debounce / traitlet sync race**
+  ([#136](https://github.com/nbx-liz/LizyML-Widget/issues/136)).
+  When Python pushed a new ``config`` (e.g. after ``apply_best_params``)
+  while a user edit was still mid-debounce, the pending timer fired
+  later and computed a patch against a stale baseline, silently
+  overwriting Python's update. The ``[config]`` ``useEffect`` now
+  cancels the pending debounce timer before resyncing local state.
+
 ### Added
 - **State-machine invariants declared (INV-A..F)** (P-033,
   [#118](https://github.com/nbx-liz/LizyML-Widget/issues/118)).

--- a/js/src/__tests__/ConfigTab-debounce-race.test.tsx
+++ b/js/src/__tests__/ConfigTab-debounce-race.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for ConfigTab debounce/traitlet race (#136).
+ *
+ * If a user is editing the config (debounce timer pending) when Python
+ * pushes a new ``config`` prop (e.g. after ``apply_best_params`` completes),
+ * the pending timer must be cancelled.  Otherwise it fires later and
+ * computes a patch against a stale baseline, silently emitting an
+ * incorrect ``patch_config``.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/preact";
+import type { ComponentChildren } from "preact";
+import { ConfigTab } from "../tabs/ConfigTab";
+import { createMockModel } from "./mock-model";
+
+// Capture handleChange from FitSubTab so the test can drive an edit.
+let capturedHandleChange: ((newConfig: Record<string, any>) => void) | null = null;
+
+vi.mock("../tabs/FitSubTab", () => ({
+  FitSubTab: (props: { handleChange: (cfg: Record<string, any>) => void; children?: ComponentChildren }) => {
+    capturedHandleChange = props.handleChange;
+    return null;
+  },
+}));
+
+vi.mock("../tabs/TuneSubTab", () => ({
+  TuneSubTab: () => null,
+}));
+
+const minimalContract = {
+  config_schema: { type: "object", properties: {} },
+  ui_schema: {
+    sections: [],
+    option_sets: {},
+    parameter_hints: [],
+    step_map: {},
+    conditional_visibility: {},
+  },
+  capabilities: {},
+};
+
+const baseConfig = { model: { name: "lgbm", params: { learning_rate: 0.1 } } };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  capturedHandleChange = null;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ConfigTab — debounce/traitlet race (#136)", () => {
+  it("cancels a pending debounce when an external config update arrives", () => {
+    const sendAction = vi.fn();
+    const { rerender } = render(
+      <ConfigTab
+        backendContract={minimalContract}
+        config={baseConfig}
+        dfInfo={{ target: "y", task: "binary", shape: [100, 5] }}
+        status="data_loaded"
+        sendAction={sendAction}
+        model={createMockModel()}
+      />,
+    );
+
+    expect(capturedHandleChange).not.toBeNull();
+    sendAction.mockClear();
+
+    // 1. User edits a field at t=0 — debounce starts
+    capturedHandleChange!({
+      ...baseConfig,
+      model: { ...baseConfig.model, params: { learning_rate: 0.5 } },
+    });
+
+    // 2. Before debounce fires, Python pushes a new config (e.g. after
+    //    apply_best_params completes).
+    vi.advanceTimersByTime(100); // halfway through the 300ms debounce
+    const externalConfig = {
+      model: { name: "lgbm", params: { learning_rate: 0.05, num_leaves: 64 } },
+    };
+    rerender(
+      <ConfigTab
+        backendContract={minimalContract}
+        config={externalConfig}
+        dfInfo={{ target: "y", task: "binary", shape: [100, 5] }}
+        status="data_loaded"
+        sendAction={sendAction}
+        model={createMockModel()}
+      />,
+    );
+
+    // 3. Drain all pending timers — the cancelled one MUST NOT fire.
+    vi.runAllTimers();
+
+    // Without the fix, the pending debounce fires after the rerender and
+    // computes a patch from ``lastSentRef.current`` (now the *external*
+    // config) to ``newConfig`` captured in the closure (the user's edit),
+    // spuriously overwriting Python's push. With the fix we cancel the
+    // timer in the ``[config]`` useEffect so no patch_config call escapes.
+    expect(sendAction).not.toHaveBeenCalled();
+  });
+
+  it("clears the timer on unmount (regression — pre-existing cleanup still works)", () => {
+    const sendAction = vi.fn();
+    const { unmount } = render(
+      <ConfigTab
+        backendContract={minimalContract}
+        config={baseConfig}
+        dfInfo={{ target: "y", task: "binary", shape: [100, 5] }}
+        status="data_loaded"
+        sendAction={sendAction}
+        model={createMockModel()}
+      />,
+    );
+
+    capturedHandleChange!({
+      ...baseConfig,
+      model: { ...baseConfig.model, params: { learning_rate: 0.7 } },
+    });
+    sendAction.mockClear();
+    unmount();
+    vi.runAllTimers();
+
+    expect(sendAction).not.toHaveBeenCalled();
+  });
+});

--- a/js/src/tabs/ConfigTab.tsx
+++ b/js/src/tabs/ConfigTab.tsx
@@ -37,8 +37,15 @@ export function ConfigTab({
   const configSchema = backendContract?.config_schema ?? {};
   const optionSets: Record<string, Record<string, string[]>> = uiSchema.option_sets ?? {};
 
-  // Sync from Python → local when Python config changes externally
+  // Sync from Python → local when Python config changes externally.
+  // #136: also cancel any pending debounce timer; otherwise it fires
+  // later and computes a patch against a stale baseline, silently
+  // overwriting Python's push.
   useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setLocalConfig(config);
     lastSentRef.current = config;
   }, [config]);


### PR DESCRIPTION
## Summary

Closes #136. Fixes a silent state-loss race in `ConfigTab`: when Python pushes a new `config` prop while the user is mid-edit, the pending debounce timer fires later with a stale closure, computing a patch against the *new* baseline that spuriously overwrites Python's update.

## Root cause

```typescript
// js/src/tabs/ConfigTab.tsx (before)
useEffect(() => {
  setLocalConfig(config);
  lastSentRef.current = config;  // baseline updated...
}, [config]);
// ...but timerRef is still alive and will fire with the old captured newConfig.
```

## Fix

Cancel the pending timer in the same `useEffect` before resyncing state:

```typescript
useEffect(() => {
  if (timerRef.current) {
    clearTimeout(timerRef.current);
    timerRef.current = null;
  }
  setLocalConfig(config);
  lastSentRef.current = config;
}, [config]);
```

## Test

New `js/src/__tests__/ConfigTab-debounce-race.test.tsx`:
1. **Race reproduction**: render ConfigTab → user edits via `handleChange` → before debounce fires, rerender with external config → drain all timers → assert `sendAction` not called.
2. **Unmount cleanup regression**: confirm pre-existing unmount cleanup still works.

Both use `vi.useFakeTimers()` for deterministic debounce control.

Verified RED then GREEN:
- Without fix: 1 failing test (race), `sendAction` was called with stale `learning_rate: 0.5` overwriting external `0.05` + `num_leaves: 64`.
- With fix: both tests pass.

## Test plan

- [x] `pnpm test` — 274 passed (was 272, +2 new)
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc --noEmit` — pre-existing errors only (verified with stash)
- [x] CHANGELOG `[Unreleased] / Fixed` updated

## Refs

- #136 (this PR)
- Code review 2026-05-08 (MEDIUM M2)
- Related instinct: `polled-state-stale-after-status-transition`