### PR TITLE
feat(types,service): move tune snapshots into TuningSummary (#132, P-035)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -95,7 +95,7 @@ Widget は LizyML の型・契約（`BackendAdapter` Protocol, `TuningResult`, `
 | レイヤー | 場所 | 責務 | 禁止事項 |
 |---------|------|------|---------|
 | **UI** | `js/src/` | `backend_contract` / `config` / `df_info` を描画し、ユーザー操作を `action` に変換する。ローカル状態は表示都合（例: Search Space の Mode）に限定する | ML ロジック・Python 直接呼び出し・backend 固有 option set / parameter catalog / step 値のハードコード・full config dict の合成 |
-| **Widget** | `src/lizyml_widget/widget.py` | traitlets 定義・Action 処理・スレッド管理・`msg:custom` 中継 | ML ロジック直接記述、Service の private 状態参照、backend 固有 config 意味論の保持 |
+| **Widget** | `src/lizyml_widget/widget.py` | traitlets 定義・Action 処理・スレッド管理・`msg:custom` 中継 | ML ロジック直接記述、Service の private 状態参照、backend 固有 config 意味論の保持、ジョブ実行時の時系列スナップショット保持（P-035 で `_tune_*_snapshot` を Service の `_last_tune_summary` へ移管済み）|
 | **Service** | `src/lizyml_widget/service.py` | Data タブ由来 state（target / task / columns / CV）の管理、実行前提判定、Adapter 呼び出し調整、canonical config と Data 系 state の結合 | バックエンド固有の default / option set / search space catalog / step 定数の保持 |
 | **Adapter** | `src/lizyml_widget/adapter.py` | Backend Contract 提供、backend 固有 config default / patch 適用 / 実行前準備、バックエンドライブラリ呼び出し、共通型への変換 | Widget / traitlets の知識 |
 
@@ -150,6 +150,9 @@ class TuningSummary:
     # ── P-027: re-tune monitoring（lizyml>=0.9.0 必須） ──
     rounds: list[dict[str, Any]]  # per-round summary (round, n_trials, best_score_before/after, expanded_dims)
     boundary_report: dict[str, Any] | None  # BoundaryReport のシリアライズ、無ければ None
+    # ── P-035: post-tune snapshots（apply_best_params の入力源） ──
+    config_snapshot: dict[str, Any]  # canonical run config（Service が prepare_run_config 後に詰める）
+    ui_snapshot: dict[str, Any]      # widget config traitlet のスナップショット（calibration 等の復元用）
 
 @dataclass
 class PredictionSummary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **TuningSummary owns post-tune snapshots (P-035)**
+  ([#132](https://github.com/nbx-liz/LizyML-Widget/issues/132)).
+  ``TuningSummary`` gains two new fields — ``config_snapshot`` (canonical
+  run config) and ``ui_snapshot`` (widget ``config`` traitlet at tune
+  time) — so post-tune Apply-to-Fit no longer relies on Widget-side
+  ``_tune_config_snapshot`` / ``_tune_ui_snapshot`` private attributes
+  (CLAUDE.md §4 violation removed). ``WidgetService`` keeps the latest
+  ``TuningSummary`` in ``_last_tune_summary``; ``apply_best_params``
+  now reads snapshots from there. ``load_data`` invalidates a prior
+  summary explicitly so a stale-on-new-data Apply fails fast with
+  ``ValueError("tune summary cleared by load …")`` instead of silently
+  rebuilding from a snapshot pinned to the old DataFrame.
+  ``JobSpec.ui_snapshot`` carries the snapshot through both
+  ``ThreadJobRunner`` and ``SubprocessJobRunner`` (the latter calls a
+  new ``WidgetService.record_subprocess_tune_summary`` because the
+  child process cannot share Python objects with the parent).
+
+### Removed
+- ``LizyWidget._tune_config_snapshot`` / ``LizyWidget._tune_ui_snapshot``
+  attributes (P-035 — replaced by Service-owned ``_last_tune_summary``).
+- ``WidgetService.apply_best_params(params, current_config, *, tune_snapshot=...,
+  tune_ui_snapshot=...)`` kwargs. The public signature is now just
+  ``apply_best_params(params, current_config)``; tests that exercised
+  the snapshot path now seed ``service._last_tune_summary`` directly.
+
+### Changed
 - **service.py / adapter.py file-size split**
   ([#137](https://github.com/nbx-liz/LizyML-Widget/issues/137)).
   Both core modules now sit below the CLAUDE.md §8 < 800-line ceiling.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-035: TuningSummary に config_snapshot / ui_snapshot を追加
 
-- **日付**: 2026-05-08
-- **ステータス**: 提案
+- **日付**: 2026-05-08（提案）/ 2026-05-09（決定・実装）
+- **ステータス**: 決定（実装済み — PR #132 → develop）
 - **関連 Issue**: [#132](https://github.com/nbx-liz/LizyML-Widget/issues/132)
 - **背景**:
   - 現状、`LizyWidget` は `_tune_config_snapshot` / `_tune_ui_snapshot` の 2 個の
@@ -62,6 +62,22 @@
     再構築するのではなく明示エラー（"tune summary cleared by load"）を返す。
   - 既存 `tests/test_widget_actions.py::test_apply_best_params_*` が引き続き green。
   - `mypy --strict` 通過。
+- **実装ノート（2026-05-09）**:
+  - `TuningSummary` に `config_snapshot` / `ui_snapshot` を追加（dataclass のため
+    `default_factory=dict` で後方互換）。
+  - `WidgetService.tune` は新しく `ui_snapshot=` kwarg を受け取り、Adapter 結果を
+    `dataclasses.replace` で `config_snapshot` / `ui_snapshot` 入りに差し替えて
+    `_last_tune_summary` に格納する（Service 内 lock 配下）。
+  - `Service.apply_best_params` は `tune_snapshot=` / `tune_ui_snapshot=` の kwarg を
+    完全削除。`_last_tune_summary` がなければ `current_config` ベース、
+    `load_data` 後の stale 状態では `ValueError("tune summary cleared by load …")` を発火。
+  - `JobSpec.ui_snapshot` を新設し、Widget の `_run_job` で
+    `copy.deepcopy(dict(self.config))` を tune ジョブのみ詰める。
+  - `SubprocessJobRunner` は `service.record_subprocess_tune_summary(...)` 経由で
+    親プロセス側 Service に TuningSummary を再構築する（subprocess 経路は別 process なので
+    `service.tune` 側で記録できないため）。
+  - `LizyWidget.__init__` から `_tune_config_snapshot` / `_tune_ui_snapshot` を削除、
+    `WidgetActionDispatcher.handle_apply_best_params` も簡素化（snapshot 受け渡しなし）。
 
 ---
 

--- a/src/lizyml_widget/job_runner.py
+++ b/src/lizyml_widget/job_runner.py
@@ -59,11 +59,16 @@ class JobSpec:
     it to the selected runner. Snapshotting ``config`` and
     ``retune_kwargs`` per-spec eliminates the cross-thread state handoff
     that the P-028 HIGH-2 review fix originally addressed.
+
+    P-035: ``ui_snapshot`` carries the widget-side ``config`` traitlet at
+    job-start time, so tune jobs can land snapshots inside the
+    ``TuningSummary`` returned to the supervisor.
     """
 
     job_type: str
     config: dict[str, Any]
     retune_kwargs: dict[str, Any] | None = None
+    ui_snapshot: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -174,7 +179,12 @@ class ThreadJobRunner:
             else f"Tuning {n_trials} trials..."
         )
         on_progress(0, n_trials, msg, round=initial_round)
-        summary_t = self._service.tune(spec.config, on_progress=on_progress, **tune_kwargs)
+        summary_t = self._service.tune(
+            spec.config,
+            ui_snapshot=spec.ui_snapshot,
+            on_progress=on_progress,
+            **tune_kwargs,
+        )
         tune_summary = {
             "best_params": summary_t.best_params,
             "best_score": summary_t.best_score,
@@ -265,6 +275,16 @@ class SubprocessJobRunner:
                     self._service.load_model_from_path(sp_result.model_path)
                 except Exception as load_err:  # noqa: BLE001
                     _log.warning("Model load from subprocess failed: %s", load_err)
+
+            # P-035: subprocess tune does not populate parent-side
+            # ``_last_tune_summary`` automatically; reconstruct it on the
+            # parent so ``apply_best_params`` works.
+            if spec.job_type == "tune" and sp_result.tune_summary:
+                self._service.record_subprocess_tune_summary(
+                    sp_result.tune_summary,
+                    config_snapshot=spec.config,
+                    ui_snapshot=spec.ui_snapshot,
+                )
 
             return JobResult(
                 job_type=spec.job_type,

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -60,6 +60,13 @@ class WidgetService:
         # resume path needs.
         self._tune_model: Any = None
         self._model_lock = threading.Lock()
+        # P-035: latest TuningSummary, owned by Service so the Widget no
+        # longer holds time-series snapshots. Cleared by load_data; the
+        # ``_tune_summary_invalidated_by_load`` flag distinguishes
+        # "never tuned" (None, no flag) from "tuned then load wiped it"
+        # (None, flag) so apply_best_params can fail loud in the latter.
+        self._last_tune_summary: TuningSummary | None = None
+        self._tune_summary_invalidated_by_load: bool = False
 
     @property
     def info(self) -> BackendInfo:
@@ -81,6 +88,13 @@ class WidgetService:
         with self._model_lock:
             self._model = None
             self._tune_model = None
+            # P-035: any prior TuningSummary becomes stale because the data
+            # changed; flag it so apply_best_params fails loud rather than
+            # silently rebuilding from a snapshot pinned to the old data.
+            had_summary = self._last_tune_summary is not None
+            self._last_tune_summary = None
+            if had_summary:
+                self._tune_summary_invalidated_by_load = True
 
         columns: list[dict[str, Any]] = []
         for col in df.columns:
@@ -499,6 +513,7 @@ class WidgetService:
         self,
         config: dict[str, Any],
         *,
+        ui_snapshot: dict[str, Any] | None = None,
         on_progress: Callable[..., Any] | None = None,
         resume: bool = False,
         n_trials: int | None = None,
@@ -548,12 +563,55 @@ class WidgetService:
             expand_boundary=expand_boundary,
             boundary_threshold=boundary_threshold,
         )
+        # P-035: embed snapshots into the TuningSummary so apply_best_params
+        # can rebuild the post-tune Fit config without the Widget keeping
+        # private snapshot attributes.
+        from dataclasses import replace
+
+        summary = replace(
+            result,
+            config_snapshot=copy.deepcopy(config),
+            ui_snapshot=copy.deepcopy(ui_snapshot or {}),
+        )
         with self._model_lock:
             self._model = model
             # Record this as the reference tune model so subsequent retune()
             # calls (even after an intervening fit()) resume *this* study.
             self._tune_model = model
-        return result
+            self._last_tune_summary = summary
+            # A fresh tune always supersedes a prior load-invalidated one.
+            self._tune_summary_invalidated_by_load = False
+        return summary
+
+    def record_subprocess_tune_summary(
+        self,
+        tune_dict: dict[str, Any],
+        *,
+        config_snapshot: dict[str, Any],
+        ui_snapshot: dict[str, Any] | None,
+    ) -> None:
+        """Reconstruct and store a ``TuningSummary`` from a subprocess result.
+
+        Subprocess tune runs cannot share Python objects with the parent;
+        the parent receives the result as a dict (P-029 boundary). This
+        helper reconstructs a typed ``TuningSummary`` on the parent side
+        so ``apply_best_params`` continues to work on the same Service
+        instance the user interacts with via ``LizyWidget``.
+        """
+        summary = TuningSummary(
+            best_params=tune_dict.get("best_params", {}),
+            best_score=tune_dict.get("best_score", 0.0),
+            trials=tune_dict.get("trials", []),
+            metric_name=tune_dict.get("metric_name", ""),
+            direction=tune_dict.get("direction", "maximize"),
+            rounds=tune_dict.get("rounds", []),
+            boundary_report=tune_dict.get("boundary_report"),
+            config_snapshot=copy.deepcopy(config_snapshot),
+            ui_snapshot=copy.deepcopy(ui_snapshot or {}),
+        )
+        with self._model_lock:
+            self._last_tune_summary = summary
+            self._tune_summary_invalidated_by_load = False
 
     def predict(self, data: pd.DataFrame, *, return_shap: bool = False) -> PredictionSummary:
         """Run prediction on new data."""
@@ -624,29 +682,41 @@ class WidgetService:
         self,
         params: dict[str, Any],
         current_config: dict[str, Any],
-        *,
-        tune_snapshot: dict[str, Any] | None = None,
-        tune_ui_snapshot: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Apply best_params from Tune to config, routing by category.
 
+        P-035: snapshot inputs are no longer accepted; the Service reads
+        ``config_snapshot`` and ``ui_snapshot`` from its own
+        ``_last_tune_summary`` (set by :meth:`tune`).
+
         Returns a canonicalized config with best params applied.
 
-        Uses *tune_snapshot* (the backend-ready run config) as the
-        authoritative base for ``model.params`` and ``training``, and
-        *tune_ui_snapshot* to recover calibration (stripped by
-        ``prepare_tune_overrides``) and smart params from older snapshots
-        that were generated before the smart-params-preservation fix.
+        Raises
+        ------
+        ValueError
+            If a prior tune ran but ``load_data`` invalidated its summary
+            (apply on stale data is rejected explicitly rather than
+            silently rebuilding from a snapshot pinned to the old data).
         """
         if not params:
             return self.canonicalize_config(copy.deepcopy(current_config))
 
+        if self._tune_summary_invalidated_by_load:
+            msg = (
+                "tune summary cleared by load — re-run w.tune() "
+                "before applying best params on the new data."
+            )
+            raise ValueError(msg)
+
+        with self._model_lock:
+            summary = self._last_tune_summary
+
         # 1. Choose base config from run snapshot, stripping Service-managed
         #    keys that are re-injected by build_config at execution time.
-        if tune_snapshot is not None:
+        if summary is not None and summary.config_snapshot:
             base = {
                 k: v
-                for k, v in copy.deepcopy(tune_snapshot).items()
+                for k, v in copy.deepcopy(summary.config_snapshot).items()
                 if k not in self._DATA_SECTION_KEYS
             }
         else:
@@ -656,8 +726,8 @@ class WidgetService:
         #    prepare_tune_overrides strips only calibration.  Smart params are
         #    now preserved in new snapshots, but older snapshots (generated
         #    before this fix) may still lack them — back-fill from UI snapshot.
-        if tune_ui_snapshot is not None:
-            ui = copy.deepcopy(tune_ui_snapshot)
+        if summary is not None and summary.ui_snapshot:
+            ui = copy.deepcopy(summary.ui_snapshot)
             ui_model = ui.get("model", {})
             base_model = base.get("model", {})
             for k, v in ui_model.items():

--- a/src/lizyml_widget/types.py
+++ b/src/lizyml_widget/types.py
@@ -51,6 +51,12 @@ class TuningSummary:
     Fields ``rounds`` and ``boundary_report`` require lizyml>=0.9.0 (re-tune
     support, proposal P-027). For single-round tuning both collapse to a
     single-element ``rounds`` list and ``boundary_report=None``.
+
+    P-035: ``config_snapshot`` (canonical run config) and ``ui_snapshot``
+    (widget-side ``config`` traitlet at tune time) are populated by
+    ``WidgetService.tune`` so ``apply_best_params`` can rebuild the
+    post-tune Fit config without the Widget having to keep its own
+    private snapshot attributes.
     """
 
     best_params: dict[str, Any]
@@ -60,6 +66,8 @@ class TuningSummary:
     direction: str  # "minimize" | "maximize"
     rounds: list[dict[str, Any]] = field(default_factory=list)  # per-round summary
     boundary_report: dict[str, Any] | None = None  # None when no resume rounds ran
+    config_snapshot: dict[str, Any] = field(default_factory=dict)  # P-035: canonical run config
+    ui_snapshot: dict[str, Any] = field(default_factory=dict)  # P-035: widget config traitlet
 
 
 @dataclass

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -105,8 +105,9 @@ class LizyWidget(anywidget.AnyWidget):
         self._job_lock = threading.Lock()
         self._job_counter = 0
         self._inference_df: pd.DataFrame | None = None
-        self._tune_config_snapshot: dict[str, Any] | None = None
-        self._tune_ui_snapshot: dict[str, Any] | None = None
+        # P-035: tune snapshots now live on TuningSummary inside
+        # WidgetService, not on the widget. Removed _tune_config_snapshot
+        # and _tune_ui_snapshot.
         # #127: action handlers extracted to widget_actions.WidgetActionDispatcher.
         # The dispatcher holds a back-reference to this widget and reads/writes
         # traitlets through it; widget owns the state machine, dispatcher owns
@@ -548,9 +549,11 @@ class LizyWidget(anywidget.AnyWidget):
                 self.status = "failed"
                 return
 
-            if job_type == "tune":
-                self._tune_config_snapshot = copy.deepcopy(full_config)
-                self._tune_ui_snapshot = copy.deepcopy(dict(self.config))
+            # P-035: tune snapshots are now carried inside TuningSummary
+            # via JobSpec.ui_snapshot → service.tune (or
+            # service.record_subprocess_tune_summary for the subprocess
+            # path). The widget no longer keeps private snapshot attrs.
+            tune_ui_snapshot = copy.deepcopy(dict(self.config)) if job_type == "tune" else None
 
             # INV-D (BLUEPRINT §6.4): cancel flag is cleared exactly once
             # per job at startup; the worker / supervisor never write it
@@ -597,6 +600,7 @@ class LizyWidget(anywidget.AnyWidget):
             job_type=job_type,
             config=full_config,
             retune_kwargs=retune_kwargs,
+            ui_snapshot=tune_ui_snapshot,
         )
         thread = threading.Thread(
             target=self._supervise,

--- a/src/lizyml_widget/widget_actions.py
+++ b/src/lizyml_widget/widget_actions.py
@@ -12,7 +12,6 @@ State-machine transitions still live in ``widget.py::_supervise`` /
 from __future__ import annotations
 
 import contextlib
-import copy
 import logging
 import os
 import re
@@ -442,20 +441,14 @@ class WidgetActionDispatcher:
             }
 
     def handle_apply_best_params(self, payload: dict[str, Any]) -> None:
+        # P-035: snapshots are owned by Service via _last_tune_summary;
+        # widget no longer holds _tune_config_snapshot / _tune_ui_snapshot.
         w = self._widget
         params = payload.get("params", {})
         if not params:
             return
-        with w._job_lock:
-            snapshot = copy.deepcopy(w._tune_config_snapshot) if w._tune_config_snapshot else None
-            ui_snapshot = copy.deepcopy(w._tune_ui_snapshot) if w._tune_ui_snapshot else None
         try:
-            w.config = self._service.apply_best_params(
-                params,
-                dict(w.config),
-                tune_snapshot=snapshot,
-                tune_ui_snapshot=ui_snapshot,
-            )
+            w.config = self._service.apply_best_params(params, dict(w.config))
         except Exception as e:
             w.error = {"code": "APPLY_ERROR", "message": str(e)}
 

--- a/tests/test_config_generation_bugs.py
+++ b/tests/test_config_generation_bugs.py
@@ -277,11 +277,10 @@ class TestBug2DualSnapshot:
                 },
                 "training": {"seed": 42, "early_stopping": {"rounds": 100}},
             }
+            _seed_tune_summary(service, run_snapshot, ui_snapshot=ui_config)
             result = service.apply_best_params(
                 {"learning_rate": 0.05},
                 ui_config,
-                tune_snapshot=run_snapshot,
-                tune_ui_snapshot=ui_config,
             )
             model = result.get("model", {})
             assert model.get("auto_num_leaves") is True
@@ -307,11 +306,10 @@ class TestBug2DualSnapshot:
                 "model": {"name": "lgbm", "params": {"learning_rate": 0.001}},
                 "training": {"seed": 42, "early_stopping": {"rounds": 100}},
             }
+            _seed_tune_summary(service, run_snapshot, ui_snapshot=ui_config)
             result = service.apply_best_params(
                 {"learning_rate": 0.05},
                 ui_config,
-                tune_snapshot=run_snapshot,
-                tune_ui_snapshot=ui_config,
             )
             assert result.get("calibration") == {"method": "platt"}
 
@@ -410,11 +408,10 @@ class TestBug7TuneApplyFitConfigIdentity:
             }
 
             # Step 3: Apply best params (as Widget does)
+            _seed_tune_summary(service, tune_config, ui_snapshot=user_config)
             applied_config = service.apply_best_params(
                 best_params,
                 user_config,
-                tune_snapshot=tune_config,
-                tune_ui_snapshot=user_config,
             )
 
             # Step 4: Prepare fit config from applied result
@@ -532,11 +529,10 @@ class TestBug9InnerValidPathPreserved:
                     },
                 },
             }
+            _seed_tune_summary(service, tune_snapshot, ui_snapshot=user_config)
             result = service.apply_best_params(
                 {"validation_ratio": 0.25, "early_stopping_rounds": 80},
                 user_config,
-                tune_snapshot=tune_snapshot,
-                tune_ui_snapshot=user_config,
             )
             es = result.get("training", {}).get("early_stopping", {})
             iv = es.get("inner_valid")
@@ -553,3 +549,31 @@ class TestBug9InnerValidPathPreserved:
 def _make_service(adapter: LizyMLAdapter) -> WidgetService:
     """Create a WidgetService with the given adapter for testing."""
     return WidgetService(adapter=adapter)
+
+
+def _seed_tune_summary(
+    service: WidgetService,
+    config_snapshot: dict[str, Any],
+    *,
+    ui_snapshot: dict[str, Any] | None = None,
+) -> None:
+    """Inject a TuningSummary into the service to simulate a prior tune.
+
+    P-035: ``apply_best_params`` reads snapshots from
+    ``service._last_tune_summary`` instead of explicit kwargs. Tests that
+    exercise the snapshot path therefore seed the summary directly.
+    """
+    import copy as _copy
+
+    from lizyml_widget.types import TuningSummary
+
+    service._last_tune_summary = TuningSummary(
+        best_params={},
+        best_score=0.0,
+        trials=[],
+        metric_name="auc",
+        direction="maximize",
+        config_snapshot=_copy.deepcopy(config_snapshot),
+        ui_snapshot=_copy.deepcopy(ui_snapshot or {}),
+    )
+    service._tune_summary_invalidated_by_load = False

--- a/tests/test_retune_monitoring.py
+++ b/tests/test_retune_monitoring.py
@@ -332,7 +332,7 @@ class TestWidgetProgressTraitletRoundFields:
 
         w = self._make_widget()
 
-        def mock_tune(config: Any, *, on_progress: Any = None) -> Any:
+        def mock_tune(config: Any, *, on_progress: Any = None, **_kwargs: Any) -> Any:
             assert on_progress is not None
             # Simulate a re-tune round 2 progress update.
             on_progress(

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -11,7 +11,31 @@ import pytest
 
 from lizyml_widget.adapter import LizyMLAdapter
 from lizyml_widget.service import WidgetService
-from lizyml_widget.types import BackendInfo
+from lizyml_widget.types import BackendInfo, TuningSummary
+
+
+def _seed_tune_summary(
+    svc: WidgetService,
+    config_snapshot: dict[str, Any],
+    *,
+    ui_snapshot: dict[str, Any] | None = None,
+) -> None:
+    """Inject a TuningSummary into the service to simulate a prior tune.
+
+    P-035: ``apply_best_params`` reads snapshots from the service's
+    ``_last_tune_summary`` instead of explicit kwargs. Tests that exercise
+    the snapshot path therefore seed it directly.
+    """
+    svc._last_tune_summary = TuningSummary(
+        best_params={},
+        best_score=0.0,
+        trials=[],
+        metric_name="auc",
+        direction="maximize",
+        config_snapshot=copy.deepcopy(config_snapshot),
+        ui_snapshot=copy.deepcopy(ui_snapshot or {}),
+    )
+    svc._tune_summary_invalidated_by_load = False
 
 
 def _mock_adapter() -> Any:
@@ -46,9 +70,7 @@ class TestApplyBestParams:
         """Model-category params go to model.params."""
         svc = self._make_service()
         config = svc.initialize_config()
-        result = svc.apply_best_params(
-            {"learning_rate": 0.05, "max_depth": 7}, config, tune_snapshot=None
-        )
+        result = svc.apply_best_params({"learning_rate": 0.05, "max_depth": 7}, config)
         assert result["model"]["params"]["learning_rate"] == 0.05
         assert result["model"]["params"]["max_depth"] == 7
 
@@ -59,7 +81,6 @@ class TestApplyBestParams:
         result = svc.apply_best_params(
             {"num_leaves_ratio": 0.7, "min_data_in_leaf_ratio": 0.05},
             config,
-            tune_snapshot=None,
         )
         assert result["model"]["num_leaves_ratio"] == 0.7
         assert result["model"]["min_data_in_leaf_ratio"] == 0.05
@@ -73,7 +94,6 @@ class TestApplyBestParams:
         result = svc.apply_best_params(
             {"early_stopping_rounds": 80, "validation_ratio": 0.2},
             config,
-            tune_snapshot=None,
         )
         es = result.get("training", {}).get("early_stopping", {})
         assert es.get("rounds") == 80
@@ -88,7 +108,7 @@ class TestApplyBestParams:
         """When validation_ratio is applied and inner_valid exists, ratio is updated."""
         svc = self._make_service()
         config = svc.initialize_config()
-        result = svc.apply_best_params({"validation_ratio": 0.2}, config, tune_snapshot=None)
+        result = svc.apply_best_params({"validation_ratio": 0.2}, config)
         es = result.get("training", {}).get("early_stopping", {})
         iv = es.get("inner_valid")
         if iv is not None:
@@ -109,7 +129,6 @@ class TestApplyBestParams:
                 "early_stopping_rounds": 80,
             },
             config,
-            tune_snapshot=None,
         )
         assert result["model"]["params"]["learning_rate"] == 0.05
         assert result["model"]["num_leaves_ratio"] == 0.7
@@ -117,7 +136,7 @@ class TestApplyBestParams:
         assert es["rounds"] == 80
 
     def test_tune_snapshot_restored(self) -> None:
-        """When tune_snapshot is provided, it replaces current config."""
+        """When the service holds a TuningSummary, its snapshot replaces current config."""
         svc = self._make_service()
         config = svc.initialize_config()
         # Modify config (simulating user changes after tune)
@@ -126,8 +145,9 @@ class TestApplyBestParams:
         snapshot = copy.deepcopy(config)
         snapshot["model"]["params"]["n_estimators"] = 1500  # original value
         snapshot["evaluation"] = {"metrics": ["auc"]}
+        _seed_tune_summary(svc, snapshot)
 
-        result = svc.apply_best_params({"learning_rate": 0.01}, config, tune_snapshot=snapshot)
+        result = svc.apply_best_params({"learning_rate": 0.01}, config)
         # Should use snapshot, not current config
         assert result["model"]["params"]["n_estimators"] == 1500
         assert result["model"]["params"]["learning_rate"] == 0.01
@@ -142,18 +162,33 @@ class TestApplyBestParams:
         snapshot["features"] = {"exclude": []}
         snapshot["split"] = {"method": "kfold"}
         snapshot["task"] = "binary"
+        _seed_tune_summary(svc, snapshot)
 
-        result = svc.apply_best_params({"learning_rate": 0.01}, config, tune_snapshot=snapshot)
+        result = svc.apply_best_params({"learning_rate": 0.01}, config)
         assert "data" not in result
         assert "features" not in result
         assert "split" not in result
         assert "task" not in result
 
+    def test_apply_best_params_after_load_raises(self) -> None:
+        """P-035 acceptance: load() after tune invalidates the summary; apply must error."""
+        svc = self._make_service()
+        config = svc.initialize_config()
+        snapshot = copy.deepcopy(config)
+        _seed_tune_summary(svc, snapshot)
+
+        # Re-loading new data invalidates the summary deliberately.
+        df = pd.DataFrame({"x": range(50), "y": [0, 1] * 25})
+        svc.load_data(df, target="y")
+
+        with pytest.raises(ValueError, match="tune summary cleared by load"):
+            svc.apply_best_params({"learning_rate": 0.01}, config)
+
     def test_empty_params_returns_canonicalized(self) -> None:
         """Empty params should still return a valid canonicalized config."""
         svc = self._make_service()
         config = svc.initialize_config()
-        result = svc.apply_best_params({}, config, tune_snapshot=None)
+        result = svc.apply_best_params({}, config)
         assert "model" in result
         assert result["model"]["name"] == "lgbm"
 
@@ -162,7 +197,7 @@ class TestApplyBestParams:
         svc = self._make_service()
         config = svc.initialize_config()
         original = copy.deepcopy(config)
-        svc.apply_best_params({"learning_rate": 0.05}, config, tune_snapshot=None)
+        svc.apply_best_params({"learning_rate": 0.05}, config)
         assert config == original
 
     def test_wrong_arity_classify_raises(self) -> None:
@@ -173,7 +208,7 @@ class TestApplyBestParams:
             return_value=({"lr": 0.1}, {"ratio": 0.5})  # 2-tuple
         )
         with pytest.raises(ValueError):
-            svc.apply_best_params({"lr": 0.1}, config, tune_snapshot=None)
+            svc.apply_best_params({"lr": 0.1}, config)
 
 
 class TestServiceValidationGuards:

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -2,7 +2,8 @@
 
 C-1: _run_job TOCTOU guard — double invocation must not spawn two workers.
 C-2: WidgetService._model must be protected during concurrent access.
-C-3: _tune_config_snapshot read in apply_best_params must be safe.
+C-3 (P-035): WidgetService._last_tune_summary read in apply_best_params
+    must be safe — snapshots now live on TuningSummary inside the service.
 """
 
 from __future__ import annotations
@@ -181,15 +182,26 @@ class TestModelLock:
 
 
 class TestTuneConfigSnapshotProtection:
-    """C-3: _tune_config_snapshot should be safely read."""
+    """C-3 (P-035): apply_best_params reads ``_last_tune_summary`` safely."""
 
     def test_apply_best_params_reads_snapshot_safely(self) -> None:
-        """apply_best_params should read a consistent snapshot."""
+        """apply_best_params should read a consistent TuningSummary snapshot."""
+        from lizyml_widget.types import TuningSummary
+
         w = _make_widget()
         _load_data(w)
 
-        # Set a snapshot as if tune completed
-        w._tune_config_snapshot = {"model": {"params": {"learning_rate": 0.1}}}
+        # Seed a TuningSummary as if tune completed.
+        w._service._last_tune_summary = TuningSummary(
+            best_params={},
+            best_score=0.0,
+            trials=[],
+            metric_name="auc",
+            direction="maximize",
+            config_snapshot={"model": {"params": {"learning_rate": 0.1}}},
+            ui_snapshot={},
+        )
+        w._service._tune_summary_invalidated_by_load = False
 
         # apply_best_params should read the snapshot
         w._handle_apply_best_params({"params": {"learning_rate": 0.05}})

--- a/tests/test_widget_actions.py
+++ b/tests/test_widget_actions.py
@@ -440,8 +440,10 @@ class TestApplyBestParamsSnapshot:
     """Tests for Apply to Fit config snapshot restoration (P-005)."""
 
     def test_apply_best_params_restores_tune_snapshot(self) -> None:
-        """When tune snapshot exists, Apply to Fit restores it."""
+        """When the service holds a TuningSummary, Apply to Fit restores its snapshot."""
         import copy
+
+        from lizyml_widget.types import TuningSummary
 
         w = _make_widget()
         df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
@@ -458,7 +460,17 @@ class TestApplyBestParamsSnapshot:
             "split": {"method": "kfold"},
             "task": "binary",
         }
-        w._tune_config_snapshot = copy.deepcopy(snapshot)
+        # P-035: the snapshot now lives on the service's TuningSummary.
+        w._service._last_tune_summary = TuningSummary(
+            best_params={},
+            best_score=0.0,
+            trials=[],
+            metric_name="auc",
+            direction="maximize",
+            config_snapshot=copy.deepcopy(snapshot),
+            ui_snapshot={},
+        )
+        w._service._tune_summary_invalidated_by_load = False
 
         # Change config after tune
         w.config = {
@@ -483,6 +495,8 @@ class TestApplyBestParamsSnapshot:
         """Snapshot restoration should not include data/features/split/task."""
         import copy
 
+        from lizyml_widget.types import TuningSummary
+
         w = _make_widget()
         df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
         w.load(df, target="y")
@@ -494,7 +508,16 @@ class TestApplyBestParamsSnapshot:
             "split": {"method": "kfold"},
             "task": "binary",
         }
-        w._tune_config_snapshot = copy.deepcopy(snapshot)
+        w._service._last_tune_summary = TuningSummary(
+            best_params={},
+            best_score=0.0,
+            trials=[],
+            metric_name="auc",
+            direction="maximize",
+            config_snapshot=copy.deepcopy(snapshot),
+            ui_snapshot={},
+        )
+        w._service._tune_summary_invalidated_by_load = False
 
         w.action = {
             "type": "apply_best_params",

--- a/tests/test_widget_jobs.py
+++ b/tests/test_widget_jobs.py
@@ -67,7 +67,7 @@ class TestTuneProgress:
         df = pd.DataFrame({"x": [i % 10 for i in range(50)], "y": [0, 1] * 25})
         w.load(df, target="y")
 
-        def mock_tune(config: Any, *, on_progress: Any = None) -> Any:
+        def mock_tune(config: Any, *, on_progress: Any = None, **_kwargs: Any) -> Any:
             # Capture progress calls and return a mock summary
             return TuningSummary(
                 best_params={"lr": 0.01},


### PR DESCRIPTION
Closes #132 — implements P-035 (Phase 1.4 of #143).

## Summary

Removes the CLAUDE.md section 4 violation where `LizyWidget` kept private time-series job state (`_tune_config_snapshot` / `_tune_ui_snapshot`). Snapshots now live on the `TuningSummary` DTO inside `WidgetService._last_tune_summary` so apply-best-params draws from a typed, Service-owned source instead of two lock-coordinated widget attributes.

## What changed

| Layer | Before | After |
|---|---|---|
| `types.TuningSummary` | 7 fields | + `config_snapshot`, `ui_snapshot` (default `dict`) |
| `WidgetService.tune` | returns adapter result as-is | `replace(...)` to embed snapshots, store in `_last_tune_summary` |
| `WidgetService.apply_best_params` | `(params, current_config, *, tune_snapshot=None, tune_ui_snapshot=None)` | `(params, current_config)` — reads from `_last_tune_summary` |
| `WidgetService.load_data` | wipes `_model` + `_tune_model` | also clears `_last_tune_summary` and flips `_tune_summary_invalidated_by_load` so stale-on-new-data Apply fails fast |
| `JobSpec` | `(job_type, config, retune_kwargs)` | + `ui_snapshot` field |
| `ThreadJobRunner._run_tune` | `service.tune(spec.config, on_progress=...)` | also passes `ui_snapshot=spec.ui_snapshot` |
| `SubprocessJobRunner.run` | returns `JobResult` | also calls `service.record_subprocess_tune_summary(...)` for tune jobs (parent process can't share Python objects with the child) |
| `LizyWidget.__init__` | sets `_tune_config_snapshot` / `_tune_ui_snapshot` | both attributes deleted |
| `WidgetActionDispatcher.handle_apply_best_params` | reads widget snapshots under `_job_lock`, threads them through | one-liner: `service.apply_best_params(params, dict(w.config))` |

## Acceptance criterion test

P-035 explicitly asks: if `apply_best_params` runs after `load()` wiped the prior tune, fail loud rather than silently rebuilding from a stale snapshot.

New `tests/test_service_config.py::TestApplyBestParams::test_apply_best_params_after_load_raises`:

```python
_seed_tune_summary(svc, snapshot)
svc.load_data(df, target="y")  # invalidates the prior summary

with pytest.raises(ValueError, match="tune summary cleared by load"):
    svc.apply_best_params({"learning_rate": 0.01}, config)
```

## Quality gates

- `uv run pytest` — **929 passed** (was 928 + 1 new regression)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — 79 files already formatted
- `uv run mypy --no-incremental src/lizyml_widget/` — Success on 19 source files

## Backward compatibility

- Public Python API (`w.tune()`, `w.apply_best_params(...)`) unchanged.
- `TuningSummary(...)` callers don't need to pass the new fields (default `dict`).
- Snapshot-path tests now seed `service._last_tune_summary` directly via a `_seed_tune_summary` helper; this is internal-only and behaviour-preserving.

## BLUEPRINT / HISTORY / CHANGELOG

- HISTORY.md P-035 marked decided / implemented (implementation notes added).
- BLUEPRINT.md section 3.3.1 (`TuningSummary` shape) and section 3.2 (Widget responsibilities table) updated to mention the move.
- CHANGELOG.md `[Unreleased]` — Changed + Removed entries.

## Test plan

- [x] Full pytest suite locally green
- [x] Snapshot-path tests (`test_service_config.py::TestApplyBestParams`, `test_widget_actions.py::TestApplyBestParamsSnapshot`, `test_config_generation_bugs.py::TestBug2*`) updated and green
- [x] New regression: `test_apply_best_params_after_load_raises`
- [x] Subprocess path: `tests/test_subprocess_runner.py` still green (mock tune already accepts `**_`)
- [x] CI to verify on push (ruff + mypy + pytest + JS)
