### PR TITLE
refactor(widget): drop _FALLBACK_STRATEGIES — fail fast on missing contract (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Drop hardcoded CV-strategy fallback in widget**
+  ([#130](https://github.com/nbx-liz/LizyML-Widget/issues/130)).
+  `LizyWidget._handle_update_cv` no longer keeps a `_FALLBACK_STRATEGIES`
+  frozenset for the case where ``backend_contract`` is unloaded.
+  The contract is now the single source of truth: a missing
+  ``capabilities.cv_strategies`` returns a structured
+  ``BACKEND_NOT_READY`` error instead of silently validating against an
+  outdated allowlist. CLAUDE.md §8 (no backend-specific option sets in
+  Widget / JS) is respected uniformly.
+
 ### Added
 - **State-machine invariants declared (INV-A..F)** (P-033,
   [#118](https://github.com/nbx-liz/LizyML-Widget/issues/118)).

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -519,24 +519,23 @@ class LizyWidget(anywidget.AnyWidget):
         except Exception as e:
             self.error = {"code": "COLUMN_ERROR", "message": str(e)}
 
-    # Fallback strategies when backend_contract is not yet loaded
-    _FALLBACK_STRATEGIES: frozenset[str] = frozenset(
-        {
-            "kfold",
-            "stratified_kfold",
-            "time_series",
-            "group_time_series",
-            "purged_time_series",
-            "group_kfold",
-            "stratified_group_kfold",
-            "blocked_group_kfold",
-        }
-    )
-
     def _handle_update_cv(self, payload: dict[str, Any]) -> None:
         strategy = payload.get("strategy", "kfold")
+        # #130: the widget no longer keeps a hardcoded fallback list of CV
+        # strategies. The backend contract is the single source of truth;
+        # if it is missing or incomplete the action fails fast so a
+        # backend that adds a new CV strategy is never silently rejected
+        # against an outdated allowlist.
         valid = self.backend_contract.get("capabilities", {}).get("cv_strategies")
-        valid_set = frozenset(valid) if valid else self._FALLBACK_STRATEGIES
+        if not valid:
+            self.error = {
+                "code": "BACKEND_NOT_READY",
+                "message": (
+                    "Backend contract is not loaded yet. Call load(df) before configuring CV."
+                ),
+            }
+            return
+        valid_set = frozenset(valid)
         if strategy not in valid_set:
             self.error = {"code": "CV_ERROR", "message": f"Invalid strategy: {strategy!r}"}
             return

--- a/tests/test_widget_core.py
+++ b/tests/test_widget_core.py
@@ -351,6 +351,21 @@ class TestUpdateCvValidation:
         assert w.error["code"] == "CV_ERROR"
         assert "n_splits" in w.error["message"]
 
+    def test_update_cv_before_load_returns_backend_not_ready(self) -> None:
+        """#130: update_cv before load() (no backend contract) fails fast.
+
+        Previously the widget kept a frozenset fallback of CV strategy
+        names so an action arriving pre-load would silently accept stale
+        options. The fallback was a backend-coupling smell; we now fail
+        fast with a structured ``BACKEND_NOT_READY`` error and require
+        callers to load() first.
+        """
+        w = _make_widget()
+        # No load() — backend_contract is empty. Trigger the action.
+        w.action = {"type": "update_cv", "payload": {"strategy": "kfold", "n_splits": 5}}
+        assert w.error["code"] == "BACKEND_NOT_READY"
+        assert "load(df)" in w.error["message"]
+
 
 class TestUpdateCvError:
     """Cover _handle_update_cv error path (widget.py lines 301-302)."""


### PR DESCRIPTION
## Summary

Closes #130. Removes the `_FALLBACK_STRATEGIES` frozenset from `LizyWidget._handle_update_cv`. The widget now treats `backend_contract.capabilities.cv_strategies` as the single source of truth and returns a structured `BACKEND_NOT_READY` error when the contract is unloaded, instead of silently validating against a stale, hand-maintained allowlist.

## Why

CLAUDE.md §8 prohibits backend-specific option sets in Widget / JS. The fallback was a defensive workaround for the "contract not yet loaded" timing case, but in practice it created a silent failure mode: a backend that adds a new CV strategy (e.g. `rolling_origin`) would surface in `capabilities.cv_strategies` yet still be rejected by the widget-side `_FALLBACK_STRATEGIES` if the action fired before the contract loaded.

In production `LizyWidget.load(df)` populates `backend_contract` synchronously, so any well-behaved client reaches `_handle_update_cv` after the contract is set. The new `BACKEND_NOT_READY` path only fires for the previously-invalid sequence of calling `update_cv` before `load`.

## Changes

```python
# Before
_FALLBACK_STRATEGIES: frozenset[str] = frozenset({"kfold", ..., "blocked_group_kfold"})
def _handle_update_cv(self, payload):
    valid = self.backend_contract.get("capabilities", {}).get("cv_strategies")
    valid_set = frozenset(valid) if valid else self._FALLBACK_STRATEGIES
    ...

# After
def _handle_update_cv(self, payload):
    valid = self.backend_contract.get("capabilities", {}).get("cv_strategies")
    if not valid:
        self.error = {"code": "BACKEND_NOT_READY", "message": "Backend contract is not loaded yet. Call load(df) before configuring CV."}
        return
    valid_set = frozenset(valid)
    ...
```

## Test plan

- [x] New test `tests/test_widget_core.py::TestUpdateCvValidation::test_update_cv_before_load_returns_backend_not_ready`
- [x] Existing `update_cv` validation tests still green (3/3)
- [x] `uv run pytest` — 922 passed (was 921, +1 new)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/lizyml_widget/` — clean
- [x] CHANGELOG `[Unreleased] / Changed` updated

## Refs

- #130 (this PR)
- Code review 2026-05-08 (HIGH H2)
- CLAUDE.md §4, §8 — backend-agnostic Widget rule