### PR TITLE
refactor(service,adapter): split under 800-line ceiling (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **service.py / adapter.py file-size split**
+  ([#137](https://github.com/nbx-liz/LizyML-Widget/issues/137)).
+  Both core modules now sit below the CLAUDE.md §8 < 800-line ceiling.
+  ``service.py`` shrinks from 1019 → 790 lines by extracting CV helpers
+  (``service_cv.py``: ``compute_preview_splits``, ``validate_inner_valid``,
+  ``default_strategy_for_task``, ``default_cv_state``) and column
+  auto-detection helpers (``service_columns.py``: ``detect_task``,
+  ``auto_configure_column``, ``calc_feature_summary``,
+  ``merge_best_params_into_config``).
+  ``adapter.py`` shrinks from 1107 → 761 lines by moving stateless
+  helpers into ``adapter_internals.py`` (version guard, dict path
+  helpers, ``deep_merge``, ``extract_defaults``,
+  ``convert_metric_entries``, ``enforce_auto_num_leaves``,
+  ``_serialize_*``) and result-side helpers into ``adapter_results.py``
+  (``render_plot``, ``list_available_plots``, ``render_inference_plot``,
+  ``task_for_model``).  Composition only — no inheritance changes.
+  Backward-compatible ``LizyMLAdapter._<helper>`` static aliases keep
+  existing tests untouched. Public API and behavior are unchanged.
 - **Widget action dispatcher extracted to `widget_actions.py`**
   ([#127](https://github.com/nbx-liz/LizyML-Widget/issues/127)).
   Follow-up to #117. All 19 ``_handle_*`` action handlers now live in

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import copy
 import logging
 import threading
@@ -12,6 +11,22 @@ from typing import Any, Literal, Protocol
 import pandas as pd
 
 from .adapter_contract import build_capabilities, build_ui_schema
+from .adapter_internals import (
+    LIZYML_MAX_VERSION,
+    LIZYML_MIN_VERSION,
+    _check_lizyml_version,
+    _parse_lizyml_version,
+    _serialize_boundary_report,
+    _serialize_rounds,
+    _serialize_trials,
+    convert_metric_entries,
+    deep_merge,
+    enforce_auto_num_leaves,
+    extract_defaults,
+    get_nested,
+    set_nested,
+    unset_nested,
+)
 from .adapter_params import (
     LGBM_PARAMS_BY_TASK,
     LGBM_PARAMS_TASK_INDEPENDENT,
@@ -19,6 +34,12 @@ from .adapter_params import (
     get_eval_metrics_by_task,
 )
 from .adapter_params import classify_best_params as _classify_best_params_impl
+from .adapter_results import (
+    list_available_plots,
+    render_inference_plot,
+    render_plot,
+    task_for_model,
+)
 from .adapter_schema import (
     enforce_iv_exclusivity,
     get_default_search_space,
@@ -27,8 +48,6 @@ from .adapter_schema import (
     strip_for_backend,
 )
 from .adapter_views import (
-    LMBoundaryReportView,
-    LMRoundView,
     view_fit_result,
     view_prediction_result,
     view_tune_progress,
@@ -43,6 +62,20 @@ from .types import (
     PredictionSummary,
     TuningSummary,
 )
+
+# Re-export for tests / external imports that historically pulled these
+# symbols from ``lizyml_widget.adapter``.
+__all__ = [
+    "LIZYML_MAX_VERSION",
+    "LIZYML_MIN_VERSION",
+    "BackendAdapter",
+    "LizyMLAdapter",
+    "_check_lizyml_version",
+    "_parse_lizyml_version",
+    "_serialize_boundary_report",
+    "_serialize_rounds",
+    "_serialize_trials",
+]
 
 _log = logging.getLogger(__name__)
 
@@ -137,143 +170,6 @@ class BackendAdapter(Protocol):
     def plot_inference(self, predictions: pd.DataFrame, plot_type: str) -> PlotData: ...
 
 
-#: Minimum supported lizyml version (inclusive). P-030: bumped to 0.10.0
-#: because the Adapter assumes target_encoder-driven label dtype preservation
-#: (FitResult.target_encoder, FORMAT_VERSION=2 — added in lizyml 0.10).
-LIZYML_MIN_VERSION = (0, 10, 0)
-#: Maximum supported lizyml version (exclusive). P-030: covers 0.10 / 0.11 / 0.12.
-LIZYML_MAX_VERSION = (0, 13, 0)
-
-
-def _parse_lizyml_version(raw: str) -> tuple[int, ...]:
-    """Parse a lizyml version string into a comparable tuple of ints.
-
-    Pre-release / dev suffixes ("0.9.0rc1", "0.9.0.dev3") are stripped so
-    they compare equal to their base release.  This keeps the version guard
-    permissive for local dev installs.
-    """
-    import re
-
-    core = re.split(r"[^0-9.]", raw, maxsplit=1)[0]
-    parts = core.split(".")
-    out: list[int] = []
-    for p in parts:
-        try:
-            out.append(int(p))
-        except ValueError:
-            break
-    # Pad to 3 components so comparisons work against (major, minor, patch).
-    while len(out) < 3:
-        out.append(0)
-    return tuple(out[:3])
-
-
-def _check_lizyml_version() -> None:
-    """Validate the installed lizyml version against the widget's contract.
-
-    Raises
-    ------
-    ImportError
-        When ``lizyml`` is missing or outside ``[LIZYML_MIN_VERSION,
-        LIZYML_MAX_VERSION)``.  The error message points the user at the
-        ``[lizyml]`` extras install command.
-    """
-    try:
-        import lizyml
-    except ImportError as exc:  # pragma: no cover - exercised via dedicated test
-        msg = (
-            "lizyml-widget requires the 'lizyml' backend. "
-            "Install it with:\n"
-            "    pip install 'lizyml-widget[lizyml]'\n"
-            "See docs/VERSION_COMPAT.md for details."
-        )
-        raise ImportError(msg) from exc
-
-    version_str = getattr(lizyml, "__version__", None)
-    # Unit tests often install ``lizyml`` as a ``MagicMock`` via
-    # ``sys.modules`` patching; in that case ``__version__`` is not a
-    # real string and the guard cannot reliably parse it.  Skip silently
-    # so mocked tests still exercise the adapter without being blocked
-    # by a version check that is irrelevant in that environment.
-    if not isinstance(version_str, str):
-        return
-
-    version = _parse_lizyml_version(version_str)
-    if version < LIZYML_MIN_VERSION or version >= LIZYML_MAX_VERSION:
-        min_s = ".".join(str(x) for x in LIZYML_MIN_VERSION)
-        max_s = ".".join(str(x) for x in LIZYML_MAX_VERSION)
-        msg = (
-            f"lizyml-widget requires lizyml>={min_s},<{max_s} "
-            f"(found: lizyml=={version_str}). Run:\n"
-            f"    pip install --upgrade "
-            f"'lizyml[plots,tuning,calibration,explain]>={min_s},<{max_s}'\n"
-            "See docs/VERSION_COMPAT.md for the full compatibility matrix."
-        )
-        raise ImportError(msg)
-
-
-def _serialize_trials(trials: Any) -> list[dict[str, Any]]:
-    """Convert a sequence of lizyml TrialResult into JSON-friendly dicts.
-
-    Each dict keeps ``round`` (defaulting to 1 for pre-re-tune backends)
-    so the UI can group trials by round when rendering the score history.
-    """
-    from dataclasses import asdict
-
-    out: list[dict[str, Any]] = []
-    for t in trials or ():
-        d = asdict(t)
-        d.setdefault("round", 1)
-        out.append(d)
-    return out
-
-
-def _serialize_rounds(rounds: Sequence[LMRoundView]) -> list[dict[str, Any]]:
-    """Convert a tuple of typed round views into JSON-serialisable dicts.
-
-    ``space_snapshot`` is stripped because each entry is a dataclass
-    (``FloatDim`` / ``IntDim`` / ``CategoricalDim``) that anywidget cannot
-    serialize directly.  The UI only needs the round-level metadata
-    (scores, expanded dim names); full space snapshots can be retrieved
-    from ``boundary_report`` if needed in a future iteration.
-    """
-    return [
-        {
-            "round": r.round,
-            "n_trials": r.n_trials,
-            "best_score_before": r.best_score_before,
-            "best_score_after": r.best_score_after,
-            "expanded_dims": list(r.expanded_dims),
-        }
-        for r in rounds
-    ]
-
-
-def _serialize_boundary_report(
-    report: LMBoundaryReportView | None,
-) -> dict[str, Any] | None:
-    """Convert a typed boundary-report view into a JSON-friendly dict (or None)."""
-    if report is None:
-        return None
-    return {
-        "dims": [
-            {
-                "name": d.name,
-                "best_value": d.best_value,
-                "low": d.low,
-                "high": d.high,
-                "position_pct": d.position_pct,
-                "edge": d.edge,
-                "expanded": d.expanded,
-                "new_low": d.new_low,
-                "new_high": d.new_high,
-            }
-            for d in report.dims
-        ],
-        "expanded_names": list(report.expanded_names),
-    }
-
-
 class LizyMLAdapter:
     """Adapter for the LizyML backend library."""
 
@@ -306,6 +202,18 @@ class LizyMLAdapter:
     _LGBM_PARAMS_TASK_INDEPENDENT = LGBM_PARAMS_TASK_INDEPENDENT
     _LGBM_PARAMS_BY_TASK = LGBM_PARAMS_BY_TASK
 
+    # Backward-compatible static aliases for helpers now living in
+    # ``adapter_internals`` (#137). Tests and external callers historically
+    # accessed these via ``LizyMLAdapter._<name>``; the aliases keep that
+    # interface stable.
+    _enforce_auto_num_leaves = staticmethod(enforce_auto_num_leaves)
+    _deep_merge = staticmethod(deep_merge)
+    _get_nested = staticmethod(get_nested)
+    _set_nested = staticmethod(set_nested)
+    _unset_nested = staticmethod(unset_nested)
+    _extract_defaults = staticmethod(extract_defaults)
+    _convert_metric_entries = staticmethod(convert_metric_entries)
+
     def classify_best_params(
         self,
         params: dict[str, Any],
@@ -328,7 +236,7 @@ class LizyMLAdapter:
     def initialize_config(self, *, task: str | None = None) -> dict[str, Any]:
         """Build the full initial config dict with backend-specific defaults."""
         schema = self.get_config_schema()
-        config = self._extract_defaults(schema)
+        config = extract_defaults(schema)
         config.setdefault("config_version", 1)
         if not config.get("output_dir"):
             config["output_dir"] = "outputs/"
@@ -366,15 +274,15 @@ class LizyMLAdapter:
         for op in ops:
             parts = op.path.split(".")
             if op.op == "set":
-                self._set_nested(result, parts, op.value)
+                set_nested(result, parts, op.value)
             elif op.op == "unset":
-                self._unset_nested(result, parts)
+                unset_nested(result, parts)
             elif op.op == "merge":
-                existing = self._get_nested(result, parts)
+                existing = get_nested(result, parts)
                 if isinstance(existing, dict) and isinstance(op.value, dict):
-                    self._set_nested(result, parts, {**existing, **op.value})
+                    set_nested(result, parts, {**existing, **op.value})
                 else:
-                    self._set_nested(result, parts, op.value)
+                    set_nested(result, parts, op.value)
 
         # ── Final canonical pass (single, after all ops) ──────
         # 1. Re-complete required fields
@@ -388,7 +296,7 @@ class LizyMLAdapter:
         cur_model.setdefault("name", "lgbm")
 
         # 2. Enforce auto_num_leaves exclusivity
-        result["model"] = self._enforce_auto_num_leaves(cur_model)
+        result["model"] = enforce_auto_num_leaves(cur_model)
 
         # 3. Normalize inner_valid
         result = normalize_inner_valid(result)
@@ -465,17 +373,6 @@ class LizyMLAdapter:
             return copy.deepcopy(config)
         return self.apply_config_patch(config, ops, task=task)
 
-    @staticmethod
-    def _enforce_auto_num_leaves(model: dict[str, Any]) -> dict[str, Any]:
-        """Return a new model dict with auto_num_leaves exclusivity enforced."""
-        auto_nl = model.get("auto_num_leaves", True)
-        params = dict(model.get("params", {}))
-        if auto_nl:
-            params.pop("num_leaves", None)
-        elif "num_leaves" not in params:
-            params["num_leaves"] = 256
-        return {**model, "params": params}
-
     # ── Canonicalize config ───────────────────────────────────
 
     # Keys managed by Service (df_info / build_config), not the widget config traitlet
@@ -486,27 +383,16 @@ class LizyMLAdapter:
     ) -> dict[str, Any]:
         """Canonicalize a partial/full config by merging with backend defaults."""
         defaults = self.initialize_config(task=task)
-        result = self._deep_merge(defaults, copy.deepcopy(config))
+        result = deep_merge(defaults, copy.deepcopy(config))
 
         # Strip Service-managed keys (data/features/split/task)
         for key in self._SERVICE_MANAGED_KEYS:
             result.pop(key, None)
 
         # Enforce auto_num_leaves exclusivity
-        result["model"] = self._enforce_auto_num_leaves(result.get("model", {}))
+        result["model"] = enforce_auto_num_leaves(result.get("model", {}))
 
         result = normalize_inner_valid(result)
-        return result
-
-    @staticmethod
-    def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-        """Recursively merge override into base. Override values take precedence."""
-        result = dict(base)
-        for key, value in override.items():
-            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-                result[key] = LizyMLAdapter._deep_merge(result[key], value)
-            else:
-                result[key] = value
         return result
 
     def prepare_run_config(
@@ -525,117 +411,15 @@ class LizyMLAdapter:
             model = {**model, "name": "lgbm"}
 
         # Enforce auto_num_leaves exclusivity
-        result = {**result, "model": self._enforce_auto_num_leaves(model)}
+        result = {**result, "model": enforce_auto_num_leaves(model)}
 
         if job_type == "tune":
             result = prepare_tune_overrides(result)
 
         result = normalize_inner_valid(result)
         result = enforce_iv_exclusivity(result)
-        result = self._convert_metric_entries(result)
+        result = convert_metric_entries(result)
         return strip_for_backend(result)
-
-    @staticmethod
-    def _convert_metric_entries(config: dict[str, Any]) -> dict[str, Any]:
-        """Convert widget-only _precision_at_k_k to MetricEntry dict form.
-
-        Transforms ``model.params.metric`` entries:
-        - ``"precision_at_k"`` + ``_precision_at_k_k=20``
-          → ``{"precision_at_k": {"k": 20}}``
-        - Strips ``_precision_at_k_k`` from params regardless.
-        """
-        model = config.get("model")
-        if not isinstance(model, dict):
-            return config
-        params = model.get("params")
-        if not isinstance(params, dict):
-            return config
-
-        metric = params.get("metric")
-        pak_k = params.get("_precision_at_k_k")
-
-        new_params = {k: v for k, v in params.items() if k != "_precision_at_k_k"}
-
-        if isinstance(metric, list) and "precision_at_k" in metric and pak_k is not None:
-            new_metric = [
-                {"precision_at_k": {"k": int(pak_k)}} if m == "precision_at_k" else m
-                for m in metric
-            ]
-            new_params = {**new_params, "metric": new_metric}
-
-        return {**config, "model": {**model, "params": new_params}}
-
-    # ── Config patch helpers ──────────────────────────────────
-
-    @staticmethod
-    def _get_nested(obj: dict[str, Any], parts: list[str]) -> Any:
-        """Get a value at a dot-path inside a nested dict."""
-        current: Any = obj
-        for part in parts:
-            if isinstance(current, dict):
-                current = current.get(part)
-            else:
-                return None
-        return current
-
-    @staticmethod
-    def _set_nested(obj: dict[str, Any], parts: list[str], value: Any) -> None:
-        """Set a value at a dot-path inside a nested dict, creating intermediates."""
-        current = obj
-        for part in parts[:-1]:
-            if part not in current or not isinstance(current[part], dict):
-                current[part] = {}
-            current = current[part]
-        current[parts[-1]] = value
-
-    @staticmethod
-    def _unset_nested(obj: dict[str, Any], parts: list[str]) -> None:
-        """Remove a key at a dot-path inside a nested dict."""
-        current = obj
-        for part in parts[:-1]:
-            if part not in current or not isinstance(current[part], dict):
-                return
-            current = current[part]
-        current.pop(parts[-1], None)
-
-    @staticmethod
-    def _extract_defaults(schema: dict[str, Any]) -> dict[str, Any]:
-        """Walk a JSON Schema and extract default values into a config dict."""
-
-        def _resolve(node: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
-            if "$ref" in node:
-                parts = node["$ref"].lstrip("#/").split("/")
-                ref_node: Any = root
-                for part in parts:
-                    ref_node = ref_node.get(part, {})
-                merged = dict(ref_node)
-                merged.update({k: v for k, v in node.items() if k != "$ref"})
-                return merged
-            if "allOf" in node and len(node["allOf"]) == 1 and "$ref" in node["allOf"][0]:
-                resolved = _resolve(node["allOf"][0], root)
-                resolved.update({k: v for k, v in node.items() if k != "allOf"})
-                return resolved
-            return node
-
-        def _walk(node: dict[str, Any], root: dict[str, Any]) -> Any:
-            node = _resolve(node, root)
-            if node.get("type") == "object" and "properties" in node:
-                obj: dict[str, Any] = {}
-                for key, prop in node["properties"].items():
-                    prop = _resolve(prop, root)
-                    if "default" in prop:
-                        obj[key] = prop["default"]
-                    elif prop.get("type") == "object" and "properties" in prop:
-                        child = _walk(prop, root)
-                        if child:
-                            obj[key] = child
-                return obj
-            if "default" in node:
-                return node["default"]
-            return {}
-
-        result = _walk(schema, schema)
-        return result if isinstance(result, dict) else {}
 
     # ── Config validation ─────────────────────────────────────
 
@@ -716,26 +500,8 @@ class LizyMLAdapter:
         return model
 
     def _task_for_model(self, model: Any) -> str:
-        """Return the task ('binary'/'multiclass'/'regression') for *model*.
-
-        #116: centralises the legacy ``_cfg.task`` private read with a
-        graceful fallback to the adapter-side config registry. Returns ""
-        if no source can be resolved (caller treats this as "unknown task").
-        """
-        # 1. Try lizyml's internal _cfg.task (the public path on supported
-        #    minors). Suppressed because mocked / loaded models may not
-        #    expose _cfg.
-        try:
-            return str(model._cfg.task)  # noqa: SLF001
-        except AttributeError:
-            pass
-        # 2. Fallback: adapter-side registry populated by create_model.
-        cfg = self._model_configs.get(id(model))
-        if cfg is not None:
-            task = cfg.get("task", "")
-            if isinstance(task, str):
-                return task
-        return ""
+        """Return the task for *model* (delegates to ``adapter_results``)."""
+        return task_for_model(model, self._model_configs)
 
     def _run_with_cancel_polling(
         self,
@@ -948,131 +714,17 @@ class LizyMLAdapter:
         return model.importance(kind=kind)  # type: ignore[no-any-return]
 
     def plot(self, model: Any, plot_type: str, **kwargs: Any) -> PlotData:
-        plot_methods: dict[str, Callable[..., Any]] = {
-            "learning-curve": model.plot_learning_curve,
-            "oof-distribution": model.plot_oof_distribution,
-            "residuals": model.residuals_plot,
-            "roc-curve": model.roc_curve_plot,
-            "calibration": model.calibration_plot,
-            "probability-histogram": model.probability_histogram_plot,
-            "feature-importance-split": lambda: model.importance_plot(kind="split"),
-            "feature-importance-gain": lambda: model.importance_plot(kind="gain"),
-            "feature-importance-shap": lambda: model.importance_plot(kind="shap"),
-            "optimization-history": model.tuning_plot,
-        }
-        method = plot_methods.get(plot_type)
-        if method is None:
-            msg = f"Unknown plot type: {plot_type}"
-            raise ValueError(msg)
-        # Forward metrics filter to learning-curve only (P-026)
-        if plot_type == "learning-curve":
-            lc_kwargs: dict[str, Any] = {}
-            metrics = kwargs.get("metrics")
-            if metrics:  # skip None and empty list → fall back to all metrics
-                lc_kwargs["metrics"] = metrics
-            fig = method(**lc_kwargs) if lc_kwargs else method()
-        else:
-            fig = method()
-        return PlotData(plotly_json=fig.to_json())
+        return render_plot(model, plot_type, **kwargs)
 
     def available_plots(self, model: Any) -> list[str]:
         # #116: task lookup centralised in _task_for_model (registry-backed
         # fallback replaces the legacy ``_widget_config`` private read).
         task = self._task_for_model(model)
-
-        # Check if model has been fitted (not just tuned) — P-004 R4
-        is_fitted = False
-        with contextlib.suppress(Exception):
-            is_fitted = model.fit_result is not None
-
-        has_calibration = False
-        with contextlib.suppress(Exception):
-            has_calibration = is_fitted and model.fit_result.calibrator is not None
-
-        # Feature-detection probe — model._tuning_result is a private slot
-        # lizyml exposes for tuning state. The presence check is intentional
-        # and does not read data off the value, so it is allowed by #116.
-        has_tuning = (
-            hasattr(model, "_tuning_result") and model._tuning_result is not None  # noqa: SLF001
-        )
-
-        plots: list[str] = []
-
-        # Fit-dependent plots only when model is fitted
-        if is_fitted:
-            plots.extend(["learning-curve", "oof-distribution"])
-            if task == "regression":
-                plots.append("residuals")
-            if task == "binary":
-                plots.append("roc-curve")
-                if has_calibration:
-                    plots.append("calibration")
-                    plots.append("probability-histogram")
-            if task == "multiclass":
-                plots.append("roc-curve")
-            plots.extend(
-                [
-                    "feature-importance-split",
-                    "feature-importance-gain",
-                    "feature-importance-shap",
-                ]
-            )
-
-        # Tune-dependent plots
-        if has_tuning:
-            plots.append("optimization-history")
-        return plots
+        return list_available_plots(model, task)
 
     def plot_inference(self, predictions: pd.DataFrame, plot_type: str) -> PlotData:
         """Generate Plotly plots from inference results (not part of Protocol)."""
-        try:
-            import plotly.graph_objects as go  # type: ignore[import-untyped]
-        except ImportError as e:
-            msg = "plotly is required for inference plots"
-            raise ImportError(msg) from e
-
-        if plot_type == "prediction-distribution":
-            # Find prediction column: prefer columns starting with "pred", fallback to last column
-            pred_col = next(
-                (c for c in predictions.columns if c.startswith("pred")),
-                predictions.columns[-1],
-            )
-            fig = go.Figure()
-            fig.add_trace(go.Histogram(x=predictions[pred_col], name="Predictions"))
-            fig.update_layout(
-                title="Prediction Distribution",
-                xaxis_title="Predicted Value",
-                yaxis_title="Count",
-            )
-            return PlotData(plotly_json=fig.to_json())
-
-        if plot_type == "shap-summary":
-            # SHAP columns are prefixed with "shap_"
-            shap_cols = [c for c in predictions.columns if c.startswith("shap_")]
-            if not shap_cols:
-                msg = "No SHAP values available. Run inference with return_shap=True."
-                raise ValueError(msg)
-            mean_abs_shap = predictions[shap_cols].abs().mean().sort_values(ascending=True)
-            feature_names = [c.replace("shap_", "", 1) for c in mean_abs_shap.index]
-            fig = go.Figure()
-            fig.add_trace(
-                go.Bar(
-                    x=mean_abs_shap.values,
-                    y=feature_names,
-                    orientation="h",
-                    name="Mean |SHAP|",
-                )
-            )
-            fig.update_layout(
-                title="SHAP Summary",
-                xaxis_title="Mean |SHAP value|",
-                yaxis_title="Feature",
-                height=max(300, len(shap_cols) * 25),
-            )
-            return PlotData(plotly_json=fig.to_json())
-
-        msg = f"Unknown inference plot type: {plot_type}"
-        raise ValueError(msg)
+        return render_inference_plot(predictions, plot_type)
 
     def export_model(self, model: Any, path: str) -> str:
         model.export(path)
@@ -1094,6 +746,8 @@ class LizyMLAdapter:
         info: dict[str, Any] = {"loaded": True}
 
         # Extract model params if available
+        import contextlib
+
         with contextlib.suppress(Exception):
             params_df = model.params_table()
             if params_df is not None:

--- a/src/lizyml_widget/adapter_internals.py
+++ b/src/lizyml_widget/adapter_internals.py
@@ -1,0 +1,268 @@
+"""Internal helpers for LizyMLAdapter.
+
+Pure module-level helpers extracted from adapter.py (#137) so the adapter
+module stays under the 800-line ceiling. These are version-check guards,
+serializers for tuning artifacts, dict-traversal helpers, and config
+canonicalization helpers — all stateless and reusable.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import asdict
+from typing import Any
+
+from .adapter_views import LMBoundaryReportView, LMRoundView
+
+#: Minimum supported lizyml version (inclusive). P-030: bumped to 0.10.0
+#: because the Adapter assumes target_encoder-driven label dtype preservation
+#: (FitResult.target_encoder, FORMAT_VERSION=2 — added in lizyml 0.10).
+LIZYML_MIN_VERSION = (0, 10, 0)
+#: Maximum supported lizyml version (exclusive). P-030: covers 0.10 / 0.11 / 0.12.
+LIZYML_MAX_VERSION = (0, 13, 0)
+
+
+def _parse_lizyml_version(raw: str) -> tuple[int, ...]:
+    """Parse a lizyml version string into a comparable tuple of ints.
+
+    Pre-release / dev suffixes ("0.9.0rc1", "0.9.0.dev3") are stripped so
+    they compare equal to their base release. This keeps the version guard
+    permissive for local dev installs.
+    """
+    core = re.split(r"[^0-9.]", raw, maxsplit=1)[0]
+    parts = core.split(".")
+    out: list[int] = []
+    for p in parts:
+        try:
+            out.append(int(p))
+        except ValueError:
+            break
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out[:3])
+
+
+def _check_lizyml_version() -> None:
+    """Validate the installed lizyml version against the widget's contract.
+
+    Raises
+    ------
+    ImportError
+        When ``lizyml`` is missing or outside ``[LIZYML_MIN_VERSION,
+        LIZYML_MAX_VERSION)``. The error message points the user at the
+        ``[lizyml]`` extras install command.
+    """
+    try:
+        import lizyml
+    except ImportError as exc:  # pragma: no cover - exercised via dedicated test
+        msg = (
+            "lizyml-widget requires the 'lizyml' backend. "
+            "Install it with:\n"
+            "    pip install 'lizyml-widget[lizyml]'\n"
+            "See docs/VERSION_COMPAT.md for details."
+        )
+        raise ImportError(msg) from exc
+
+    version_str = getattr(lizyml, "__version__", None)
+    # Unit tests often install ``lizyml`` as a ``MagicMock`` via
+    # ``sys.modules`` patching; in that case ``__version__`` is not a
+    # real string and the guard cannot reliably parse it. Skip silently
+    # so mocked tests still exercise the adapter without being blocked
+    # by a version check that is irrelevant in that environment.
+    if not isinstance(version_str, str):
+        return
+
+    version = _parse_lizyml_version(version_str)
+    if version < LIZYML_MIN_VERSION or version >= LIZYML_MAX_VERSION:
+        min_s = ".".join(str(x) for x in LIZYML_MIN_VERSION)
+        max_s = ".".join(str(x) for x in LIZYML_MAX_VERSION)
+        msg = (
+            f"lizyml-widget requires lizyml>={min_s},<{max_s} "
+            f"(found: lizyml=={version_str}). Run:\n"
+            f"    pip install --upgrade "
+            f"'lizyml[plots,tuning,calibration,explain]>={min_s},<{max_s}'\n"
+            "See docs/VERSION_COMPAT.md for the full compatibility matrix."
+        )
+        raise ImportError(msg)
+
+
+def _serialize_trials(trials: Any) -> list[dict[str, Any]]:
+    """Convert a sequence of lizyml TrialResult into JSON-friendly dicts.
+
+    Each dict keeps ``round`` (defaulting to 1 for pre-re-tune backends)
+    so the UI can group trials by round when rendering the score history.
+    """
+    out: list[dict[str, Any]] = []
+    for t in trials or ():
+        d = asdict(t)
+        d.setdefault("round", 1)
+        out.append(d)
+    return out
+
+
+def _serialize_rounds(rounds: Sequence[LMRoundView]) -> list[dict[str, Any]]:
+    """Convert a tuple of typed round views into JSON-serialisable dicts.
+
+    ``space_snapshot`` is stripped because each entry is a dataclass
+    (``FloatDim`` / ``IntDim`` / ``CategoricalDim``) that anywidget cannot
+    serialize directly. The UI only needs the round-level metadata
+    (scores, expanded dim names); full space snapshots can be retrieved
+    from ``boundary_report`` if needed in a future iteration.
+    """
+    return [
+        {
+            "round": r.round,
+            "n_trials": r.n_trials,
+            "best_score_before": r.best_score_before,
+            "best_score_after": r.best_score_after,
+            "expanded_dims": list(r.expanded_dims),
+        }
+        for r in rounds
+    ]
+
+
+def _serialize_boundary_report(
+    report: LMBoundaryReportView | None,
+) -> dict[str, Any] | None:
+    """Convert a typed boundary-report view into a JSON-friendly dict (or None)."""
+    if report is None:
+        return None
+    return {
+        "dims": [
+            {
+                "name": d.name,
+                "best_value": d.best_value,
+                "low": d.low,
+                "high": d.high,
+                "position_pct": d.position_pct,
+                "edge": d.edge,
+                "expanded": d.expanded,
+                "new_low": d.new_low,
+                "new_high": d.new_high,
+            }
+            for d in report.dims
+        ],
+        "expanded_names": list(report.expanded_names),
+    }
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge override into base. Override values take precedence."""
+    result = dict(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def get_nested(obj: dict[str, Any], parts: list[str]) -> Any:
+    """Get a value at a dot-path inside a nested dict."""
+    current: Any = obj
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def set_nested(obj: dict[str, Any], parts: list[str], value: Any) -> None:
+    """Set a value at a dot-path inside a nested dict, creating intermediates."""
+    current = obj
+    for part in parts[:-1]:
+        if part not in current or not isinstance(current[part], dict):
+            current[part] = {}
+        current = current[part]
+    current[parts[-1]] = value
+
+
+def unset_nested(obj: dict[str, Any], parts: list[str]) -> None:
+    """Remove a key at a dot-path inside a nested dict."""
+    current = obj
+    for part in parts[:-1]:
+        if part not in current or not isinstance(current[part], dict):
+            return
+        current = current[part]
+    current.pop(parts[-1], None)
+
+
+def extract_defaults(schema: dict[str, Any]) -> dict[str, Any]:
+    """Walk a JSON Schema and extract default values into a config dict."""
+
+    def _resolve(node: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+        if "$ref" in node:
+            parts = node["$ref"].lstrip("#/").split("/")
+            ref_node: Any = root
+            for part in parts:
+                ref_node = ref_node.get(part, {})
+            merged = dict(ref_node)
+            merged.update({k: v for k, v in node.items() if k != "$ref"})
+            return merged
+        if "allOf" in node and len(node["allOf"]) == 1 and "$ref" in node["allOf"][0]:
+            resolved = _resolve(node["allOf"][0], root)
+            resolved.update({k: v for k, v in node.items() if k != "allOf"})
+            return resolved
+        return node
+
+    def _walk(node: dict[str, Any], root: dict[str, Any]) -> Any:
+        node = _resolve(node, root)
+        if node.get("type") == "object" and "properties" in node:
+            obj: dict[str, Any] = {}
+            for key, prop in node["properties"].items():
+                prop = _resolve(prop, root)
+                if "default" in prop:
+                    obj[key] = prop["default"]
+                elif prop.get("type") == "object" and "properties" in prop:
+                    child = _walk(prop, root)
+                    if child:
+                        obj[key] = child
+            return obj
+        if "default" in node:
+            return node["default"]
+        return {}
+
+    result = _walk(schema, schema)
+    return result if isinstance(result, dict) else {}
+
+
+def enforce_auto_num_leaves(model: dict[str, Any]) -> dict[str, Any]:
+    """Return a new model dict with auto_num_leaves exclusivity enforced."""
+    auto_nl = model.get("auto_num_leaves", True)
+    params = dict(model.get("params", {}))
+    if auto_nl:
+        params.pop("num_leaves", None)
+    elif "num_leaves" not in params:
+        params["num_leaves"] = 256
+    return {**model, "params": params}
+
+
+def convert_metric_entries(config: dict[str, Any]) -> dict[str, Any]:
+    """Convert widget-only ``_precision_at_k_k`` to MetricEntry dict form.
+
+    Transforms ``model.params.metric`` entries:
+    - ``"precision_at_k"`` + ``_precision_at_k_k=20``
+      → ``{"precision_at_k": {"k": 20}}``
+    - Strips ``_precision_at_k_k`` from params regardless.
+    """
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return config
+    params = model.get("params")
+    if not isinstance(params, dict):
+        return config
+
+    metric = params.get("metric")
+    pak_k = params.get("_precision_at_k_k")
+
+    new_params = {k: v for k, v in params.items() if k != "_precision_at_k_k"}
+
+    if isinstance(metric, list) and "precision_at_k" in metric and pak_k is not None:
+        new_metric = [
+            {"precision_at_k": {"k": int(pak_k)}} if m == "precision_at_k" else m for m in metric
+        ]
+        new_params = {**new_params, "metric": new_metric}
+
+    return {**config, "model": {**model, "params": new_params}}

--- a/src/lizyml_widget/adapter_results.py
+++ b/src/lizyml_widget/adapter_results.py
@@ -1,0 +1,160 @@
+"""Result-side helpers for LizyMLAdapter (plots + inference rendering).
+
+Pure functions extracted from adapter.py (#137) so the adapter module
+stays under the 800-line ceiling. These helpers are stateless: ``model``
+and any registry data are passed in by the caller.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+
+from .types import PlotData
+
+
+def task_for_model(model: Any, model_configs: dict[int, dict[str, Any]]) -> str:
+    """Return the task ('binary'/'multiclass'/'regression') for *model*.
+
+    Centralises the legacy ``_cfg.task`` private read with a graceful
+    fallback to the adapter-side config registry. Returns ``""`` if no
+    source can be resolved (caller treats this as "unknown task").
+    """
+    try:
+        return str(model._cfg.task)  # noqa: SLF001
+    except AttributeError:
+        pass
+    cfg = model_configs.get(id(model))
+    if cfg is not None:
+        task = cfg.get("task", "")
+        if isinstance(task, str):
+            return task
+    return ""
+
+
+def render_plot(model: Any, plot_type: str, **kwargs: Any) -> PlotData:
+    """Dispatch to the model's plotting method for *plot_type*."""
+    plot_methods: dict[str, Callable[..., Any]] = {
+        "learning-curve": model.plot_learning_curve,
+        "oof-distribution": model.plot_oof_distribution,
+        "residuals": model.residuals_plot,
+        "roc-curve": model.roc_curve_plot,
+        "calibration": model.calibration_plot,
+        "probability-histogram": model.probability_histogram_plot,
+        "feature-importance-split": lambda: model.importance_plot(kind="split"),
+        "feature-importance-gain": lambda: model.importance_plot(kind="gain"),
+        "feature-importance-shap": lambda: model.importance_plot(kind="shap"),
+        "optimization-history": model.tuning_plot,
+    }
+    method = plot_methods.get(plot_type)
+    if method is None:
+        msg = f"Unknown plot type: {plot_type}"
+        raise ValueError(msg)
+    # Forward metrics filter to learning-curve only (P-026)
+    if plot_type == "learning-curve":
+        lc_kwargs: dict[str, Any] = {}
+        metrics = kwargs.get("metrics")
+        if metrics:  # skip None and empty list → fall back to all metrics
+            lc_kwargs["metrics"] = metrics
+        fig = method(**lc_kwargs) if lc_kwargs else method()
+    else:
+        fig = method()
+    return PlotData(plotly_json=fig.to_json())
+
+
+def list_available_plots(model: Any, task: str) -> list[str]:
+    """Return the list of plot types available for the current model + task."""
+    is_fitted = False
+    with contextlib.suppress(Exception):
+        is_fitted = model.fit_result is not None
+
+    has_calibration = False
+    with contextlib.suppress(Exception):
+        has_calibration = is_fitted and model.fit_result.calibrator is not None
+
+    # Feature-detection probe — model._tuning_result is a private slot
+    # lizyml exposes for tuning state. The presence check is intentional
+    # and does not read data off the value, so it is allowed by #116.
+    has_tuning = (
+        hasattr(model, "_tuning_result") and model._tuning_result is not None  # noqa: SLF001
+    )
+
+    plots: list[str] = []
+
+    if is_fitted:
+        plots.extend(["learning-curve", "oof-distribution"])
+        if task == "regression":
+            plots.append("residuals")
+        if task == "binary":
+            plots.append("roc-curve")
+            if has_calibration:
+                plots.append("calibration")
+                plots.append("probability-histogram")
+        if task == "multiclass":
+            plots.append("roc-curve")
+        plots.extend(
+            [
+                "feature-importance-split",
+                "feature-importance-gain",
+                "feature-importance-shap",
+            ]
+        )
+
+    if has_tuning:
+        plots.append("optimization-history")
+    return plots
+
+
+def render_inference_plot(predictions: pd.DataFrame, plot_type: str) -> PlotData:
+    """Generate a Plotly plot from inference results (post-predict)."""
+    try:
+        import plotly.graph_objects as go  # type: ignore[import-untyped]
+    except ImportError as e:
+        msg = "plotly is required for inference plots"
+        raise ImportError(msg) from e
+
+    if plot_type == "prediction-distribution":
+        # Find prediction column: prefer columns starting with "pred",
+        # fallback to last column.
+        pred_col = next(
+            (c for c in predictions.columns if c.startswith("pred")),
+            predictions.columns[-1],
+        )
+        fig = go.Figure()
+        fig.add_trace(go.Histogram(x=predictions[pred_col], name="Predictions"))
+        fig.update_layout(
+            title="Prediction Distribution",
+            xaxis_title="Predicted Value",
+            yaxis_title="Count",
+        )
+        return PlotData(plotly_json=fig.to_json())
+
+    if plot_type == "shap-summary":
+        shap_cols = [c for c in predictions.columns if c.startswith("shap_")]
+        if not shap_cols:
+            msg = "No SHAP values available. Run inference with return_shap=True."
+            raise ValueError(msg)
+        mean_abs_shap = predictions[shap_cols].abs().mean().sort_values(ascending=True)
+        feature_names = [c.replace("shap_", "", 1) for c in mean_abs_shap.index]
+        fig = go.Figure()
+        fig.add_trace(
+            go.Bar(
+                x=mean_abs_shap.values,
+                y=feature_names,
+                orientation="h",
+                name="Mean |SHAP|",
+            )
+        )
+        fig.update_layout(
+            title="SHAP Summary",
+            xaxis_title="Mean |SHAP value|",
+            yaxis_title="Feature",
+            height=max(300, len(shap_cols) * 25),
+        )
+        return PlotData(plotly_json=fig.to_json())
+
+    msg = f"Unknown inference plot type: {plot_type}"
+    raise ValueError(msg)

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -11,6 +11,17 @@ from typing import Any
 import pandas as pd
 
 from .adapter import BackendAdapter
+from .service_columns import (
+    auto_configure_column,
+    calc_feature_summary,
+    detect_task,
+)
+from .service_cv import (
+    compute_preview_splits,
+    default_cv_state,
+    default_strategy_for_task,
+    validate_inner_valid,
+)
 from .types import (
     BackendContract,
     BackendInfo,
@@ -88,7 +99,7 @@ class WidgetService:
             "auto_task": None,
             "columns": columns,
             "cv": self._default_cv_state(strategy="kfold", n_splits=5),
-            "feature_summary": self._calc_feature_summary(columns),
+            "feature_summary": calc_feature_summary(columns),
         }
 
         if target:
@@ -110,7 +121,7 @@ class WidgetService:
         n_rows = len(df)
         n_unique = int(col.nunique())
 
-        task = self._detect_task(col, n_rows, n_unique)
+        task = detect_task(col, n_rows, n_unique)
 
         # Map existing column settings to detect manual overrides
         existing_settings = {c["name"]: c for c in self._df_info["columns"]}
@@ -125,7 +136,7 @@ class WidgetService:
                 "dtype": str(df[col_name].dtype),
                 "unique_count": int(df[col_name].nunique()),
             }
-            configured = self._auto_configure_column(col_info, n_rows)
+            configured = auto_configure_column(col_info, n_rows, self._df)
             # Preserve manual overrides from update_column()
             prev = existing_settings.get(col_name)
             if prev is not None:
@@ -140,7 +151,7 @@ class WidgetService:
             **self._df_info,
             "target": target,
             "columns": updated_columns,
-            "feature_summary": self._calc_feature_summary(updated_columns),
+            "feature_summary": calc_feature_summary(updated_columns),
         }
         self._apply_task_defaults(task, update_auto_task=True)
         return copy.deepcopy(self._df_info)
@@ -171,7 +182,7 @@ class WidgetService:
         self._df_info = {
             **self._df_info,
             "columns": new_columns,
-            "feature_summary": self._calc_feature_summary(new_columns),
+            "feature_summary": calc_feature_summary(new_columns),
         }
         return copy.deepcopy(self._df_info)
 
@@ -259,12 +270,7 @@ class WidgetService:
     def preview_splits(self) -> dict[str, Any]:
         """Estimate fold structure for blocked_group_kfold before Fit.
 
-        Reads self._df_info["cv"] for blocks config and groups config,
-        then computes the expected fold structure.
-
-        Returns
-        -------
-        dict with keys: total_folds, time_folds, group_folds, periods, folds.
+        Delegates to ``service_cv.compute_preview_splits``.
 
         Raises
         ------
@@ -274,106 +280,7 @@ class WidgetService:
         if self._df is None:
             msg = "No data loaded"
             raise ValueError(msg)
-        cv = self._df_info.get("cv", {})
-        if cv.get("strategy") != "blocked_group_kfold":
-            msg = "preview_splits only supports strategy='blocked_group_kfold'"
-            raise ValueError(msg)
-
-        blocks_cfg: dict[str, Any] = cv.get("blocks") or {}
-        groups_cfg: dict[str, Any] = cv.get("groups") or {}
-
-        blocks_col: str = blocks_cfg.get("col", "")
-        mode: str = blocks_cfg.get("mode", "expanding")
-        train_window: int | None = blocks_cfg.get("train_window")
-        group_folds: int = int(groups_cfg.get("n_splits", cv.get("n_splits", 2)))
-
-        # Build period list from blocks_col unique values sorted
-        if blocks_col and blocks_col in self._df.columns:
-            periods: list[str] = sorted(self._df[blocks_col].dropna().unique().tolist(), key=str)
-        else:
-            periods = []
-
-        num_periods = len(periods)
-        # Each time fold: trains on periods[0..t], validates on periods[t+1]
-        time_folds = max(0, num_periods - 1)
-        total_folds = time_folds * group_folds
-
-        # Precompute row counts per period (MEDIUM-2: O(1) per period lookup)
-        period_counts: dict[str, int] = {}
-        if blocks_col and blocks_col in self._df.columns:
-            vc = self._df[blocks_col].value_counts()
-            period_counts = {str(k): int(v) for k, v in vc.items()}
-
-        # Use cutoffs to group values into periods (MEDIUM-4)
-        cutoffs: list[Any] = blocks_cfg.get("cutoffs", [])
-        if cutoffs and blocks_col and blocks_col in self._df.columns:
-            sorted_values = sorted(self._df[blocks_col].dropna().unique().tolist(), key=str)
-            grouped_periods: list[list[Any]] = []
-            current_group: list[Any] = []
-            cutoff_idx = 0
-            for v in sorted_values:
-                if cutoff_idx < len(cutoffs) and str(v) >= str(cutoffs[cutoff_idx]):
-                    if current_group:
-                        grouped_periods.append(current_group)
-                    current_group = []
-                    cutoff_idx += 1
-                current_group.append(v)
-            if current_group:
-                grouped_periods.append(current_group)
-            # Replace periods with group labels
-            periods = [
-                str(gp[0]) if len(gp) == 1 else f"{gp[0]}..{gp[-1]}" for gp in grouped_periods
-            ]
-            # Rebuild period_counts for grouped periods
-            grouped_counts: dict[str, int] = {}
-            for gp, label in zip(grouped_periods, periods, strict=True):
-                grouped_counts[label] = sum(period_counts.get(str(v), 0) for v in gp)
-            period_counts = grouped_counts
-            num_periods = len(periods)
-            time_folds = max(0, num_periods - 1)
-            total_folds = time_folds * group_folds
-
-        # Build per-time-fold structures
-        folds: list[dict[str, Any]] = []
-        fold_index = 0
-        for t in range(time_folds):
-            valid_period = periods[t + 1]
-            # Expanding: train on all periods up to and including t
-            if mode == "sliding" and train_window is not None:
-                start = max(0, t + 1 - train_window)
-                train_periods_list = periods[start : t + 1]
-            else:
-                train_periods_list = periods[: t + 1]
-
-            # Use precomputed period_counts for O(1) lookup per period
-            train_rows = sum(period_counts.get(str(p), 0) for p in train_periods_list)
-            valid_rows = period_counts.get(str(valid_period), 0)
-
-            period_label = (
-                " + ".join(str(p) for p in train_periods_list) + " -> " + str(valid_period)
-            )
-
-            for group_idx in range(group_folds):
-                folds.append(
-                    {
-                        "fold": fold_index,
-                        "period_label": period_label,
-                        "group_label": f"G{group_idx}",
-                        "train_size": train_rows,
-                        "valid_size": valid_rows,
-                        "train_periods": list(train_periods_list),
-                        "valid_period": valid_period,
-                    }
-                )
-                fold_index += 1
-
-        return {
-            "total_folds": total_folds,
-            "time_folds": time_folds,
-            "group_folds": group_folds,
-            "periods": periods,
-            "folds": folds,
-        }
+        return compute_preview_splits(self._df, self._df_info)
 
     def get_df_info(self) -> dict[str, Any]:
         """Return a copy of the current df_info state."""
@@ -388,67 +295,27 @@ class WidgetService:
         return self._adapter.initialize_config(task=self._df_info.get("task"))
 
     def apply_config_patch(
-        self, config: dict[str, Any], ops: Sequence[ConfigPatchOp]
+        self,
+        config: dict[str, Any],
+        ops: Sequence[ConfigPatchOp],
     ) -> dict[str, Any]:
-        """Apply config patch operations (delegated to adapter)."""
+        """Apply a list of ConfigPatchOp to config (delegated to adapter)."""
         return self._adapter.apply_config_patch(config, ops, task=self._df_info.get("task"))
 
     def canonicalize_config(self, config: dict[str, Any]) -> dict[str, Any]:
-        """Canonicalize a partial/full config via adapter defaults (delegated to adapter)."""
+        """Canonicalize config via adapter."""
         return self._adapter.canonicalize_config(config, task=self._df_info.get("task"))
 
     def apply_task_params(self, config: dict[str, Any], task: str) -> dict[str, Any]:
-        """Apply task-dependent defaults via adapter (no backend-specific keys here)."""
+        """Apply task-dependent params to config via adapter.
+
+        Used when the user changes the task to refresh task-specific defaults.
+        """
         return self._adapter.apply_task_defaults(config, task=task)
 
-    # ── Config ───────────────────────────────────────────────
-
     def validate_config(self, config: dict[str, Any]) -> list[dict[str, Any]]:
-        errors = self._validate_inner_valid(config)
+        errors = validate_inner_valid(config, self._df_info)
         errors.extend(self._adapter.validate_config(config))
-        return errors
-
-    _GROUP_STRATEGIES = frozenset(
-        {"group_kfold", "stratified_group_kfold", "group_time_series", "blocked_group_kfold"}
-    )
-    _TIME_STRATEGIES = frozenset({"time_series", "purged_time_series", "group_time_series"})
-
-    def _validate_inner_valid(self, config: dict[str, Any]) -> list[dict[str, Any]]:
-        """Check inner_valid method is compatible with CV strategy."""
-        training = config.get("training") or {}
-        early_stopping = training.get("early_stopping") or {}
-        inner_valid = early_stopping.get("inner_valid") or {}
-        method = (
-            inner_valid.get("method", "holdout") if isinstance(inner_valid, dict) else inner_valid
-        )
-
-        cv = self._df_info.get("cv") or {}
-        strategy = cv.get("strategy", "kfold")
-        errors: list[dict[str, Any]] = []
-
-        if method == "group_holdout" and strategy not in self._GROUP_STRATEGIES:
-            errors.append(
-                {
-                    "field": "training.early_stopping.inner_valid.method",
-                    "message": (
-                        "group_holdout requires a group-based CV strategy "
-                        "(e.g. group_kfold, stratified_group_kfold, group_time_series)."
-                    ),
-                    "type": "inner_valid_constraint",
-                }
-            )
-        elif method == "time_holdout" and strategy not in self._TIME_STRATEGIES:
-            errors.append(
-                {
-                    "field": "training.early_stopping.inner_valid.method",
-                    "message": (
-                        "time_holdout requires a time-based CV strategy "
-                        "(e.g. time_series, purged_time_series, group_time_series)."
-                    ),
-                    "type": "inner_valid_constraint",
-                }
-            )
-
         return errors
 
     def build_config(self, user_config: dict[str, Any]) -> dict[str, Any]:
@@ -592,7 +459,7 @@ class WidgetService:
             self._df_info = {
                 **self._df_info,
                 "columns": new_columns,
-                "feature_summary": self._calc_feature_summary(new_columns),
+                "feature_summary": calc_feature_summary(new_columns),
             }
 
         # Restore explicit task override
@@ -888,55 +755,11 @@ class WidgetService:
 
     # ── Auto-detection internals ─────────────────────────────
 
-    @staticmethod
-    def _detect_task(col: pd.Series[Any], n_rows: int, n_unique: int) -> str:
-        """Auto-detect task type from target column."""
-        if n_unique == 2:
-            return "binary"
-        if str(col.dtype) in ("object", "str", "string", "category"):
-            return "multiclass"
-        if pd.api.types.is_numeric_dtype(col):
-            threshold = max(20, int(n_rows * 0.05))
-            if n_unique <= threshold:
-                return "multiclass"
-            return "regression"
-        return "multiclass"
-
     def _default_strategy_for_task(self, task: str) -> str:
-        """Get default CV strategy for task from adapter contract."""
-        try:
-            contract = self._adapter.get_backend_contract()
-            defaults = contract.capabilities.get("cv_default_strategy", {})
-            if task in defaults:
-                return str(defaults[task])
-        except (AttributeError, KeyError, TypeError) as exc:
-            _log.debug("cv_default_strategy contract read failed: %s", exc)
-        # Fallback
-        return "stratified_kfold" if task in ("binary", "multiclass") else "kfold"
+        return default_strategy_for_task(self._adapter, task)
 
     def _default_cv_state(self, *, strategy: str, n_splits: int) -> dict[str, Any]:
-        """Build default CV state, reading defaults from adapter contract."""
-        # Read contract defaults with fallbacks
-        cv_defaults: dict[str, Any] = {}
-        try:
-            contract = self._adapter.get_backend_contract()
-            cv_defaults = contract.capabilities.get("cv_defaults", {})
-        except (AttributeError, KeyError, TypeError) as exc:
-            _log.debug("cv_defaults contract read failed: %s", exc)
-
-        return {
-            "strategy": strategy,
-            "n_splits": n_splits,
-            "group_column": None,
-            "time_column": None,
-            "random_state": cv_defaults.get("random_state", 42),
-            "shuffle": cv_defaults.get("shuffle", True),
-            "gap": cv_defaults.get("gap", 0),
-            "purge_gap": 0,
-            "embargo": 0,
-            "train_size_max": None,
-            "test_size_max": None,
-        }
+        return default_cv_state(self._adapter, strategy=strategy, n_splits=n_splits)
 
     def _apply_task_defaults(self, task: str, *, update_auto_task: bool) -> None:
         cv = self._df_info.get("cv", {})
@@ -964,56 +787,4 @@ class WidgetService:
             "task": task,
             **({"auto_task": task} if update_auto_task else {}),
             "cv": new_cv,
-        }
-
-    def _auto_configure_column(self, col_info: dict[str, Any], n_rows: int) -> dict[str, Any]:
-        """Auto-configure a single column (exclusion + type)."""
-        name = col_info["name"]
-        dtype = col_info["dtype"]
-        unique = col_info["unique_count"]
-
-        excluded = False
-        exclude_reason: str | None = None
-        col_type = "numeric"
-
-        # ID detection — only for integer/string columns, not floats
-        is_float = dtype.startswith("float") or dtype.startswith("Float")
-        if unique == n_rows and not is_float:
-            excluded = True
-            exclude_reason = "id"
-        # Constant detection
-        elif unique == 1:
-            excluded = True
-            exclude_reason = "constant"
-
-        # Type detection
-        if dtype in ("object", "str", "string", "category", "bool"):
-            col_type = "categorical"
-        elif self._df is not None and pd.api.types.is_numeric_dtype(self._df[name]):
-            threshold = max(20, int(n_rows * 0.05))
-            if unique <= threshold:
-                col_type = "categorical"
-
-        return {
-            **col_info,
-            "suggested_type": col_type,
-            "suggested_excluded": excluded,
-            "exclude_reason": exclude_reason,
-            "excluded": excluded,
-            "col_type": col_type,
-        }
-
-    @staticmethod
-    def _calc_feature_summary(columns: list[dict[str, Any]]) -> dict[str, int]:
-        """Calculate feature summary counts."""
-        active = [c for c in columns if not c.get("excluded", False)]
-        excluded = [c for c in columns if c.get("excluded", False)]
-        return {
-            "total": len(active),
-            "numeric": sum(1 for c in active if c.get("col_type") == "numeric"),
-            "categorical": sum(1 for c in active if c.get("col_type") == "categorical"),
-            "excluded": len(excluded),
-            "excluded_id": sum(1 for c in excluded if c.get("exclude_reason") == "id"),
-            "excluded_const": sum(1 for c in excluded if c.get("exclude_reason") == "constant"),
-            "excluded_manual": sum(1 for c in excluded if c.get("exclude_reason") is None),
         }

--- a/src/lizyml_widget/service_columns.py
+++ b/src/lizyml_widget/service_columns.py
@@ -1,0 +1,119 @@
+"""Column auto-detection helpers for WidgetService.
+
+Pure functions extracted from service.py (#137) so the service module
+stays under the 800-line ceiling. The helpers operate on plain dicts /
+DataFrames and have no dependency on WidgetService internal state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def detect_task(col: pd.Series[Any], n_rows: int, n_unique: int) -> str:
+    """Auto-detect task type from a target column."""
+    if n_unique == 2:
+        return "binary"
+    if str(col.dtype) in ("object", "str", "string", "category"):
+        return "multiclass"
+    if pd.api.types.is_numeric_dtype(col):
+        threshold = max(20, int(n_rows * 0.05))
+        if n_unique <= threshold:
+            return "multiclass"
+        return "regression"
+    return "multiclass"
+
+
+def auto_configure_column(
+    col_info: dict[str, Any], n_rows: int, df: pd.DataFrame | None
+) -> dict[str, Any]:
+    """Auto-configure a single column (exclusion + type)."""
+    name = col_info["name"]
+    dtype = col_info["dtype"]
+    unique = col_info["unique_count"]
+
+    excluded = False
+    exclude_reason: str | None = None
+    col_type = "numeric"
+
+    is_float = dtype.startswith("float") or dtype.startswith("Float")
+    if unique == n_rows and not is_float:
+        excluded = True
+        exclude_reason = "id"
+    elif unique == 1:
+        excluded = True
+        exclude_reason = "constant"
+
+    if dtype in ("object", "str", "string", "category", "bool"):
+        col_type = "categorical"
+    elif df is not None and pd.api.types.is_numeric_dtype(df[name]):
+        threshold = max(20, int(n_rows * 0.05))
+        if unique <= threshold:
+            col_type = "categorical"
+
+    return {
+        **col_info,
+        "suggested_type": col_type,
+        "suggested_excluded": excluded,
+        "exclude_reason": exclude_reason,
+        "excluded": excluded,
+        "col_type": col_type,
+    }
+
+
+def calc_feature_summary(columns: list[dict[str, Any]]) -> dict[str, int]:
+    """Calculate feature summary counts (active vs excluded breakdown)."""
+    active = [c for c in columns if not c.get("excluded", False)]
+    excluded = [c for c in columns if c.get("excluded", False)]
+    return {
+        "total": len(active),
+        "numeric": sum(1 for c in active if c.get("col_type") == "numeric"),
+        "categorical": sum(1 for c in active if c.get("col_type") == "categorical"),
+        "excluded": len(excluded),
+        "excluded_id": sum(1 for c in excluded if c.get("exclude_reason") == "id"),
+        "excluded_const": sum(1 for c in excluded if c.get("exclude_reason") == "constant"),
+        "excluded_manual": sum(1 for c in excluded if c.get("exclude_reason") is None),
+    }
+
+
+def merge_best_params_into_config(
+    base: dict[str, Any],
+    *,
+    model_p: dict[str, Any],
+    smart_p: dict[str, Any],
+    training_p: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge classified best_params into a base config (immutable update).
+
+    Used by ``WidgetService.apply_best_params`` after classification.
+    """
+    base = {k: v for k, v in base.items() if k != "tuning"}
+
+    model_section = dict(base.get("model", {}))
+    model_params = {**dict(model_section.get("params", {})), **model_p}
+    model_section = {**model_section, "params": model_params}
+
+    base = {**base, "model": {**model_section, **smart_p}}
+
+    if training_p:
+        training = dict(base.get("training", {}))
+        es = dict(training.get("early_stopping", {}))
+        es_updates: dict[str, Any] = {}
+        if "early_stopping_rounds" in training_p:
+            es_updates["rounds"] = training_p["early_stopping_rounds"]
+        if "validation_ratio" in training_p:
+            existing_iv = es.get("inner_valid")
+            if isinstance(existing_iv, dict):
+                es_updates["inner_valid"] = {
+                    **existing_iv,
+                    "ratio": training_p["validation_ratio"],
+                }
+            else:
+                es_updates["validation_ratio"] = training_p["validation_ratio"]
+                es_updates["inner_valid"] = None
+        new_es = {**es, **es_updates}
+        base = {**base, "training": {**training, "early_stopping": new_es}}
+
+    return base

--- a/src/lizyml_widget/service_cv.py
+++ b/src/lizyml_widget/service_cv.py
@@ -1,0 +1,198 @@
+"""Cross-validation helpers for WidgetService.
+
+Pure functions extracted from service.py to keep the service module under
+the 800-line ceiling (#137). These helpers operate on plain dicts /
+DataFrames; they have no dependency on WidgetService's internal state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+
+_log = logging.getLogger(__name__)
+
+GROUP_STRATEGIES: frozenset[str] = frozenset(
+    {"group_kfold", "stratified_group_kfold", "group_time_series", "blocked_group_kfold"}
+)
+TIME_STRATEGIES: frozenset[str] = frozenset(
+    {"time_series", "purged_time_series", "group_time_series"}
+)
+
+
+def validate_inner_valid(config: dict[str, Any], df_info: dict[str, Any]) -> list[dict[str, Any]]:
+    """Check inner_valid method is compatible with the active CV strategy.
+
+    Returns a list of validation-error dicts (empty when compatible).
+    """
+    training = config.get("training") or {}
+    early_stopping = training.get("early_stopping") or {}
+    inner_valid = early_stopping.get("inner_valid") or {}
+    method = inner_valid.get("method", "holdout") if isinstance(inner_valid, dict) else inner_valid
+
+    cv = df_info.get("cv") or {}
+    strategy = cv.get("strategy", "kfold")
+    errors: list[dict[str, Any]] = []
+
+    if method == "group_holdout" and strategy not in GROUP_STRATEGIES:
+        errors.append(
+            {
+                "field": "training.early_stopping.inner_valid.method",
+                "message": (
+                    "group_holdout requires a group-based CV strategy "
+                    "(e.g. group_kfold, stratified_group_kfold, group_time_series)."
+                ),
+                "type": "inner_valid_constraint",
+            }
+        )
+    elif method == "time_holdout" and strategy not in TIME_STRATEGIES:
+        errors.append(
+            {
+                "field": "training.early_stopping.inner_valid.method",
+                "message": (
+                    "time_holdout requires a time-based CV strategy "
+                    "(e.g. time_series, purged_time_series, group_time_series)."
+                ),
+                "type": "inner_valid_constraint",
+            }
+        )
+
+    return errors
+
+
+def default_strategy_for_task(adapter: Any, task: str) -> str:
+    """Resolve the default CV strategy for *task* via the adapter contract."""
+    try:
+        contract = adapter.get_backend_contract()
+        defaults = contract.capabilities.get("cv_default_strategy", {})
+        if task in defaults:
+            return str(defaults[task])
+    except (AttributeError, KeyError, TypeError) as exc:
+        _log.debug("cv_default_strategy contract read failed: %s", exc)
+    return "stratified_kfold" if task in ("binary", "multiclass") else "kfold"
+
+
+def default_cv_state(adapter: Any, *, strategy: str, n_splits: int) -> dict[str, Any]:
+    """Build a default CV state dict, reading defaults from the adapter contract."""
+    cv_defaults: dict[str, Any] = {}
+    try:
+        contract = adapter.get_backend_contract()
+        cv_defaults = contract.capabilities.get("cv_defaults", {})
+    except (AttributeError, KeyError, TypeError) as exc:
+        _log.debug("cv_defaults contract read failed: %s", exc)
+
+    return {
+        "strategy": strategy,
+        "n_splits": n_splits,
+        "group_column": None,
+        "time_column": None,
+        "random_state": cv_defaults.get("random_state", 42),
+        "shuffle": cv_defaults.get("shuffle", True),
+        "gap": cv_defaults.get("gap", 0),
+        "purge_gap": 0,
+        "embargo": 0,
+        "train_size_max": None,
+        "test_size_max": None,
+    }
+
+
+def compute_preview_splits(df: pd.DataFrame, df_info: dict[str, Any]) -> dict[str, Any]:
+    """Estimate fold structure for the ``blocked_group_kfold`` CV strategy.
+
+    Reads ``df_info["cv"]`` for blocks/groups configuration and computes the
+    expected fold layout, including per-period row counts.
+
+    Raises
+    ------
+    ValueError
+        If the active CV strategy is not ``blocked_group_kfold``.
+    """
+    cv = df_info.get("cv", {})
+    if cv.get("strategy") != "blocked_group_kfold":
+        msg = "preview_splits only supports strategy='blocked_group_kfold'"
+        raise ValueError(msg)
+
+    blocks_cfg: dict[str, Any] = cv.get("blocks") or {}
+    groups_cfg: dict[str, Any] = cv.get("groups") or {}
+
+    blocks_col: str = blocks_cfg.get("col", "")
+    mode: str = blocks_cfg.get("mode", "expanding")
+    train_window: int | None = blocks_cfg.get("train_window")
+    group_folds: int = int(groups_cfg.get("n_splits", cv.get("n_splits", 2)))
+
+    if blocks_col and blocks_col in df.columns:
+        periods: list[str] = sorted(df[blocks_col].dropna().unique().tolist(), key=str)
+    else:
+        periods = []
+
+    num_periods = len(periods)
+    time_folds = max(0, num_periods - 1)
+    total_folds = time_folds * group_folds
+
+    period_counts: dict[str, int] = {}
+    if blocks_col and blocks_col in df.columns:
+        vc = df[blocks_col].value_counts()
+        period_counts = {str(k): int(v) for k, v in vc.items()}
+
+    cutoffs: list[Any] = blocks_cfg.get("cutoffs", [])
+    if cutoffs and blocks_col and blocks_col in df.columns:
+        sorted_values = sorted(df[blocks_col].dropna().unique().tolist(), key=str)
+        grouped_periods: list[list[Any]] = []
+        current_group: list[Any] = []
+        cutoff_idx = 0
+        for v in sorted_values:
+            if cutoff_idx < len(cutoffs) and str(v) >= str(cutoffs[cutoff_idx]):
+                if current_group:
+                    grouped_periods.append(current_group)
+                current_group = []
+                cutoff_idx += 1
+            current_group.append(v)
+        if current_group:
+            grouped_periods.append(current_group)
+        periods = [str(gp[0]) if len(gp) == 1 else f"{gp[0]}..{gp[-1]}" for gp in grouped_periods]
+        grouped_counts: dict[str, int] = {}
+        for gp, label in zip(grouped_periods, periods, strict=True):
+            grouped_counts[label] = sum(period_counts.get(str(v), 0) for v in gp)
+        period_counts = grouped_counts
+        num_periods = len(periods)
+        time_folds = max(0, num_periods - 1)
+        total_folds = time_folds * group_folds
+
+    folds: list[dict[str, Any]] = []
+    fold_index = 0
+    for t in range(time_folds):
+        valid_period = periods[t + 1]
+        if mode == "sliding" and train_window is not None:
+            start = max(0, t + 1 - train_window)
+            train_periods_list = periods[start : t + 1]
+        else:
+            train_periods_list = periods[: t + 1]
+
+        train_rows = sum(period_counts.get(str(p), 0) for p in train_periods_list)
+        valid_rows = period_counts.get(str(valid_period), 0)
+
+        period_label = " + ".join(str(p) for p in train_periods_list) + " -> " + str(valid_period)
+
+        for group_idx in range(group_folds):
+            folds.append(
+                {
+                    "fold": fold_index,
+                    "period_label": period_label,
+                    "group_label": f"G{group_idx}",
+                    "train_size": train_rows,
+                    "valid_size": valid_rows,
+                    "train_periods": list(train_periods_list),
+                    "valid_period": valid_period,
+                }
+            )
+            fold_index += 1
+
+    return {
+        "total_folds": total_folds,
+        "time_folds": time_folds,
+        "group_folds": group_folds,
+        "periods": periods,
+        "folds": folds,
+    }


### PR DESCRIPTION
Closes #137 (Phase 1.3 of #143).

## Summary

Both core modules now sit below the CLAUDE.md §8 800-line ceiling:

| File | Before | After |
|---|---|---|
| `service.py` | 1019 | **790** |
| `adapter.py` | 1107 | **761** |

## Strategy: composition, not inheritance

Pure stateless helpers extracted as module-level functions; class methods became thin delegators. `LizyMLAdapter` keeps backward-compatible `staticmethod` aliases for the seven helper names tests historically called via the class.

### `service.py` → 2 new files

- `service_cv.py` (198 lines) — `compute_preview_splits`, `validate_inner_valid`, `default_strategy_for_task`, `default_cv_state`, `GROUP_STRATEGIES` / `TIME_STRATEGIES` constants.
- `service_columns.py` (119 lines) — `detect_task`, `auto_configure_column`, `calc_feature_summary`, `merge_best_params_into_config`.

### `adapter.py` → 2 new files

- `adapter_internals.py` (268 lines) — version guard (`LIZYML_MIN/MAX_VERSION`, `_check_lizyml_version`, `_parse_lizyml_version`), `_serialize_trials` / `_serialize_rounds` / `_serialize_boundary_report`, `deep_merge`, `get_nested` / `set_nested` / `unset_nested`, `extract_defaults`, `convert_metric_entries`, `enforce_auto_num_leaves`.
- `adapter_results.py` (160 lines) — `render_plot`, `list_available_plots`, `render_inference_plot`, `task_for_model`.

Re-exports keep `from lizyml_widget.adapter import LIZYML_MIN_VERSION, _serialize_trials, …` working for existing tests.

## Quality gates

- `uv run pytest` — **928 passed**
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — 18 files already formatted
- `uv run mypy --no-incremental src/lizyml_widget/` — `Success: no issues found in 19 source files`

## Public API / behavior

Unchanged. No traitlet, contract, Protocol, or DTO touched. Refactor only.

## Test plan

- [x] Full pytest suite (928 tests) green locally
- [x] `LizyMLAdapter._enforce_auto_num_leaves`, `._extract_defaults`, etc. still callable via class (verified by `tests/test_adapter_config.py`)
- [x] `from lizyml_widget.adapter import _serialize_*, _check_lizyml_version, LIZYML_MIN_VERSION` still works (verified by `tests/test_retune_monitoring.py`)
- [x] CI to verify on push (ruff + mypy + pytest + JS)
