### PR TITLE
feat(contract): expose ui_schema.defaults & step_map for JS UI (#131, P-034)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -797,6 +797,19 @@ Model タブは Fit サブタブと Tune サブタブで構成する（実装コ
 | Lambda L2 | `model.params.lambda_l2` | `0.0001` |
 | Early Stopping Rounds | `training.early_stopping.rounds` | `50` |
 | Validation Ratio | `training.early_stopping.validation_ratio` | `0.05` |
+| Feature Weights | `model.feature_weights[col]` | `0.1` | P-034 — Search Space / Feature Weights エディタの数値増減幅 |
+| Boundary Threshold | `RetuneControls.boundary_threshold` | `0.01` | P-034 — Re-tune の boundary expansion 閾値 step |
+
+`backend_contract.ui_schema.defaults` には JS UI の `??` フォールバックを廃止するための数値 default を保持する（P-034）:
+
+| グループ | キー | 初期値 | 用途 |
+|---------|------|--------|------|
+| `defaults.cv` | `n_splits` | `5` | KFold 系の初期 fold 数 |
+| `defaults.cv` | `random_state` | `42` | shuffle / split の seed |
+| `defaults.cv` | `gap` / `purge_gap` / `embargo` | `0` | TimeSeries 系の初期境界 |
+| `defaults.tune` | `n_trials` | `10` | Tune の初期試行回数 |
+| `defaults.metric_params` | `precision_at_k_k` | `10` | `precision_at_k` メトリクスの k 値 |
+| `defaults.calibration` | `{method: "isotonic", params: {}}` | — | Calibration セクションの初期値 |
 
 #### Fit サブタブ要件（初期 backend contract 例: LightGBM）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Backend contract owns UI numeric defaults and step values (P-034)**
+  ([#131](https://github.com/nbx-liz/LizyML-Widget/issues/131)).
+  ``ui_schema.defaults`` gains ``cv`` / ``tune`` / ``metric_params``
+  sub-dicts and ``ui_schema.step_map`` gains ``feature_weights`` /
+  ``boundary_threshold`` so the JS UI no longer falls back to hardcoded
+  literals (``n_splits ?? 5``, ``n_trials ?? 10``, ``random_state ?? 42``,
+  ``step={0.1}``, ``step={0.01}``, etc.). A backend default change now
+  propagates to the UI without a JS edit (CLAUDE.md §8). Affected JS
+  files: ``DataTab.tsx``, ``TuneSubTab.tsx``, ``SearchSpace.tsx``,
+  ``ModelEditors.tsx`` (new ``metricParamDefaults`` prop on
+  ``ModelSection`` / ``TypedParamsEditor``), ``RetuneControls.tsx``,
+  ``ResultsTab.tsx`` (forwards ``stepMap`` to ``RetuneControls``), and
+  ``App.tsx`` (passes ``stepMap`` from ``backend_contract``). New
+  ``TestContractNumericDefaultsAndStepMap`` golden test pins the new
+  contract shape.
+
+### Changed
 - **TuningSummary owns post-tune snapshots (P-035)**
   ([#132](https://github.com/nbx-liz/LizyML-Widget/issues/132)).
   ``TuningSummary`` gains two new fields — ``config_snapshot`` (canonical

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -83,8 +83,8 @@
 
 ### P-034: BackendContract に UI defaults / step_map を追加
 
-- **日付**: 2026-05-08
-- **ステータス**: 提案
+- **日付**: 2026-05-08（提案）/ 2026-05-09（決定・実装）
+- **ステータス**: 決定（実装済み — PR #131 → develop）
 - **関連 Issue**: [#131](https://github.com/nbx-liz/LizyML-Widget/issues/131)
 - **背景**:
   - PR #119 / #121 で JS から backend 固有 option set / parameter catalog をハードコードする
@@ -144,6 +144,16 @@
     すべてのファイルから消える（grep で残存 0）。
   - `pnpm test:coverage` の vitest threshold（statements 75% / branches 70%）を維持。
   - `js/src/__tests__/` で contract-driven レンダリング経路を最低 1 ケースずつ検証。
+- **実装ノート（2026-05-09）**:
+  - `adapter_contract.build_ui_schema` の `defaults` に `cv` / `tune` / `metric_params` を、
+    `step_map` に `feature_weights` / `boundary_threshold` を追加。`schema_version` は据え置き。
+  - JS では contract から読み出すための薄いヘルパ（`dN(key, fallback)` 等）を追加し、
+    fallback 数値は **fixture が contract を渡さないユニットテスト用のみ** 残した。
+  - 影響ファイル: `DataTab.tsx` / `TuneSubTab.tsx` / `SearchSpace.tsx` / `ModelEditors.tsx`
+    （`metricParamDefaults` prop を ModelSection→TypedParamsEditor で伝搬） /
+    `RetuneControls.tsx` / `ResultsTab.tsx` / `App.tsx`（`stepMap` を contract から RetuneControls へ伝搬）。
+  - ゴールデンテスト: `TestContractNumericDefaultsAndStepMap` を `tests/test_frontend_contract.py` に追加。
+  - 既存 vitest 274 件 / pytest 935 件すべて green、ruff + mypy strict クリーン。
 
 ---
 

--- a/js/src/App.tsx
+++ b/js/src/App.tsx
@@ -184,6 +184,7 @@ export function App({ model, rootEl }: AppProps) {
               setExportLoading(true);
               sendAction("export_code", {});
             }}
+            stepMap={backendContract?.ui_schema?.step_map ?? {}}
           />
         )}
       </div>

--- a/js/src/components/ModelEditors.tsx
+++ b/js/src/components/ModelEditors.tsx
@@ -50,6 +50,7 @@ function TypedParamsEditor({
   parameterHints,
   optionSets,
   stepMap,
+  metricParamDefaults,
   manualNumLeavesKey,
   manualNumLeavesDefault,
 }: {
@@ -60,11 +61,14 @@ function TypedParamsEditor({
   parameterHints: TypedParamMeta[];
   optionSets: Record<string, Record<string, string[]>>;
   stepMap: Record<string, number>;
+  /** P-034: numeric defaults for metric-related fields (precision_at_k_k etc.). */
+  metricParamDefaults?: Record<string, number>;
   /** Key for the manual leaf-count override (e.g. "num_leaves"); only rendered when defined. */
   manualNumLeavesKey?: string;
   /** Default leaf count used when toggle is off and value is unset. */
   manualNumLeavesDefault?: number;
 }) {
+  const defaultPrecisionAtK = metricParamDefaults?.precision_at_k_k ?? 10;
   const set = (k: string, v: any) => onChange({ ...value, [k]: v });
 
   return (
@@ -124,11 +128,11 @@ function TypedParamsEditor({
                 <div class="lzw-form-row">
                   <label class="lzw-label">precision_at_k: k</label>
                   <NumericStepper
-                    value={value._precision_at_k_k ?? 10}
+                    value={value._precision_at_k_k ?? defaultPrecisionAtK}
                     min={1}
                     max={100}
                     step={1}
-                    onChange={(v) => set("_precision_at_k_k", v ?? 10)}
+                    onChange={(v) => set("_precision_at_k_k", v ?? defaultPrecisionAtK)}
                   />
                 </div>
               )}
@@ -184,11 +188,14 @@ function FeatureWeightsEditor({
   value,
   onChange,
   columns,
+  stepMap,
 }: {
   value: Record<string, number> | null;
   onChange: (v: Record<string, number> | null) => void;
   columns: Array<{ name: string }>;
+  stepMap?: Record<string, number>;
 }) {
+  const featureWeightStep = stepMap?.feature_weights ?? 0.1;
   const enabled = value != null;
   const weights = value ?? {};
   const entries = Object.entries(weights);
@@ -231,7 +238,7 @@ function FeatureWeightsEditor({
               </select>
               <NumericStepper
                 value={w}
-                step={0.1}
+                step={featureWeightStep}
                 onChange={(v) => onChange({ ...weights, [col]: v ?? 1.0 })}
               />
               <button
@@ -343,6 +350,7 @@ export function ModelSection({
   parameterHints,
   optionSets,
   stepMap,
+  metricParamDefaults,
   columns,
   additionalParams,
   searchSpaceCatalog,
@@ -356,6 +364,8 @@ export function ModelSection({
   parameterHints: TypedParamMeta[];
   optionSets: Record<string, Record<string, string[]>>;
   stepMap: Record<string, number>;
+  /** P-034: metric-param numeric defaults (precision_at_k_k etc.) from contract. */
+  metricParamDefaults?: Record<string, number>;
   columns: Array<{ name: string }>;
   additionalParams: string[];
   /** search_space_catalog from backend ui_schema (optional; falls back to legacy literal set when absent). */
@@ -480,7 +490,7 @@ export function ModelSection({
         <label class="lzw-label">Min Data In Leaf Ratio</label>
         <NumericStepper
           value={value.min_data_in_leaf_ratio ?? 0.01}
-          step={0.01}
+          step={stepMap.min_data_in_leaf_ratio ?? 0.01}
           min={0}
           onChange={(v) => setField("min_data_in_leaf_ratio", v ?? 0.01)}
         />
@@ -490,7 +500,7 @@ export function ModelSection({
         <label class="lzw-label">Min Data In Bin Ratio</label>
         <NumericStepper
           value={value.min_data_in_bin_ratio ?? 0.01}
-          step={0.01}
+          step={stepMap.min_data_in_bin_ratio ?? 0.01}
           min={0}
           onChange={(v) => setField("min_data_in_bin_ratio", v ?? 0.01)}
         />
@@ -500,6 +510,7 @@ export function ModelSection({
         value={value.feature_weights ?? null}
         onChange={(v) => setField("feature_weights", v)}
         columns={columns}
+        stepMap={stepMap}
       />
 
       <div class="lzw-form-row">
@@ -536,6 +547,7 @@ export function ModelSection({
         parameterHints={parameterHints}
         optionSets={optionSets}
         stepMap={stepMap}
+        metricParamDefaults={metricParamDefaults}
         manualNumLeavesKey={manualNumLeavesKey}
         manualNumLeavesDefault={manualNumLeavesDefault}
       />

--- a/js/src/components/RetuneControls.tsx
+++ b/js/src/components/RetuneControls.tsx
@@ -33,13 +33,20 @@ interface RetuneControlsProps {
   disabled: boolean;
   /** Optional default n_trials; defaults to 20 so the bump is visible. */
   defaultNTrials?: number;
+  /** P-034: step values from backend contract (``ui_schema.step_map``). */
+  stepMap?: Record<string, number>;
 }
 
 export function RetuneControls({
   onRetune,
   disabled,
   defaultNTrials = 20,
+  stepMap,
 }: RetuneControlsProps) {
+  // P-034: read step from contract; fall back to historical literal so unit
+  // tests that omit a contract still render the same input.
+  const boundaryThresholdStep: number =
+    typeof stepMap?.boundary_threshold === "number" ? stepMap.boundary_threshold : 0.01;
   const [nTrials, setNTrials] = useState<number>(defaultNTrials);
   const [expandBoundary, setExpandBoundary] = useState<boolean>(true);
   const [boundaryThreshold, setBoundaryThreshold] = useState<number>(0.05);
@@ -96,7 +103,7 @@ export function RetuneControls({
           value={boundaryThreshold}
           min={0}
           max={1}
-          step={0.01}
+          step={boundaryThresholdStep}
           onChange={(v) => setBoundaryThreshold(v ?? 0.05)}
         />
       </div>

--- a/js/src/components/SearchSpace.tsx
+++ b/js/src/components/SearchSpace.tsx
@@ -190,7 +190,7 @@ function renderFixed(
                 <span class="lzw-label" style="min-width: 120px; font-size: 11px;">{col}</span>
                 <NumericStepper
                   value={w}
-                  step={0.1}
+                  step={sm.feature_weights ?? 0.1}
                   onChange={(v) => {
                     const next = { ...weights, [col]: v ?? 1.0 };
                     onChange({ ...config, fixed: next });
@@ -298,6 +298,13 @@ export function SearchSpace({
   const [addedParams, setAddedParams] = useState<string[]>([]);
   const optionSets: Record<string, Record<string, string[]>> = uiSchema?.option_sets ?? {};
   const stepMap: Record<string, number> = uiSchema?.step_map ?? {};
+  // P-034: numeric defaults from the contract; fallback only for fixtures
+  // that omit ui_schema.defaults.
+  const metricParamDefaults: Record<string, number> = uiSchema?.defaults?.metric_params ?? {};
+  const defaultPrecisionAtK: number =
+    typeof metricParamDefaults.precision_at_k_k === "number"
+      ? metricParamDefaults.precision_at_k_k
+      : 10;
   const searchSpaceCatalog: CatalogEntry[] = uiSchema?.search_space_catalog ?? [];
   const innerValidOpts: string[] = uiSchema?.inner_valid_options ?? [];
   const conditionalVisibility: Record<string, any> = uiSchema?.conditional_visibility ?? {};
@@ -465,14 +472,17 @@ export function SearchSpace({
                       <div role="cell" />
                       <div role="cell">
                         <NumericStepper
-                          value={fixedModelParams._precision_at_k_k ?? 10}
+                          value={fixedModelParams._precision_at_k_k ?? defaultPrecisionAtK}
                           min={1}
                           max={100}
                           step={1}
                           onChange={(v) =>
                             onChange({
                               space: spaceValue,
-                              fixedModelParams: { ...fixedModelParams, _precision_at_k_k: v ?? 10 },
+                              fixedModelParams: {
+                                ...fixedModelParams,
+                                _precision_at_k_k: v ?? defaultPrecisionAtK,
+                              },
                               fixedTraining,
                             })
                           }

--- a/js/src/tabs/DataTab.tsx
+++ b/js/src/tabs/DataTab.tsx
@@ -82,6 +82,12 @@ function deriveStrategiesWithField(
 export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAction, backendContract }: DataTabProps) {
   // Read CV strategy fields from backend contract, derive Sets with fallbacks
   const capabilities: Record<string, any> = backendContract?.capabilities ?? {};
+  const uiSchema: Record<string, any> = backendContract?.ui_schema ?? {};
+  // P-034: numeric defaults from the contract; the JS fallback literals only
+  // survive when a unit-test fixture omits the contract entirely.
+  const cvDefaults: Record<string, number> = uiSchema.defaults?.cv ?? {};
+  const dN = (key: string, fallback: number): number =>
+    typeof cvDefaults[key] === "number" ? cvDefaults[key] : fallback;
   const cvStrategyFields: Record<string, string[]> = capabilities.cv_strategy_fields ?? {};
   const hasContractFields = Object.keys(cvStrategyFields).length > 0;
   const contractStrategies: string[] | undefined = capabilities.cv_strategies;
@@ -124,7 +130,7 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
     (dfInfo.task && cvDefaultByTask[dfInfo.task]) ||
     strategyList[0] ||
     FALLBACK_CV_STRATEGIES[0];
-  const cv = dfInfo.cv ?? { strategy: fallbackStrategy, n_splits: 5 };
+  const cv = dfInfo.cv ?? { strategy: fallbackStrategy, n_splits: dN("n_splits", 5) };
   const fs = dfInfo.feature_summary;
   const featureCols = columns.filter((c: any) => !c.excluded).map((c: any) => c.name);
   const hasTarget = Boolean(dfInfo.target);
@@ -229,16 +235,16 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
             min={2}
             max={50}
             step={1}
-            onChange={(v) => sendCv({ ...cv, n_splits: v ?? 5 })}
+            onChange={(v) => sendCv({ ...cv, n_splits: v ?? dN("n_splits", 5) })}
           />
         </div>
         {NEEDS_RANDOM_STATE.has(cv.strategy) && (
           <div class="lzw-form-row">
             <label class="lzw-label">Random state</label>
             <NumericStepper
-              value={cv.random_state ?? 42}
+              value={cv.random_state ?? dN("random_state", 42)}
               step={1}
-              onChange={(v) => sendCv({ ...cv, random_state: v ?? 42 })}
+              onChange={(v) => sendCv({ ...cv, random_state: v ?? dN("random_state", 42) })}
             />
           </div>
         )}
@@ -292,10 +298,10 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
           <div class="lzw-form-row">
             <label class="lzw-label">Gap</label>
             <NumericStepper
-              value={cv.gap ?? 0}
+              value={cv.gap ?? dN("gap", 0)}
               min={0}
               step={1}
-              onChange={(v) => sendCv({ ...cv, gap: v ?? 0 })}
+              onChange={(v) => sendCv({ ...cv, gap: v ?? dN("gap", 0) })}
             />
           </div>
         )}
@@ -304,19 +310,19 @@ export function DataTab({ dfInfo, allColumns, columnStats, splitPreview, sendAct
             <div class="lzw-form-row">
               <label class="lzw-label">Purge gap</label>
               <NumericStepper
-                value={cv.purge_gap ?? 0}
+                value={cv.purge_gap ?? dN("purge_gap", 0)}
                 min={0}
                 step={1}
-                onChange={(v) => sendCv({ ...cv, purge_gap: v ?? 0 })}
+                onChange={(v) => sendCv({ ...cv, purge_gap: v ?? dN("purge_gap", 0) })}
               />
             </div>
             <div class="lzw-form-row">
               <label class="lzw-label">Embargo</label>
               <NumericStepper
-                value={cv.embargo ?? 0}
+                value={cv.embargo ?? dN("embargo", 0)}
                 min={0}
                 step={1}
-                onChange={(v) => sendCv({ ...cv, embargo: v ?? 0 })}
+                onChange={(v) => sendCv({ ...cv, embargo: v ?? dN("embargo", 0) })}
               />
             </div>
           </>

--- a/js/src/tabs/FitSubTab.tsx
+++ b/js/src/tabs/FitSubTab.tsx
@@ -179,6 +179,7 @@ export function FitSubTab({
                 parameterHints={parameterHints}
                 optionSets={optionSets}
                 stepMap={stepMap}
+                metricParamDefaults={defaults.metric_params ?? {}}
                 columns={dfInfo?.columns ?? []}
                 additionalParams={uiSchema.additional_params ?? []}
                 searchSpaceCatalog={searchSpaceCatalog}

--- a/js/src/tabs/ResultsTab.tsx
+++ b/js/src/tabs/ResultsTab.tsx
@@ -49,6 +49,8 @@ interface ResultsTabProps {
   exportLoading?: boolean;
   /** Callback to initiate a code export download. */
   onExportCode?: () => void;
+  /** P-034: backend contract step_map (passed through to RetuneControls etc.). */
+  stepMap?: Record<string, number>;
 }
 
 /** Format a plot type slug into a display label. */
@@ -82,6 +84,7 @@ export function ResultsTab({
   theme = "light",
   exportLoading = false,
   onExportCode,
+  stepMap,
 }: ResultsTabProps) {
   const [selectedPlot, setSelectedPlot] = useState<string | null>(null);
 
@@ -267,6 +270,7 @@ export function ResultsTab({
             <RetuneControls
               disabled={status === "running"}
               onRetune={(payload) => sendAction("retune", payload)}
+              stepMap={stepMap}
             />
             <div class="lzw-form-row" style="margin-top: 8px;">
               <span class="lzw-label">Best Score</span>

--- a/js/src/tabs/TuneSubTab.tsx
+++ b/js/src/tabs/TuneSubTab.tsx
@@ -32,6 +32,10 @@ export function TuneSubTab({
   yamlExportCount,
 }: TuneSubTabProps) {
   const optionSets: Record<string, Record<string, string[]>> = uiSchema.option_sets ?? {};
+  // P-034: read numeric defaults from the contract instead of hardcoded ?? literals.
+  const tuneDefaults: Record<string, number> = uiSchema.defaults?.tune ?? {};
+  const defaultNTrials: number =
+    typeof tuneDefaults.n_trials === "number" ? tuneDefaults.n_trials : 10;
   const tuning = localConfig.tuning ?? {};
   const tuneSpace = tuning.optuna?.space ?? {};
   const tuneModelParams = tuning.model_params ?? {};
@@ -70,10 +74,10 @@ export function TuneSubTab({
         <div class="lzw-form-row">
           <label class="lzw-label">n_trials</label>
           <NumericStepper
-            value={localConfig.tuning?.optuna?.params?.n_trials ?? 10}
+            value={localConfig.tuning?.optuna?.params?.n_trials ?? defaultNTrials}
             min={1}
             step={1}
-            onChange={(v) => handleTuneParam("n_trials", v ?? 10)}
+            onChange={(v) => handleTuneParam("n_trials", v ?? defaultNTrials)}
           />
         </div>
       </Accordion>

--- a/src/lizyml_widget/adapter_contract.py
+++ b/src/lizyml_widget/adapter_contract.py
@@ -387,6 +387,9 @@ def build_ui_schema(all_metrics_by_task: dict[str, list[str]]) -> dict[str, Any]
             "early_stopping.rounds": 50,
             "validation_ratio": 0.05,
             "seed": 1,
+            # P-034: step values for fields whose JS used a hardcoded literal.
+            "feature_weights": 0.1,
+            "boundary_threshold": 0.01,
         },
         "conditional_visibility": {
             "calibration": {"task": ["binary"]},
@@ -398,6 +401,23 @@ def build_ui_schema(all_metrics_by_task: dict[str, list[str]]) -> dict[str, Any]
         },
         "defaults": {
             "calibration": {"method": "isotonic", "params": {}},
+            # P-034: numeric defaults the JS UI used to fall back to via
+            # ``payload ?? <literal>``. Centralising them here keeps the
+            # contract the single source of truth (CLAUDE.md §8) so
+            # updating a default no longer requires a JS-side change.
+            "cv": {
+                "n_splits": 5,
+                "random_state": 42,
+                "gap": 0,
+                "purge_gap": 0,
+                "embargo": 0,
+            },
+            "tune": {
+                "n_trials": 10,
+            },
+            "metric_params": {
+                "precision_at_k_k": 10,
+            },
         },
         "calibration_methods": ["platt", "isotonic", "beta"],
         "calibration_params": {

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -432,3 +432,61 @@ class TestContractNewFields:
             assert w.error == {} or w.error.get("code") != "CV_ERROR", (
                 f"Strategy {strategy!r} from contract was rejected"
             )
+
+
+class TestContractNumericDefaultsAndStepMap:
+    """P-034: ui_schema.defaults and ui_schema.step_map for numeric UI fields.
+
+    The JS UI used to fall back to ``payload ?? <literal>`` for several
+    numeric defaults (``n_splits ?? 5``, ``n_trials ?? 10``,
+    ``step={0.1}``, etc.). The backend contract now owns those values so
+    a backend change propagates without touching JS (CLAUDE.md §8).
+    """
+
+    def _ui_schema(self) -> dict:
+        from lizyml_widget.adapter_contract import build_ui_schema
+        from lizyml_widget.adapter_params import get_eval_metrics_by_task
+
+        return build_ui_schema(get_eval_metrics_by_task())
+
+    def test_defaults_cv_present(self) -> None:
+        """ui_schema.defaults.cv exposes the JS fallback numerics."""
+        defaults = self._ui_schema()["defaults"]
+        assert "cv" in defaults, "ui_schema.defaults.cv must exist"
+        cv = defaults["cv"]
+        for key, value in (
+            ("n_splits", 5),
+            ("random_state", 42),
+            ("gap", 0),
+            ("purge_gap", 0),
+            ("embargo", 0),
+        ):
+            assert cv.get(key) == value, (
+                f"defaults.cv.{key} must equal {value}, got {cv.get(key)!r}"
+            )
+
+    def test_defaults_tune_present(self) -> None:
+        """ui_schema.defaults.tune.n_trials replaces JS ``n_trials ?? 10``."""
+        defaults = self._ui_schema()["defaults"]
+        assert defaults.get("tune", {}).get("n_trials") == 10
+
+    def test_defaults_metric_params_present(self) -> None:
+        """ui_schema.defaults.metric_params.precision_at_k_k replaces ``?? 10`` in JS."""
+        defaults = self._ui_schema()["defaults"]
+        assert defaults.get("metric_params", {}).get("precision_at_k_k") == 10
+
+    def test_step_map_feature_weights_present(self) -> None:
+        """step_map.feature_weights replaces ``step={0.1}`` literal in JS."""
+        step_map = self._ui_schema()["step_map"]
+        assert step_map.get("feature_weights") == 0.1
+
+    def test_step_map_boundary_threshold_present(self) -> None:
+        """step_map.boundary_threshold replaces ``step={0.01}`` literal in JS."""
+        step_map = self._ui_schema()["step_map"]
+        assert step_map.get("boundary_threshold") == 0.01
+
+    def test_calibration_default_unchanged(self) -> None:
+        """defaults.calibration must remain in place (regression guard for new keys)."""
+        defaults = self._ui_schema()["defaults"]
+        cal = defaults.get("calibration")
+        assert cal == {"method": "isotonic", "params": {}}


### PR DESCRIPTION
Closes #131 — implements P-034 (Phase 1.5 of #143, completes Phase 1).

## Summary

Move the remaining hardcoded numeric fallbacks (`payload ?? <literal>`, `step={0.1}`, `step={0.01}`, etc.) out of the JS UI by extending the backend contract. A backend default change now propagates to the UI without a JS edit (CLAUDE.md §8).

## Contract additions (additive, schema_version unchanged)

```python
ui_schema["defaults"] = {
    "cv": {"n_splits": 5, "random_state": 42, "gap": 0, "purge_gap": 0, "embargo": 0},
    "tune": {"n_trials": 10},
    "metric_params": {"precision_at_k_k": 10},
    # existing "calibration" preserved
}
ui_schema["step_map"] = {
    # existing entries preserved …
    "feature_weights": 0.1,
    "boundary_threshold": 0.01,
}
```

## JS migrations

| File | Before | After |
|---|---|---|
| `DataTab.tsx` | `cv.n_splits ?? 5`, `cv.random_state ?? 42`, `cv.gap ?? 0`, `cv.purge_gap ?? 0`, `cv.embargo ?? 0` | new `dN(key, fallback)` helper reads `ui_schema.defaults.cv[key]` |
| `TuneSubTab.tsx` | `n_trials ?? 10` | `defaults.tune.n_trials` (with literal fallback for fixture-only tests) |
| `SearchSpace.tsx` | `step={0.1}` (feature weights) and `_precision_at_k_k ?? 10` | `stepMap.feature_weights` and `defaults.metric_params.precision_at_k_k` |
| `ModelEditors.tsx` | `step={0.1}` and `_precision_at_k_k ?? 10` | `FeatureWeightsEditor` takes `stepMap`, `TypedParamsEditor` takes `metricParamDefaults` (plumbed via `ModelSection` from `FitSubTab`). `min_data_in_leaf_ratio` / `min_data_in_bin_ratio` step now also prefers `stepMap` |
| `RetuneControls.tsx` | `step={0.01}` | new `stepMap` prop reads `boundary_threshold` from contract |
| `ResultsTab.tsx` | – | forwards `stepMap` prop to `RetuneControls` |
| `App.tsx` | – | passes `stepMap={backendContract?.ui_schema?.step_map ?? {}}` to `ResultsTab` |

Fallback literals are kept only so unit-test fixtures that don't supply a contract still render the historical UI. The contract is the single source of truth in production.

## Tests

New golden test `TestContractNumericDefaultsAndStepMap` in `tests/test_frontend_contract.py` pins the contract shape:

- `test_defaults_cv_present`: all five CV defaults.
- `test_defaults_tune_present`: `n_trials = 10`.
- `test_defaults_metric_params_present`: `precision_at_k_k = 10`.
- `test_step_map_feature_weights_present`: `0.1`.
- `test_step_map_boundary_threshold_present`: `0.01`.
- `test_calibration_default_unchanged`: regression guard for the pre-existing `defaults.calibration` entry.

## Quality gates

- `uv run pytest` — **935 passed** (929 + 6 new)
- `uv run ruff check . && uv run ruff format --check .` — clean
- `uv run mypy --no-incremental src/lizyml_widget/` — Success on 19 source files
- `pnpm test:coverage` — **274 vitest passed**
- `pnpm lint` — clean

## Documentation

- HISTORY.md P-034 marked decided / implemented (notes added).
- BLUEPRINT.md §5.3 — adds rows for `feature_weights` / `boundary_threshold` in step_map and a new table for `ui_schema.defaults`.
- CHANGELOG.md `[Unreleased]` — Changed entry.

## Test plan

- [x] Local quality gates (pytest, ruff, mypy, vitest, eslint) all green
- [x] All `??` literal fallbacks listed in the proposal removed (grep confirms)
- [x] Contract golden test pins the new shape
- [x] CI to verify on push
