### PR TITLE
feat(widget,subprocess): subprocess retune resume (P-038, #154 #128 #156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - 2026-05-09
 
 ### Fixed
-- **Default-install ``w.retune()`` no longer surfaces ``RETUNE_SUBPROCESS_UNSUPPORTED`` ([#154](https://github.com/nbx-liz/LizyML-Widget/issues/154))**.
-  After P-036 made subprocess the default execution strategy on Linux +
-  libgomp, ``w.tune() → w.retune()`` failed by default because
-  ``SubprocessJobRunner`` cannot resume an Optuna study from a fresh
-  process. The widget now transparently falls back to the thread runner
-  for re-tune jobs only when subprocess is the default — initial tune
-  still uses subprocess to keep the P-036 / #147 perf win. The remediation
-  message on the (now rare) explicit-opt-in subprocess retune path was
-  updated to point users to ``LZW_FORCE_THREAD=1`` instead of the no-op
-  ``LZW_FORCE_SUBPROCESS=1``. Subprocess re-tune resume itself remains
-  tracked by [#128](https://github.com/nbx-liz/LizyML-Widget/issues/128).
+- **Default-install ``w.retune()`` runs through subprocess and no longer surfaces ``RETUNE_SUBPROCESS_UNSUPPORTED`` (P-038, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154), [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156))**.
+  After P-036 made subprocess the default on Linux + libgomp,
+  ``w.tune() → w.retune()`` failed by default because the subprocess could
+  not resume the existing Optuna study. P-038 extends the P-037 tune-state
+  IPC to the input direction so the parent serialises the current
+  ``service._tune_model`` tune state into a temp file, the subprocess
+  restores it via ``adapter.restore_tune_state``, then runs
+  ``adapter.tune(resume=True, ...)``. ``RetuneSubprocessUnsupportedError``
+  and the ``RETUNE_SUBPROCESS_UNSUPPORTED`` error code are removed, and the
+  ``widget._run_job`` thread-fallback branch is gone. Empirical perf
+  (100k × 50, 3 trials, libgomp host): clean retune is now within ~1.1x of
+  subprocess tune (was 1.43x with the thread fallback), and the
+  ``tune → main-thread booster.predict → retune`` flow stays within ~1.1x
+  instead of regressing to ~11x via the libgomp pool-affinity catastrophe.
+  Closes [#128](https://github.com/nbx-liz/LizyML-Widget/issues/128).
 - **Persist tune state across subprocess boundary so post-tune plots render on the parent (P-037, [#152](https://github.com/nbx-liz/LizyML-Widget/issues/152))**.
   After P-036 made subprocess the default on Linux + libgomp, ``w.tune()``
   followed by Results → Tuning History got stuck at "Loading plot..." because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-09
+
 ### Fixed
+- **Default-install ``w.retune()`` no longer surfaces ``RETUNE_SUBPROCESS_UNSUPPORTED`` ([#154](https://github.com/nbx-liz/LizyML-Widget/issues/154))**.
+  After P-036 made subprocess the default execution strategy on Linux +
+  libgomp, ``w.tune() → w.retune()`` failed by default because
+  ``SubprocessJobRunner`` cannot resume an Optuna study from a fresh
+  process. The widget now transparently falls back to the thread runner
+  for re-tune jobs only when subprocess is the default — initial tune
+  still uses subprocess to keep the P-036 / #147 perf win. The remediation
+  message on the (now rare) explicit-opt-in subprocess retune path was
+  updated to point users to ``LZW_FORCE_THREAD=1`` instead of the no-op
+  ``LZW_FORCE_SUBPROCESS=1``. Subprocess re-tune resume itself remains
+  tracked by [#128](https://github.com/nbx-liz/LizyML-Widget/issues/128).
 - **Persist tune state across subprocess boundary so post-tune plots render on the parent (P-037, [#152](https://github.com/nbx-liz/LizyML-Widget/issues/152))**.
   After P-036 made subprocess the default on Linux + libgomp, ``w.tune()``
   followed by Results → Tuning History got stuck at "Loading plot..." because
@@ -246,8 +259,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `num_leaves ?? 256` defaults are removed; default flows from the catalog.
     The `verbose / num_threads` exclusion comes from
     `additional_params_hidden_keys`.
-
-## [0.9.0] - 2026-05-08
 
 ### Changed
 - **Required lizyml version bumped to `>=0.10.0,<0.13`** (P-030, [#112](https://github.com/nbx-liz/LizyML-Widget/issues/112))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,91 @@
 ## LizyML-Widget 仕様変更履歴
 
+### P-038: subprocess Retune Resume を P-037 の tune state IPC を input 方向に拡張して実装（#154 thread fallback の置換）
+
+- **日付**: 2026-05-09（提案・決定・実装）
+- **ステータス**: 決定（実装中 — fix/issue-154-default-retune → develop, PR #155 を Option A に転換）
+- **関連 Issue**: [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（PR #155 follow-up）, [#128](https://github.com/nbx-liz/LizyML-Widget/issues/128)（subprocess retune の本フィックス、本 Proposal で完了）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 の元 issue）
+- **背景**:
+  - PR #155（`e286626`）は `widget._run_job` で retune を ThreadJobRunner にフォールバックさせる **暫定 hotfix** を入れた。`w.tune() → w.retune()` の最低限の正常系は復帰したが、構造的な問題が残った。
+  - [#156 の調査](https://github.com/nbx-liz/LizyML-Widget/issues/156#issuecomment-4412462760)で empirical に確認した内容:
+    1. **Clean path のみで 1.43x 劣化**（subprocess tune 3.24 s/trial vs thread retune 4.64 s/trial）。issue#156 本文の 1.96x はこの band。
+    2. **典型的ユーザフローで 11x 劣化（30x catastrophe の再発）**。`w.tune()` の後に `w.predict(test_df)` を 1 回呼ぶだけで、retune 中の親プロセス CPU が ~29 cores（2904%）から ~2.25 cores（225%）に崩壊し per-trial wall が 36 s に達する（S5/S7 で実測：109 s vs 14 s）。原因は GCC #108494 libgomp プール親和性バグ。`booster.predict` 単独でも親 main thread を pool owner に bind するのに十分（`learned/openmp-daemon-thread-degradation`）。
+    3. **同一カーネル内累積劣化**（5.20 s → 9.04 s/trial across 4 cycles）。スレッド数は flat、CPU は full、原因不明。issue #158 で別途追跡。
+  - PR #155 の thread fallback は構造上回避不可能なリスクを抱える。`w.predict` / Inference タブ / SHAP plot のいずれかが tune と retune の間に挟まれた瞬間に catastrophe path に入るが、ユーザがそれを避ける手段はない。
+  - P-037（PR #153）で **subprocess→parent の tune state IPC**（`tune_state_out_path` + `BackendAdapter.export_tune_state` / `restore_tune_state`）を既に整備済み。本 Proposal はこれを **parent→subprocess の方向**にも拡張するだけで完結する。
+- **提案内容**:
+  - **(a) IPC 入力に `tune_state_in_path` と `retune_kwargs` を追加**:
+    - `_subprocess_entry.read_input` が受け取る dict に 2 フィールドを追加:
+      - `tune_state_in_path: str | None` — retune 時に親が事前に書き出した tune state の path（pickle blob, P-037 と同 format）
+      - `retune_kwargs: dict[str, Any] | None` — `{"resume": True, "n_trials": int|None, "expand_boundary": bool|None, "boundary_threshold": float}`
+    - `subprocess_runner.run_job_subprocess` の signature に同 2 引数を追加。
+  - **(b) subprocess エントリの retune ブランチ**:
+    - `retune_kwargs is not None` のとき、`adapter.create_model(config, df)` の直後に `adapter.restore_tune_state(model, tune_state_in_path)` を呼び、`adapter.tune(model, on_progress=on_progress, **retune_kwargs)` を実行する。
+    - retune 後の更新済み tune state は既存の `tune_state_out_path` 経路で親に返す（P-037 と対称）。
+    - subprocess 内の挙動は `service.tune(resume=True)` と論理同等（adapter.tune は既に resume kwargs を受け付ける）。
+  - **(c) Service 拡張**: `WidgetService.export_tune_state_to_path(path)` を追加。`_tune_model` が None の場合は `ValueError` を上げ、subprocess retune を防ぐ defensive guard とする。
+  - **(d) `SubprocessJobRunner.run` の retune 対応**:
+    - `RetuneSubprocessUnsupportedError` の raise を **削除**。
+    - `spec.retune_kwargs is not None` のとき:
+      1. tempfile で `tune_state_in_path` を確保。
+      2. `service.export_tune_state_to_path(tune_state_in_path)` を呼ぶ。
+      3. `run_job_subprocess(..., retune_kwargs=spec.retune_kwargs, tune_state_in_path=tune_state_in_path)` で投げる。
+      4. `finally` で `tune_state_in_path` を削除（既存の `tune_state_out_path` cleanup と対称）。
+    - retune の場合も `record_subprocess_tune_summary` および `restore_tune_state_from_path` の post-subprocess 経路を流用する（既存実装で動作する）。
+  - **(e) widget._run_job の thread fallback を撤去**:
+    - PR #155 が追加した `_retune_fallback_warned` フラグおよび `if self._execution_strategy == "subprocess" and retune_kwargs is not None:` ブランチを削除。
+    - runner 選択は execution strategy のみで決まる（retune_kwargs を見ない）。
+  - **(f) 既存テストの更新**:
+    - `tests/regression/test_reg_154_default_strategy_retune.py::INV-#154-A` の意味を **"retune は subprocess を使う"** に反転。
+    - `INV-#154-B`（`LZW_FORCE_THREAD` 指示文言）は `RetuneSubprocessUnsupportedError` 全削除のため削除。
+    - `INV-#154-C`（subprocess Fit overhead 30s bound）は無関係なので維持。
+  - **(g) 新規 regression test**:
+    - `tests/regression/test_reg_156_subprocess_retune.py`:
+      - `INV-#156-A`: `w.tune() → w.retune()` がデフォルト install で `subprocess` runner 経由で完了する（`SubprocessJobRunner.run` 呼び出しを mock で検証）。
+      - `INV-#156-B`（slow）: 100k × 50, 3 trials, `tune → main-thread booster.predict → retune` の per-trial wall-clock が clean subprocess tune の 1.5x 以内。catastrophe path を pin する（`learned/promote-learned-skill-to-regression-test` 適用）。
+      - `INV-#156-C`（slow）: clean tune→retune の per-trial wall-clock が clean subprocess tune の 1.2x 以内。
+- **Invariants**:
+  - INV-1: subprocess retune を実行する条件下では、親プロセスは lightgbm を `import` のみで `train` / `predict` を呼ばない（subprocess が全並列領域を担う）。
+  - INV-2: `service.export_tune_state_to_path` は `_tune_model is None` のとき必ず `ValueError` を上げる（subprocess retune の前提逸脱を early fail）。
+  - INV-3: `tune_state_in_path` は `SubprocessJobRunner.run` の `finally` で必ず削除される（INV-5 の対称、ファイルリーク防止）。
+  - INV-4: subprocess retune 完了後、親プロセスの `_tune_model._tuning_result.rounds` は元の rounds + retune で追加された rounds を含む（`restore_tune_state_from_path` 経由で復元）。
+  - INV-5: `RetuneSubprocessUnsupportedError` は本 Proposal で削除する。BackendAdapter Protocol が `export_tune_state` / `restore_tune_state` を required としているため、retune を支えられない adapter は型レベルで存在しない。
+- **影響範囲**:
+  - `src/lizyml_widget/_subprocess_entry.py` — input dict に 2 フィールド、retune branch 追加
+  - `src/lizyml_widget/subprocess_runner.py` — `run_job_subprocess` signature 拡張、input pickle に 2 フィールド追加
+  - `src/lizyml_widget/job_runner.py` — `SubprocessJobRunner.run` で `RetuneSubprocessUnsupportedError` 削除、retune 経路追加；`RetuneSubprocessUnsupportedError` クラス自体は削除し import を整理
+  - `src/lizyml_widget/service.py` — `export_tune_state_to_path` メソッド追加
+  - `src/lizyml_widget/widget.py` — `_retune_fallback_warned` フラグと thread fallback ブランチを削除；`RetuneSubprocessUnsupportedError` の `except` 句は削除（type 削除に伴う）
+  - `tests/regression/test_reg_154_default_strategy_retune.py` — INV-A 反転、INV-B 削除、INV-C 維持
+  - `tests/regression/test_reg_156_subprocess_retune.py` — 新規（catastrophe path pin + clean perf bound）
+  - `tests/test_subprocess_integration.py` — happy-path retune の mock テスト追加
+  - `tests/test_widget.py` / `tests/test_widget_threading.py` — `RetuneSubprocessUnsupportedError` 参照の更新（残っていれば削除）
+  - `BLUEPRINT.md` §3.7.1 — subprocess IPC ペイロードの input 方向追加を記載
+  - `HISTORY.md` — 本 Proposal
+  - `CHANGELOG.md` — `[0.9.0]` セクションの「Bug fixes」に追加（PR #155 のエントリを置換）
+- **互換性**:
+  - 公開 Python API（`w.fit/tune/retune`）の signature / 振る舞いは変更なし。`w.retune()` のユーザ可視動作は PR #155 の v0.9.0 直前状態と同一（成功する／status=`completed`）。
+  - 副次的に `RetuneSubprocessUnsupportedError` クラスを削除する。`from lizyml_widget.job_runner import RetuneSubprocessUnsupportedError` は ImportError になるが、これは internal class（BLUEPRINT で公開 API として宣言されておらず、テストのみが参照していた）。CHANGELOG で internal change として明記。
+  - subprocess IPC は input pickle に 2 フィールド追加。古い親 + 新しい subprocess の組み合わせは存在しない（subprocess は親と同じ Python 環境で起動する）ので skew リスクなし。
+- **代替案（却下）**:
+  - **案A**: PR #155 の thread fallback を維持し、`w.predict` の前後で警告を出す → ユーザ教育に頼るのは脆弱、誤って踏むと 11x 劣化、現在の v0.9.0 リリースを正当化できない。
+  - **案B**: PR #155 を revert し `RETUNE_SUBPROCESS_UNSUPPORTED` を再露出 → #154 の元症状に戻る、最悪。
+  - **案C**: lizyml 0.12 の resumable Optuna SQLite storage（issue #129）に依存 → P-030 でリリーススコープから外しており UI 露出が無い。本 Proposal で扱う in-memory tune state pickle で十分目的を達せるため不要。
+- **Optuna study の扱い**:
+  - P-037 と同じ。subprocess は受け取った `_study` を P-037 の `restore_tune_state` 経由で attach し、`adapter.tune(resume=True)` を呼ぶ。lizyml 内部で `_study` を使って resume する。
+  - InMemoryStorage（既定）は pickleable。RDB-backed storage の場合 P-037 と同様に best-effort で `study=None` に降格し、retune は新規 study として動作する（functional には正しい動作）。
+- **受け入れ基準**:
+  - [ ] Linux + libgomp デフォルト環境で `w.tune() → w.retune()` が `subprocess` runner で完了する（mock で `SubprocessJobRunner.run` 呼び出しを検証）。
+  - [ ] `tune → main-thread booster.predict → retune` の per-trial wall-clock が `tune` の per-trial wall の 1.5x 以内に収まる（issue #156 S7 の 11x catastrophe を除去）。slow regression test で pin。
+  - [ ] clean `tune → retune` の per-trial wall-clock が `tune` の 1.2x 以内（PR #155 の 1.43x も改善）。
+  - [ ] `RetuneSubprocessUnsupportedError` および `RETUNE_SUBPROCESS_UNSUPPORTED` エラーコードへの参照が widget / supervisor / tests から完全に消える。
+  - [ ] PR #155 が追加した `_retune_fallback_warned` / "re-tune temporarily falls back to thread runner" ログが消える。
+  - [ ] 既存品質ゲート: `pytest`, `pytest -m slow`, `ruff check`, `ruff format --check`, `mypy --strict`, `pnpm test:coverage`, `pnpm lint` 全 green。
+  - [ ] CHANGELOG `[0.9.0]` の retune 関連エントリが PR #155 の "thread fallback" 記述から本 Proposal の "subprocess retune resume" 記述に置換される。
+- **本 Proposal の終了条件**:
+  - 受け入れ基準を満たした PR が `develop` にマージされる。
+  - PR #155 の不採用部分（thread fallback コード）が同じ PR で回収される。
+
 ### P-037: Adapter Protocol に Tune State Cross-Process Persistence を追加（subprocess tune 後の plot 復元）
 
 - **日付**: 2026-05-09（提案・決定・実装）

--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ print(lizyml_widget.__version__)
 
 Powered by [anywidget](https://anywidget.dev/) for cross-environment compatibility.
 
+### Execution strategy on Linux + libgomp
+
+On Linux hosts where ``lightgbm`` is dynamically linked against GCC's
+``libgomp`` (the common apt / pip distribution), Fit and Tune jobs run in a
+fresh subprocess by default. This avoids a libgomp pool-affinity bug that
+makes worker-thread training ~30x slower than main-thread training (and
+multi-trial Tune compounds to 20–50x). See [issue #147](https://github.com/nbx-liz/LizyML-Widget/issues/147).
+
+The trade-off is a fixed startup cost on every Fit/Tune call:
+
+| Path | Typical wall-clock (5000 rows × 30 cols) |
+|---|---|
+| in-process Fit (`LZW_FORCE_THREAD=1`) | ~0.7 s |
+| subprocess startup + lightgbm import (overhead) | ~0.8–1.2 s |
+| subprocess Fit (default) | ~1.6–2.0 s |
+
+For interactive Notebook workflows where you fit small datasets repeatedly
+and the libgomp affinity bug does not manifest in your environment (e.g.
+fresh kernel, single Fit per session), set the opt-out env var:
+
+```bash
+export LZW_FORCE_THREAD=1
+```
+
+Tune still benefits from subprocess execution — leave the default in place
+when running multi-trial hyperparameter searches.
+
 ## Development
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/nbx-liz/LizyML-Widget"
 Repository = "https://github.com/nbx-liz/LizyML-Widget"
+"Bug Tracker" = "https://github.com/nbx-liz/LizyML-Widget/issues"
+Changelog = "https://github.com/nbx-liz/LizyML-Widget/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # Pin lizyml to the exact minor range this widget version understands.

--- a/src/lizyml_widget/_subprocess_entry.py
+++ b/src/lizyml_widget/_subprocess_entry.py
@@ -57,11 +57,19 @@ def run_job(
     model_out_path: str | None,
     output: IO[bytes],
     tune_state_out_path: str | None = None,
+    retune_kwargs: dict[str, Any] | None = None,
+    tune_state_in_path: str | None = None,
 ) -> None:
     """Execute a fit or tune job and write results to output.
 
     This function runs on the main thread of the subprocess,
     so OpenMP parallel regions use the correct thread pool.
+
+    P-038: when ``retune_kwargs`` is non-None and ``job_type == "tune"``,
+    the subprocess restores tune state from ``tune_state_in_path`` before
+    invoking ``adapter.tune(resume=True, ...)``. Updated tune state is
+    written back to ``tune_state_out_path`` so the parent can reattach it
+    to ``service._tune_model``.
     """
     cancel_flag = threading.Event()
 
@@ -105,6 +113,12 @@ def run_job(
         adapter = _create_adapter()
         model = adapter.create_model(config, df)
 
+        # P-038: subprocess retune resume — restore prior tune state into the
+        # fresh model so ``adapter.tune(resume=True, ...)`` continues the
+        # existing Optuna study instead of starting a new one.
+        if job_type == "tune" and retune_kwargs is not None and tune_state_in_path is not None:
+            adapter.restore_tune_state(model, tune_state_in_path)
+
         if job_type == "fit":
             summary = adapter.fit(model, on_progress=on_progress)
             result_msg: dict[str, Any] = {
@@ -120,7 +134,13 @@ def run_job(
                 "model_path": None,
             }
         elif job_type == "tune":
-            summary_t = adapter.tune(model, on_progress=on_progress)
+            tune_kwargs: dict[str, Any] = {"on_progress": on_progress}
+            if retune_kwargs is not None:
+                # Forward ``resume`` / ``n_trials`` / ``expand_boundary`` /
+                # ``boundary_threshold`` straight to the adapter; the
+                # signatures match by design (P-028 / adapter.tune).
+                tune_kwargs.update(retune_kwargs)
+            summary_t = adapter.tune(model, **tune_kwargs)
             # ``model.tune()`` does not auto-fit — the adapter returns
             # ``[]`` from evaluate_table/split_summary on an unfit model
             # (#147 / P-036, see :func:`adapter_results.is_model_fitted`).
@@ -194,6 +214,8 @@ def main() -> None:
         target=input_data["target"],
         model_out_path=input_data.get("model_out_path"),
         tune_state_out_path=input_data.get("tune_state_out_path"),
+        retune_kwargs=input_data.get("retune_kwargs"),
+        tune_state_in_path=input_data.get("tune_state_in_path"),
         output=sys.stdout.buffer,
     )
 

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -752,11 +752,22 @@ class LizyMLAdapter:
         return path
 
     def export_tune_state(self, model: Any, path: str) -> None:
-        """Persist tune state for IPC across the subprocess boundary (P-037).
+        """Persist tune state for IPC across the subprocess boundary (P-037, P-038).
 
-        Writes a pickle blob containing ``_tuning_result`` (always) and
-        ``_study`` (best-effort — silently dropped when the study object
-        cannot be pickled, e.g., RDB-backed Optuna storage).
+        Writes a pickle blob containing the lizyml ``Model`` state required
+        to resume tuning in a different process:
+
+        - ``tuning_result``: always present. Drives ``optimization-history``
+          plot rendering on the parent (P-037).
+        - ``study``: Optuna study handle, best-effort — silently dropped
+          when not pickleable (e.g., RDB-backed storage).
+        - ``round_number`` / ``rounds`` / ``space`` / ``used_default_space``:
+          added for P-038 (subprocess retune resume). lizyml's
+          ``Model.tune(resume=True)`` reads these instance attributes to
+          build the cumulative ``rounds`` list and to reuse the original
+          search space; without them, retune appears to succeed but
+          discards previous rounds (only the new round shows up in
+          ``tune_summary.rounds``).
 
         Raises:
             ValueError: when *model* has no tune state to export. Callers
@@ -768,7 +779,17 @@ class LizyMLAdapter:
             msg = "Model has no tune state to export (run tune() first)"
             raise ValueError(msg)
 
-        blob: dict[str, Any] = {"tuning_result": tuning_result, "study": None}
+        blob: dict[str, Any] = {
+            "tuning_result": tuning_result,
+            "study": None,
+            # P-038: round bookkeeping. Pulled via getattr so older lizyml
+            # versions that lack any of these attributes still produce a
+            # blob (the corresponding restore step skips missing keys).
+            "round_number": getattr(model, "_round_number", 0),
+            "rounds": list(getattr(model, "_rounds", [])),
+            "space": getattr(model, "_space", None),
+            "used_default_space": getattr(model, "_used_default_space", False),
+        }
 
         study = getattr(model, "_study", None)
         if study is not None:
@@ -786,10 +807,16 @@ class LizyMLAdapter:
             pickle.dump(blob, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     def restore_tune_state(self, model: Any, path: str) -> None:
-        """Reattach tune state onto *model* from an IPC blob (P-037).
+        """Reattach tune state onto *model* from an IPC blob (P-037, P-038).
 
-        Reads what :meth:`export_tune_state` wrote and assigns
-        ``model._tuning_result`` (and ``model._study`` when present).
+        Reads what :meth:`export_tune_state` wrote and assigns the
+        corresponding ``Model`` private attributes. P-037 keys
+        (``tuning_result`` / ``study``) are always restored; P-038 keys
+        (``round_number`` / ``rounds`` / ``space`` / ``used_default_space``)
+        are restored when present so subprocess retune accumulates rounds
+        correctly. Backward compat: blobs written by a P-037-only export
+        still restore ``_tuning_result`` (plot rendering keeps working).
+
         The model remains unfit — INV-2 keeps ``is_model_fitted`` False so
         downstream guards (``available_plots``, ``evaluate_table``)
         continue to behave correctly.
@@ -802,6 +829,17 @@ class LizyMLAdapter:
         study = blob.get("study")
         if study is not None:
             model._study = study  # noqa: SLF001
+        # P-038: restore round bookkeeping when present. Older blobs
+        # (P-037) lack these keys; skipping them leaves lizyml's defaults
+        # intact, which is what plot-only restore needs anyway.
+        if "round_number" in blob:
+            model._round_number = blob["round_number"]  # noqa: SLF001
+        if "rounds" in blob:
+            model._rounds = list(blob["rounds"])  # noqa: SLF001
+        if "space" in blob:
+            model._space = blob["space"]  # noqa: SLF001
+        if "used_default_space" in blob:
+            model._used_default_space = blob["used_default_space"]  # noqa: SLF001
 
     def export_code(self, model: Any, path: str) -> Any:
         """Export inference code for the trained model."""

--- a/src/lizyml_widget/adapter.py
+++ b/src/lizyml_widget/adapter.py
@@ -165,10 +165,23 @@ class BackendAdapter(Protocol):
 
     def model_info(self, model: Any) -> dict[str, Any]: ...
 
-    # P-037: tune state cross-process persistence (#152). The subprocess
-    # writes ``model._tuning_result`` (and best-effort ``_study``) to a
-    # path; the parent reads the path back onto a freshly-created model so
-    # ``optimization-history`` plot renders without re-fitting.
+    # P-037: tune state cross-process persistence (#152). P-038 (#156)
+    # extended this to support subprocess retune resume.
+    #
+    # ``export_tune_state`` writes a pickle blob containing every Model
+    # attribute the backend's resume path reads. For LizyMLAdapter the
+    # blob holds 6 keys: ``tuning_result`` (always — P-037 minimum,
+    # required for ``optimization-history`` plot rendering) plus
+    # ``study``, ``round_number``, ``rounds``, ``space``,
+    # ``used_default_space`` (P-038, required for ``Model.tune(resume=True)``
+    # to accumulate rounds correctly). Implementations may add more keys
+    # but MUST keep the existing keys forward-compatible.
+    #
+    # ``restore_tune_state`` reads the blob produced by the same adapter
+    # version (or an older one) and reattaches every present key to the
+    # model. Missing keys must NOT raise — that path supports loading
+    # P-037-format blobs onto a P-038 adapter so plot rendering keeps
+    # working without retune support.
     def export_tune_state(self, model: Any, path: str) -> None: ...
 
     def restore_tune_state(self, model: Any, path: str) -> None: ...

--- a/src/lizyml_widget/job_runner.py
+++ b/src/lizyml_widget/job_runner.py
@@ -244,10 +244,18 @@ class SubprocessJobRunner:
         cancel_event: threading.Event,
     ) -> JobResult:
         if spec.retune_kwargs:
+            # #154: under default install, ``widget._run_job`` falls back to
+            # the thread runner before reaching this branch. This rejection
+            # only fires when a caller bypasses the supervisor (tests) or
+            # the user explicitly forces subprocess via direct construction.
+            # Remediation must point to the actual opt-out env var
+            # (``LZW_FORCE_THREAD=1`` post-P-036, not the legacy
+            # ``LZW_FORCE_SUBPROCESS=1`` which is a no-op).
             msg = (
                 "Re-tune is not supported in subprocess execution mode. "
-                "Unset LZW_FORCE_SUBPROCESS=1 or use w.tune() for a "
-                "fresh study."
+                "Set LZW_FORCE_THREAD=1 to opt back into the in-process "
+                "runner, or call w.tune() for a fresh study. "
+                "(Subprocess re-tune resume is tracked by issue #128.)"
             )
             raise RetuneSubprocessUnsupportedError(msg)
 

--- a/src/lizyml_widget/job_runner.py
+++ b/src/lizyml_widget/job_runner.py
@@ -37,19 +37,15 @@ __all__ = [
     "JobResult",
     "JobRunner",
     "JobSpec",
-    "RetuneSubprocessUnsupportedError",
     "SubprocessJobRunner",
     "ThreadJobRunner",
 ]
 
 
-class RetuneSubprocessUnsupportedError(RuntimeError):
-    """Raised when retune is requested via the subprocess runner.
-
-    The subprocess path cannot pick up an existing Optuna study from a
-    fresh process today; supervisors translate this into a structured
-    ``RETUNE_SUBPROCESS_UNSUPPORTED`` error code on the widget.
-    """
+# P-038: ``RetuneSubprocessUnsupportedError`` removed. Subprocess retune
+# resume is the supported path now (see ``SubprocessJobRunner.run`` and
+# ``service.export_tune_state_to_path``). The historical class became dead
+# weight once the thread fallback (PR #155) was removed.
 
 
 @dataclass(frozen=True)
@@ -219,11 +215,12 @@ class SubprocessJobRunner:
     delivered as ``SIGTERM`` to the child process; the parent's
     ``on_progress`` does not need to raise ``InterruptedError`` itself.
 
-    Re-tune is not supported on this path yet — the subprocess starts
-    with a fresh interpreter and cannot resume the previous Optuna
-    study. The supervisor turns
-    :class:`RetuneSubprocessUnsupportedError` into the
-    ``RETUNE_SUBPROCESS_UNSUPPORTED`` error code.
+    P-038: re-tune is supported on this path via the tune-state IPC. The
+    parent serialises the current ``service._tune_model`` tune state into
+    a temp file, the subprocess reads it back via
+    ``adapter.restore_tune_state`` before invoking
+    ``adapter.tune(resume=True, ...)``. This decouples retune execution
+    from the parent main thread's libgomp pool affinity (#156).
     """
 
     kind: str = "subprocess"
@@ -243,22 +240,6 @@ class SubprocessJobRunner:
         on_progress: Callable[..., None],
         cancel_event: threading.Event,
     ) -> JobResult:
-        if spec.retune_kwargs:
-            # #154: under default install, ``widget._run_job`` falls back to
-            # the thread runner before reaching this branch. This rejection
-            # only fires when a caller bypasses the supervisor (tests) or
-            # the user explicitly forces subprocess via direct construction.
-            # Remediation must point to the actual opt-out env var
-            # (``LZW_FORCE_THREAD=1`` post-P-036, not the legacy
-            # ``LZW_FORCE_SUBPROCESS=1`` which is a no-op).
-            msg = (
-                "Re-tune is not supported in subprocess execution mode. "
-                "Set LZW_FORCE_THREAD=1 to opt back into the in-process "
-                "runner, or call w.tune() for a fresh study. "
-                "(Subprocess re-tune resume is tracked by issue #128.)"
-            )
-            raise RetuneSubprocessUnsupportedError(msg)
-
         df = self._service.get_dataframe()
         target = self._service.get_df_info().get("target", "")
         model_out_path = tempfile.mkdtemp(prefix="lzw_model_")
@@ -275,6 +256,29 @@ class SubprocessJobRunner:
         tune_state_out_path = tune_state_fd.name
         tune_state_fd.close()
 
+        # P-038: subprocess retune resume — when ``retune_kwargs`` is set,
+        # serialise the current parent-side tune state into a temp file so
+        # the subprocess can pick up the existing Optuna study. ``service``
+        # raises ``ValueError`` if no prior tune model exists (early fail
+        # before the subprocess spawns).
+        tune_state_in_path: str | None = None
+        if spec.retune_kwargs is not None:
+            tune_state_in_fd = tempfile.NamedTemporaryFile(  # noqa: SIM115 — caller owns lifecycle
+                prefix="lzw_tune_state_in_", suffix=".pkl", delete=False
+            )
+            tune_state_in_path = tune_state_in_fd.name
+            tune_state_in_fd.close()
+            try:
+                self._service.export_tune_state_to_path(tune_state_in_path)
+            except Exception:
+                with contextlib.suppress(OSError):
+                    Path(tune_state_in_path).unlink(missing_ok=True)
+                with contextlib.suppress(OSError):
+                    shutil.rmtree(model_out_path, ignore_errors=True)
+                with contextlib.suppress(OSError):
+                    Path(tune_state_out_path).unlink(missing_ok=True)
+                raise
+
         try:
             sp_result = run_job_subprocess(
                 job_type=spec.job_type,
@@ -286,6 +290,8 @@ class SubprocessJobRunner:
                 cancel_flag=cancel_event,
                 model_out_path=model_out_path,
                 tune_state_out_path=tune_state_out_path,
+                retune_kwargs=spec.retune_kwargs,
+                tune_state_in_path=tune_state_in_path,
             )
             # Load model back from subprocess so the widget side can
             # serve plots / inference.
@@ -337,3 +343,8 @@ class SubprocessJobRunner:
             # finished reading it (no-op if subprocess never wrote it).
             with contextlib.suppress(OSError):
                 Path(tune_state_out_path).unlink(missing_ok=True)
+            # P-038: symmetric cleanup for the inbound retune tune-state
+            # blob; the subprocess only reads it, never writes it back.
+            if tune_state_in_path is not None:
+                with contextlib.suppress(OSError):
+                    Path(tune_state_in_path).unlink(missing_ok=True)

--- a/src/lizyml_widget/job_runner.py
+++ b/src/lizyml_widget/job_runner.py
@@ -268,6 +268,11 @@ class SubprocessJobRunner:
             )
             tune_state_in_path = tune_state_in_fd.name
             tune_state_in_fd.close()
+            # Catch broad to cover both expected ``ValueError`` (no prior
+            # tune) and unexpected I/O errors during pickle.dump — both
+            # must abort before the subprocess spawns and clean up the
+            # three tempfiles allocated above. The ``raise`` re-throws
+            # the original so the supervisor classifies it correctly.
             try:
                 self._service.export_tune_state_to_path(tune_state_in_path)
             except Exception:

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -791,6 +791,30 @@ class WidgetService:
         with self._model_lock:
             self._model = model
 
+    def export_tune_state_to_path(self, path: str) -> None:
+        """Serialize the current tune state to *path* for subprocess retune (P-038).
+
+        Symmetric counterpart of :meth:`restore_tune_state_from_path`. Used by
+        ``SubprocessJobRunner`` when launching a subprocess retune: the parent
+        writes ``_tune_model._tuning_result`` (and best-effort ``_study``) to
+        *path* so the subprocess can pick up the existing Optuna study before
+        calling ``adapter.tune(resume=True, ...)``.
+
+        Raises
+        ------
+        ValueError
+            If no prior tune model exists. Subprocess retune requires the
+            in-memory state of a previous tune to be exportable; calling
+            without a prior tune is a programming error and is rejected
+            early so the subprocess never spawns.
+        """
+        with self._model_lock:
+            model = self._tune_model
+        if model is None:
+            msg = "Cannot export tune state: no prior tune exists. Run w.tune() first."
+            raise ValueError(msg)
+        self._adapter.export_tune_state(model, path)
+
     def restore_tune_state_from_path(
         self,
         path: str,
@@ -815,11 +839,9 @@ class WidgetService:
             self._model = model
             # Mirror the in-process tune path (P-028 ``_tune_model`` slot) so
             # apply_best_params → Fit → retune still has the tuned-state model
-            # available. Without this, subprocess tune leaves
-            # ``_tune_model is None`` and any future retune flow regresses.
-            # Subprocess retune itself is still rejected today (see
-            # ``RetuneSubprocessUnsupportedError``), so the parity matters
-            # only when the user opts back into thread mode for retune.
+            # available. Without this, subprocess tune would leave
+            # ``_tune_model is None`` and the next retune (P-038 subprocess
+            # retune resume) would have no tune state to export.
             self._tune_model = model
 
     def save_model(self, path: str) -> str:

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -800,6 +800,20 @@ class WidgetService:
         *path* so the subprocess can pick up the existing Optuna study before
         calling ``adapter.tune(resume=True, ...)``.
 
+        Concurrency note
+        ----------------
+        The pickle I/O runs **outside** ``_model_lock`` for the same reason
+        :meth:`tune` does: holding the lock through a multi-MB write would
+        serialise unrelated reads (e.g., ``predict``). The lock is held only
+        long enough to take a strong reference to ``_tune_model`` so that an
+        intervening ``load_data()`` cannot null it out between the read and
+        the export. Inside :meth:`adapter.LizyMLAdapter.export_tune_state`,
+        ``_rounds`` is copied with ``list(...)`` and the study is pickled
+        (deep copy semantics), so concurrent writes to the model after the
+        reference is taken cannot corrupt the blob; the worst case is that
+        the blob reflects a slightly stale snapshot, which the supervisor
+        FSM (INV-A: at most one running job) already prevents in practice.
+
         Raises
         ------
         ValueError

--- a/src/lizyml_widget/subprocess_runner.py
+++ b/src/lizyml_widget/subprocess_runner.py
@@ -86,8 +86,15 @@ def run_job_subprocess(
     cancel_flag: threading.Event,
     model_out_path: str | None = None,
     tune_state_out_path: str | None = None,
+    retune_kwargs: dict[str, Any] | None = None,
+    tune_state_in_path: str | None = None,
 ) -> SubprocessJobResult:
     """Spawn subprocess and run training job.
+
+    P-038: ``retune_kwargs`` and ``tune_state_in_path`` extend the input
+    contract to support subprocess retune resume. When ``retune_kwargs``
+    is non-None, the subprocess restores tune state from
+    ``tune_state_in_path`` and invokes ``adapter.tune(resume=True, ...)``.
 
     Raises InterruptedError on cancellation, RuntimeError on failure.
     """
@@ -100,6 +107,8 @@ def run_job_subprocess(
             "target": target,
             "model_out_path": model_out_path,
             "tune_state_out_path": tune_state_out_path,
+            "retune_kwargs": retune_kwargs,
+            "tune_state_in_path": tune_state_in_path,
         },
         protocol=pickle.HIGHEST_PROTOCOL,
     )

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -20,7 +20,6 @@ from .job_runner import (
     JobResult,
     JobRunner,
     JobSpec,
-    RetuneSubprocessUnsupportedError,
     SubprocessJobRunner,
     ThreadJobRunner,
 )
@@ -105,13 +104,6 @@ class LizyWidget(anywidget.AnyWidget):
         self._job_lock = threading.Lock()
         self._job_counter = 0
         self._inference_df: pd.DataFrame | None = None
-        # #154: warn-once flag for the retune→thread fallback notice. The
-        # check/set in ``_run_job`` runs after ``_job_lock`` is released
-        # (the lock only protects the FSM transition, not runner choice),
-        # so a race between two near-simultaneous retunes could log the
-        # notice twice. That is harmless and we accept it; the cost of
-        # adding a separate lock is not justified for an info log.
-        self._retune_fallback_warned: bool = False
         # P-035: tune snapshots now live on TuningSummary inside
         # WidgetService, not on the widget. Removed _tune_config_snapshot
         # and _tune_ui_snapshot.
@@ -606,25 +598,14 @@ class LizyWidget(anywidget.AnyWidget):
         # The supervisor in ``_supervise`` owns the state machine + traitlet
         # plumbing for *both* runners, so the worker logic lives once.
         #
-        # #154: ``SubprocessJobRunner`` cannot resume an Optuna study from a
-        # fresh process today (#128 tracks the long-term fix using P-037's
-        # tune-state IPC). Until that lands, transparently fall back to the
-        # thread runner for re-tune jobs when subprocess is the default —
-        # otherwise the happy-path ``w.tune() → w.retune()`` flow surfaces
-        # ``RETUNE_SUBPROCESS_UNSUPPORTED`` on every default install. Initial
-        # tune (``retune_kwargs is None``) still uses subprocess to keep the
-        # P-036 / #147 perf win.
+        # P-038: subprocess retune resume is now supported via tune-state
+        # IPC. Runner selection is therefore strategy-only — retune routes
+        # to the same path as initial tune. The previous PR #155 thread
+        # fallback is gone; it was unsafe whenever the user entered any
+        # libgomp parallel region on the parent main thread (#156).
         runner: JobRunner
-        if self._execution_strategy == "subprocess" and retune_kwargs is None:
+        if self._execution_strategy == "subprocess":
             runner = SubprocessJobRunner(self._service, libomp_path=self._libomp_path)
-        elif self._execution_strategy == "subprocess" and retune_kwargs is not None:
-            if not self._retune_fallback_warned:
-                _log.info(
-                    "re-tune temporarily falls back to thread runner; "
-                    "subprocess re-tune resume is tracked by issue #128"
-                )
-                self._retune_fallback_warned = True
-            runner = ThreadJobRunner(self._service)
         else:
             runner = ThreadJobRunner(self._service)
         spec = JobSpec(
@@ -707,13 +688,6 @@ class LizyWidget(anywidget.AnyWidget):
             self._apply_job_result(result)
             self.elapsed_sec = round(time.monotonic() - start, 1)
             self.status = "completed"
-        except RetuneSubprocessUnsupportedError as exc:
-            self.elapsed_sec = round(time.monotonic() - start, 1)
-            self.error = {
-                "code": "RETUNE_SUBPROCESS_UNSUPPORTED",
-                "message": str(exc),
-            }
-            self.status = "failed"
         except InterruptedError:
             # INV-D (BLUEPRINT §6.4): cancel during running -> failed/CANCELLED.
             self.elapsed_sec = round(time.monotonic() - start, 1)

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -105,6 +105,13 @@ class LizyWidget(anywidget.AnyWidget):
         self._job_lock = threading.Lock()
         self._job_counter = 0
         self._inference_df: pd.DataFrame | None = None
+        # #154: warn-once flag for the retune→thread fallback notice. The
+        # check/set in ``_run_job`` runs after ``_job_lock`` is released
+        # (the lock only protects the FSM transition, not runner choice),
+        # so a race between two near-simultaneous retunes could log the
+        # notice twice. That is harmless and we accept it; the cost of
+        # adding a separate lock is not justified for an info log.
+        self._retune_fallback_warned: bool = False
         # P-035: tune snapshots now live on TuningSummary inside
         # WidgetService, not on the widget. Removed _tune_config_snapshot
         # and _tune_ui_snapshot.
@@ -598,9 +605,26 @@ class LizyWidget(anywidget.AnyWidget):
         # P-032: pick the runner strategy and hand it the immutable JobSpec.
         # The supervisor in ``_supervise`` owns the state machine + traitlet
         # plumbing for *both* runners, so the worker logic lives once.
+        #
+        # #154: ``SubprocessJobRunner`` cannot resume an Optuna study from a
+        # fresh process today (#128 tracks the long-term fix using P-037's
+        # tune-state IPC). Until that lands, transparently fall back to the
+        # thread runner for re-tune jobs when subprocess is the default —
+        # otherwise the happy-path ``w.tune() → w.retune()`` flow surfaces
+        # ``RETUNE_SUBPROCESS_UNSUPPORTED`` on every default install. Initial
+        # tune (``retune_kwargs is None``) still uses subprocess to keep the
+        # P-036 / #147 perf win.
         runner: JobRunner
-        if self._execution_strategy == "subprocess":
+        if self._execution_strategy == "subprocess" and retune_kwargs is None:
             runner = SubprocessJobRunner(self._service, libomp_path=self._libomp_path)
+        elif self._execution_strategy == "subprocess" and retune_kwargs is not None:
+            if not self._retune_fallback_warned:
+                _log.info(
+                    "re-tune temporarily falls back to thread runner; "
+                    "subprocess re-tune resume is tracked by issue #128"
+                )
+                self._retune_fallback_warned = True
+            runner = ThreadJobRunner(self._service)
         else:
             runner = ThreadJobRunner(self._service)
         spec = JobSpec(

--- a/tests/regression/test_reg_154_default_strategy_retune.py
+++ b/tests/regression/test_reg_154_default_strategy_retune.py
@@ -2,26 +2,28 @@
 
 After P-036 made subprocess the default execution strategy on libgomp hosts,
 ``w.tune() → w.retune()`` happy path failed by default with
-``RETUNE_SUBPROCESS_UNSUPPORTED``. The remediation message also pointed
-users to the post-P-036 no-op ``LZW_FORCE_SUBPROCESS=1`` env var.
+``RETUNE_SUBPROCESS_UNSUPPORTED``. PR #155 patched this with a thread
+fallback; #156 / P-038 then replaced the fallback with subprocess retune
+resume because the thread fallback was unsafe whenever any libgomp
+parallel region had been entered on the parent main thread.
 
-These tests pin the post-fix contract:
+These tests pin the post-P-038 contract:
 
-- INV-#154-A: under the default strategy, ``w.retune(...)`` after a successful
-  ``w.tune()`` completes via an automatic fallback to the thread runner.
-- INV-#154-B: any remaining subprocess-rejection error message must point to
-  ``LZW_FORCE_THREAD=1`` (the actual opt-out), not the no-op env var.
+- INV-#154-A: under the default strategy, ``w.retune(...)`` after a
+  successful ``w.tune()`` completes via the SAME ``SubprocessJobRunner``
+  used by initial tune (no thread fallback any more).
 - INV-#154-C: subprocess Fit overhead is bounded (slow regression — pinned
   numerically so future strategy changes that double the cost fail CI).
 
-Test failures on commit ``8d169f5`` (current ``develop`` tip), pass after the
-hotfix lands.
+INV-#154-B (rejection-message remediation) was retired alongside
+``RetuneSubprocessUnsupportedError`` itself in P-038. The full
+subprocess retune contract now lives in
+``test_reg_156_subprocess_retune.py``.
 """
 
 from __future__ import annotations
 
 import os
-import threading
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -67,25 +69,46 @@ def _make_widget_with_data() -> Any:
 
 
 # ---------------------------------------------------------------------------
-# INV-#154-A: retune auto-fallback under default subprocess strategy
+# INV-#154-A: retune routes through the SubprocessJobRunner under default
+# (P-038 replaced PR #155's thread fallback with subprocess retune resume).
 # ---------------------------------------------------------------------------
 
 
-class TestRetuneAutoFallbackUnderDefaultStrategy:
-    """When strategy is detected as ``subprocess``, ``_run_job(retune)`` must
-    transparently fall back to ``ThreadJobRunner`` so the user-visible flow
-    succeeds without env-var fiddling."""
+class TestRetuneRoutesToSubprocessRunnerUnderDefault:
+    """Under the default subprocess strategy, ``w.retune(...)`` must use the
+    same ``SubprocessJobRunner`` as initial tune. PR #155's thread fallback
+    is gone."""
 
-    def test_retune_with_subprocess_default_uses_thread_runner(self) -> None:
-        """The supervisor must end in ``completed``, not ``failed`` with
-        ``RETUNE_SUBPROCESS_UNSUPPORTED``."""
-        with patch(
-            "lizyml_widget.widget.get_execution_strategy",
-            return_value=("subprocess", "/usr/lib/libomp5.so"),
+    def test_retune_with_subprocess_default_uses_subprocess_runner(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", "/usr/lib/libomp5.so"),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
         ):
-            w = _make_widget_with_data()
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = MagicMock(
+                job_type="tune",
+                fit_summary={},
+                tune_summary={
+                    "best_params": {},
+                    "best_score": 0.91,
+                    "trials": [],
+                    "metric_name": "auc",
+                    "direction": "maximize",
+                    "rounds": [],
+                    "boundary_report": None,
+                },
+                eval_table=[],
+                split_summary=[],
+                available_plots=["optimization-history"],
+                model_path=None,
+            )
 
-            # Seed prior tune so retune() passes the precondition.
+            w = _make_widget_with_data()
             w.tune_summary = {
                 "best_params": {"learning_rate": 0.05},
                 "best_score": 0.9,
@@ -95,45 +118,23 @@ class TestRetuneAutoFallbackUnderDefaultStrategy:
                 "rounds": [],
                 "boundary_report": None,
             }
-            # Replace service.tune so retune doesn't hit lightgbm.
-            captured: list[dict[str, Any]] = []
-
-            def mock_tune(config: dict[str, Any], *, on_progress: Any = None, **kwargs: Any) -> Any:
-                captured.append(kwargs)
-                from lizyml_widget.types import TuningSummary
-
-                return TuningSummary(
-                    best_params={},
-                    best_score=0.91,
-                    trials=[],
-                    metric_name="auc",
-                    direction="maximize",
-                    rounds=[],
-                    boundary_report=None,
-                )
-
-            w._service.tune = mock_tune  # type: ignore[assignment]
             w._service._tune_model = MagicMock()  # P-028 prerequisite
 
             w.retune(n_trials=5)
-
-            # Wait for the supervisor thread to complete.
             if w._job_thread:
                 w._job_thread.join(timeout=10)
 
+            mock_sp.assert_called_once()
+            mock_thread.assert_not_called()
             assert w.status == "completed", (
-                f"Expected retune to complete via thread fallback; "
+                f"Expected retune to complete via subprocess runner; "
                 f"got status={w.status!r} error={w.error!r}"
             )
             assert w.error.get("code") != "RETUNE_SUBPROCESS_UNSUPPORTED"
-            # The thread runner forwards resume kwargs via _run_tune.
-            assert captured, "service.tune was never called"
-            assert captured[0].get("resume") is True
-            assert captured[0].get("n_trials") == 5
 
     def test_initial_tune_still_uses_subprocess_under_default(self) -> None:
-        """The fallback must be retune-only — initial tune must NOT regress
-        back to thread mode (that would re-introduce the #147 30x slowdown)."""
+        """Initial tune must continue to use subprocess (the #147 perf win
+        must not regress)."""
 
         with (
             patch(
@@ -169,45 +170,6 @@ class TestRetuneAutoFallbackUnderDefaultStrategy:
             # Initial tune used subprocess runner.
             mock_sp.assert_called_once()
             mock_thread.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# INV-#154-B: error message points to the actual opt-out env var
-# ---------------------------------------------------------------------------
-
-
-class TestRejectionMessageRemediation:
-    """Even when subprocess retune is rejected (e.g. user explicitly forces
-    subprocess), the remediation guidance must reference ``LZW_FORCE_THREAD``,
-    not the no-op ``LZW_FORCE_SUBPROCESS``."""
-
-    def test_rejection_message_mentions_lzw_force_thread(self) -> None:
-        from lizyml_widget.job_runner import (
-            JobSpec,
-            RetuneSubprocessUnsupportedError,
-            SubprocessJobRunner,
-        )
-
-        w = _make_widget_with_data()
-        runner = SubprocessJobRunner(w._service)
-        spec = JobSpec(
-            job_type="tune",
-            config={"config_version": 1},
-            retune_kwargs={"resume": True, "n_trials": 10},
-        )
-        with pytest.raises(RetuneSubprocessUnsupportedError) as exc_info:
-            runner.run(spec, on_progress=lambda *a, **kw: None, cancel_event=threading.Event())
-
-        msg = str(exc_info.value)
-        # The historical wording referenced the no-op env var; the new
-        # message must point users to the actual opt-out.
-        assert "LZW_FORCE_THREAD" in msg, (
-            f"Expected remediation message to mention LZW_FORCE_THREAD; got: {msg!r}"
-        )
-        assert "LZW_FORCE_SUBPROCESS" not in msg, (
-            f"LZW_FORCE_SUBPROCESS is a no-op after P-036 and must not appear "
-            f"in the remediation message; got: {msg!r}"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_reg_154_default_strategy_retune.py
+++ b/tests/regression/test_reg_154_default_strategy_retune.py
@@ -1,0 +1,274 @@
+"""Regression tests for issue #154 — subprocess-default retune regressions.
+
+After P-036 made subprocess the default execution strategy on libgomp hosts,
+``w.tune() → w.retune()`` happy path failed by default with
+``RETUNE_SUBPROCESS_UNSUPPORTED``. The remediation message also pointed
+users to the post-P-036 no-op ``LZW_FORCE_SUBPROCESS=1`` env var.
+
+These tests pin the post-fix contract:
+
+- INV-#154-A: under the default strategy, ``w.retune(...)`` after a successful
+  ``w.tune()`` completes via an automatic fallback to the thread runner.
+- INV-#154-B: any remaining subprocess-rejection error message must point to
+  ``LZW_FORCE_THREAD=1`` (the actual opt-out), not the no-op env var.
+- INV-#154-C: subprocess Fit overhead is bounded (slow regression — pinned
+  numerically so future strategy changes that double the cost fail CI).
+
+Test failures on commit ``8d169f5`` (current ``develop`` tip), pass after the
+hotfix lands.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.types import BackendInfo
+
+
+def _make_widget_with_data() -> Any:
+    """Build a LizyWidget with the real LizyMLAdapter wrapped behind a mock so
+    canonical config / backend-contract calls work but ML library calls can
+    be intercepted by the test."""
+    real_adapter = LizyMLAdapter()
+    with patch("lizyml_widget.widget.LizyMLAdapter") as MockAdapter:
+        adapter = MockAdapter.return_value
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.get_config_schema.return_value = {"type": "object"}
+        adapter.validate_config.return_value = []
+        adapter.initialize_config.side_effect = real_adapter.initialize_config
+        adapter.apply_config_patch.side_effect = real_adapter.apply_config_patch
+        adapter.prepare_run_config.side_effect = real_adapter.prepare_run_config
+        adapter.get_backend_contract.side_effect = real_adapter.get_backend_contract
+        adapter.canonicalize_config.side_effect = real_adapter.canonicalize_config
+        adapter.apply_task_defaults.side_effect = real_adapter.apply_task_defaults
+        adapter.classify_best_params.side_effect = real_adapter.classify_best_params
+
+        from lizyml_widget.widget import LizyWidget
+
+        w = LizyWidget()
+    df = pd.DataFrame(
+        {
+            "f1": list(range(40)),
+            "f2": [i * 0.5 for i in range(40)],
+            "f3": [i % 5 for i in range(40)],
+            "y": [0, 1] * 20,
+        }
+    )
+    w.load(df, target="y")
+    return w
+
+
+# ---------------------------------------------------------------------------
+# INV-#154-A: retune auto-fallback under default subprocess strategy
+# ---------------------------------------------------------------------------
+
+
+class TestRetuneAutoFallbackUnderDefaultStrategy:
+    """When strategy is detected as ``subprocess``, ``_run_job(retune)`` must
+    transparently fall back to ``ThreadJobRunner`` so the user-visible flow
+    succeeds without env-var fiddling."""
+
+    def test_retune_with_subprocess_default_uses_thread_runner(self) -> None:
+        """The supervisor must end in ``completed``, not ``failed`` with
+        ``RETUNE_SUBPROCESS_UNSUPPORTED``."""
+        with patch(
+            "lizyml_widget.widget.get_execution_strategy",
+            return_value=("subprocess", "/usr/lib/libomp5.so"),
+        ):
+            w = _make_widget_with_data()
+
+            # Seed prior tune so retune() passes the precondition.
+            w.tune_summary = {
+                "best_params": {"learning_rate": 0.05},
+                "best_score": 0.9,
+                "trials": [],
+                "metric_name": "auc",
+                "direction": "maximize",
+                "rounds": [],
+                "boundary_report": None,
+            }
+            # Replace service.tune so retune doesn't hit lightgbm.
+            captured: list[dict[str, Any]] = []
+
+            def mock_tune(config: dict[str, Any], *, on_progress: Any = None, **kwargs: Any) -> Any:
+                captured.append(kwargs)
+                from lizyml_widget.types import TuningSummary
+
+                return TuningSummary(
+                    best_params={},
+                    best_score=0.91,
+                    trials=[],
+                    metric_name="auc",
+                    direction="maximize",
+                    rounds=[],
+                    boundary_report=None,
+                )
+
+            w._service.tune = mock_tune  # type: ignore[assignment]
+            w._service._tune_model = MagicMock()  # P-028 prerequisite
+
+            w.retune(n_trials=5)
+
+            # Wait for the supervisor thread to complete.
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            assert w.status == "completed", (
+                f"Expected retune to complete via thread fallback; "
+                f"got status={w.status!r} error={w.error!r}"
+            )
+            assert w.error.get("code") != "RETUNE_SUBPROCESS_UNSUPPORTED"
+            # The thread runner forwards resume kwargs via _run_tune.
+            assert captured, "service.tune was never called"
+            assert captured[0].get("resume") is True
+            assert captured[0].get("n_trials") == 5
+
+    def test_initial_tune_still_uses_subprocess_under_default(self) -> None:
+        """The fallback must be retune-only — initial tune must NOT regress
+        back to thread mode (that would re-introduce the #147 30x slowdown)."""
+
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = MagicMock(
+                job_type="tune",
+                fit_summary={},
+                tune_summary={
+                    "best_params": {},
+                    "best_score": 0.9,
+                    "trials": [],
+                    "metric_name": "auc",
+                    "direction": "maximize",
+                },
+                eval_table=[],
+                split_summary=[],
+                available_plots=[],
+                model_path=None,
+            )
+
+            w = _make_widget_with_data()
+            w._run_job("tune")
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            # Initial tune used subprocess runner.
+            mock_sp.assert_called_once()
+            mock_thread.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# INV-#154-B: error message points to the actual opt-out env var
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionMessageRemediation:
+    """Even when subprocess retune is rejected (e.g. user explicitly forces
+    subprocess), the remediation guidance must reference ``LZW_FORCE_THREAD``,
+    not the no-op ``LZW_FORCE_SUBPROCESS``."""
+
+    def test_rejection_message_mentions_lzw_force_thread(self) -> None:
+        from lizyml_widget.job_runner import (
+            JobSpec,
+            RetuneSubprocessUnsupportedError,
+            SubprocessJobRunner,
+        )
+
+        w = _make_widget_with_data()
+        runner = SubprocessJobRunner(w._service)
+        spec = JobSpec(
+            job_type="tune",
+            config={"config_version": 1},
+            retune_kwargs={"resume": True, "n_trials": 10},
+        )
+        with pytest.raises(RetuneSubprocessUnsupportedError) as exc_info:
+            runner.run(spec, on_progress=lambda *a, **kw: None, cancel_event=threading.Event())
+
+        msg = str(exc_info.value)
+        # The historical wording referenced the no-op env var; the new
+        # message must point users to the actual opt-out.
+        assert "LZW_FORCE_THREAD" in msg, (
+            f"Expected remediation message to mention LZW_FORCE_THREAD; got: {msg!r}"
+        )
+        assert "LZW_FORCE_SUBPROCESS" not in msg, (
+            f"LZW_FORCE_SUBPROCESS is a no-op after P-036 and must not appear "
+            f"in the remediation message; got: {msg!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-#154-C: subprocess Fit overhead is bounded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_subprocess_fit_overhead_is_bounded() -> None:
+    """End-to-end: under default strategy on a libgomp host, a small Fit
+    must complete within a generous upper bound. This pins the overhead so
+    a catastrophic strategy regression (e.g. double-spawning, recursive
+    process tree) fails CI.
+
+    Threshold rationale: measured 1.6-1.9s standalone on a WSL2 host
+    (5000 rows x 30 cols). When this test runs immediately after
+    ``test_reg_147_openmp_perf.py``, ``subprocess.Popen`` slows
+    dramatically (observed 22s) because the parent process retains
+    ~120 leaked libgomp threads from the perf test's worker-thread
+    sequence — the cost is in fork()/Popen, not in the actual Fit. The
+    bound is set high enough (30s) to absorb that interaction while still
+    catching a genuine 15x+ regression in the subprocess code path
+    (BLUEPRINT §3.7.1 design budget is ~500ms-2s; anything past 30s
+    indicates a fundamentally broken strategy).
+    """
+    if not __import__("sys").platform.startswith("linux"):
+        pytest.skip("subprocess default applies only on Linux + libgomp")
+
+    from lizyml_widget.openmp_detect import _reset_libgomp_cache, get_execution_strategy
+
+    _reset_libgomp_cache()
+    os.environ.pop("LZW_FORCE_THREAD", None)
+    strategy, _ = get_execution_strategy()
+    if strategy != "subprocess":
+        pytest.skip(f"strategy is {strategy}; bound applies only to subprocess default")
+
+    import numpy as np
+
+    n = 5000
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(rng.random((n, 30), dtype=np.float32))
+    df.columns = [f"f{i}" for i in range(30)]
+    df["y"] = (rng.random(n) > 0.5).astype(int)
+
+    from lizyml_widget import LizyWidget
+
+    w = LizyWidget()
+    w.load(df, target="y")
+    t0 = time.perf_counter()
+    w.fit()
+    if w._job_thread:
+        w._job_thread.join(timeout=60)
+    elapsed = time.perf_counter() - t0
+
+    UPPER_BOUND_S = 30.0
+    assert w.status == "completed", f"Fit failed: error={w.error!r}"
+    assert elapsed < UPPER_BOUND_S, (
+        f"Subprocess Fit overhead regressed: elapsed={elapsed:.2f}s "
+        f"exceeds bound {UPPER_BOUND_S}s. Standalone baseline is ~2s; "
+        f"a 15x regression indicates a fundamentally broken strategy "
+        f"(double-spawn, recursive process tree, or massive thread leak "
+        f"in the parent). Investigate strategy detection / subprocess "
+        f"startup / DataFrame pickling."
+    )

--- a/tests/regression/test_reg_156_subprocess_retune.py
+++ b/tests/regression/test_reg_156_subprocess_retune.py
@@ -423,6 +423,91 @@ class TestRetuneSubprocessUnsupportedRemoval:
 
 
 # ---------------------------------------------------------------------------
+# INV-#156-I: tune-state IPC preserves the lizyml ``Model`` resume state
+# (regression for a P-038 implementation bug discovered via Playwright /
+# manual smoke testing — only ``_tuning_result`` and ``_study`` were being
+# round-tripped, so subprocess retune appeared to succeed but discarded
+# previous rounds).
+# ---------------------------------------------------------------------------
+
+
+class TestTuneStateRoundTripPreservesResumeState:
+    """``adapter.export_tune_state`` / ``restore_tune_state`` must capture
+    every ``Model`` private attribute that ``Model.tune(resume=True)``
+    reads. P-037 only round-tripped ``_tuning_result`` / ``_study`` (which
+    is enough for the ``optimization-history`` plot); P-038 also needs
+    ``_rounds`` / ``_round_number`` / ``_space`` / ``_used_default_space``
+    so the cumulative ``rounds`` list is preserved across subprocess
+    boundaries.
+    """
+
+    def test_export_then_restore_round_trips_all_resume_state(self, tmp_path: Path) -> None:
+        from lizyml_widget.adapter import LizyMLAdapter
+
+        adapter = LizyMLAdapter()
+
+        # Hand-build a model-shaped object — we only care that the adapter
+        # round-trips the right private attributes, not that lizyml's tune
+        # logic actually accepts them.
+        class _StubModel:
+            pass
+
+        src = _StubModel()
+        src._tuning_result = {"sentinel": "tuning_result"}  # noqa: SLF001
+        src._study = {"sentinel": "study"}  # noqa: SLF001
+        src._round_number = 7  # noqa: SLF001
+        src._rounds = [{"round": 1}, {"round": 2}, {"round": 3}]  # noqa: SLF001
+        src._space = [{"name": "lr", "low": 1e-4, "high": 1e-1}]  # noqa: SLF001
+        src._used_default_space = True  # noqa: SLF001
+
+        path = tmp_path / "blob.pkl"
+        adapter.export_tune_state(src, str(path))
+
+        dst = _StubModel()
+        adapter.restore_tune_state(dst, str(path))
+
+        assert dst._tuning_result == src._tuning_result  # noqa: SLF001
+        assert dst._study == src._study  # noqa: SLF001
+        assert dst._round_number == 7, (  # noqa: SLF001
+            "INV-#156-I: _round_number must round-trip — without it, "
+            "Model.tune(resume=True) restarts the round counter at 1"
+        )
+        assert dst._rounds == src._rounds, (  # noqa: SLF001
+            "INV-#156-I: _rounds must round-trip — without it, retune's "
+            "cumulative rounds list is overwritten by the new round only"
+        )
+        assert dst._space == src._space  # noqa: SLF001
+        assert dst._used_default_space is True  # noqa: SLF001
+
+    def test_restore_tolerates_p037_legacy_blob(self, tmp_path: Path) -> None:
+        """Backward compat: a P-037-only blob (only ``tuning_result`` / ``study``)
+        must still restore those keys without raising. Plot rendering paths
+        should not regress when reading old-format blobs."""
+        import pickle
+
+        from lizyml_widget.adapter import LizyMLAdapter
+
+        path = tmp_path / "legacy.pkl"
+        with open(path, "wb") as f:
+            pickle.dump(
+                {"tuning_result": {"sentinel": "old"}, "study": None},
+                f,
+                protocol=pickle.HIGHEST_PROTOCOL,
+            )
+
+        class _StubModel:
+            pass
+
+        adapter = LizyMLAdapter()
+        m = _StubModel()
+        adapter.restore_tune_state(m, str(path))
+        assert m._tuning_result == {"sentinel": "old"}  # noqa: SLF001
+        # P-038 keys absent → adapter must not raise; downstream tune
+        # would fail with the same error a fresh model would, so no
+        # additional invariant is needed here.
+
+
+# ---------------------------------------------------------------------------
 # INV-#156-G/H: end-to-end perf bounds (slow)
 # ---------------------------------------------------------------------------
 

--- a/tests/regression/test_reg_156_subprocess_retune.py
+++ b/tests/regression/test_reg_156_subprocess_retune.py
@@ -1,0 +1,629 @@
+"""Regression tests for issue #156 — subprocess retune resume (P-038).
+
+PR #155 patched #154 by routing retune to ``ThreadJobRunner`` under the
+default subprocess strategy. The investigation in #156 found that the
+thread fallback re-exposes the libgomp pool-affinity catastrophe whenever
+the user enters any OpenMP parallel region on the parent main thread
+(e.g., ``w.predict(test_df)``) between ``w.tune()`` and ``w.retune()``.
+Per-trial retune wall-clock then jumps from ~3.2s (subprocess tune
+baseline) to ~36s (~11x slowdown), with parent CPU collapsing from
+~29 cores active to ~2 cores — exactly matching the user's "core usage
+decreases" report.
+
+P-038 / Option A replaces the thread fallback with subprocess retune
+resume, extending the P-037 tune-state IPC to the input direction so the
+subprocess can pick up the existing Optuna study before running
+``adapter.tune(resume=True, ...)``.
+
+These tests pin the post-fix contract:
+
+- INV-#156-A: under the default strategy, retune routes through the
+  subprocess runner (NOT the thread fallback any more).
+- INV-#156-B: ``SubprocessJobRunner.run`` for retune exports current
+  tune state to a temp path before invoking ``run_job_subprocess``.
+- INV-#156-C: ``run_job_subprocess`` receives ``retune_kwargs`` AND
+  ``tune_state_in_path`` from the parent.
+- INV-#156-D: ``SubprocessJobRunner.run`` cleans up the inbound tune-state
+  temp file in ``finally`` regardless of subprocess outcome.
+- INV-#156-E: ``_subprocess_entry.run_job`` for retune calls
+  ``adapter.restore_tune_state`` and then ``adapter.tune(resume=True)``.
+- INV-#156-F: ``RetuneSubprocessUnsupportedError`` and its
+  ``RETUNE_SUBPROCESS_UNSUPPORTED`` error code are no longer reachable.
+- INV-#156-G (slow): clean ``tune → retune`` per-trial wall-clock is
+  within 1.2x of subprocess tune.
+- INV-#156-H (slow): catastrophe path
+  ``tune → main-thread booster.predict → retune`` per-trial wall-clock
+  is within 1.5x of subprocess tune (ratio that PR #155 hit ~11x on).
+
+Tests in the "fast" tier use mocks so they do not require lightgbm /
+libgomp; the slow tier reproduces the actual perf signature on Linux.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.types import BackendInfo
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_widget_with_data() -> Any:
+    """Build a LizyWidget with the real LizyMLAdapter wrapped behind a mock.
+
+    Mirrors the harness in ``test_reg_154_default_strategy_retune.py`` so
+    canonical config / backend-contract calls work but ML library calls can
+    be intercepted.
+    """
+    real_adapter = LizyMLAdapter()
+    with patch("lizyml_widget.widget.LizyMLAdapter") as MockAdapter:
+        adapter = MockAdapter.return_value
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.get_config_schema.return_value = {"type": "object"}
+        adapter.validate_config.return_value = []
+        adapter.initialize_config.side_effect = real_adapter.initialize_config
+        adapter.apply_config_patch.side_effect = real_adapter.apply_config_patch
+        adapter.prepare_run_config.side_effect = real_adapter.prepare_run_config
+        adapter.get_backend_contract.side_effect = real_adapter.get_backend_contract
+        adapter.canonicalize_config.side_effect = real_adapter.canonicalize_config
+        adapter.apply_task_defaults.side_effect = real_adapter.apply_task_defaults
+        adapter.classify_best_params.side_effect = real_adapter.classify_best_params
+
+        from lizyml_widget.widget import LizyWidget
+
+        w = LizyWidget()
+    df = pd.DataFrame(
+        {
+            "f1": list(range(40)),
+            "f2": [i * 0.5 for i in range(40)],
+            "f3": [i % 5 for i in range(40)],
+            "y": [0, 1] * 20,
+        }
+    )
+    w.load(df, target="y")
+    return w
+
+
+def _seed_tune_summary(w: Any) -> None:
+    """Make ``w.retune(...)`` pass its precondition without an actual prior tune."""
+    w.tune_summary = {
+        "best_params": {"learning_rate": 0.05},
+        "best_score": 0.9,
+        "trials": [],
+        "metric_name": "auc",
+        "direction": "maximize",
+        "rounds": [],
+        "boundary_report": None,
+    }
+
+
+def _stub_subprocess_result() -> Any:
+    """Build a SubprocessJobResult that satisfies the supervisor's contract."""
+    from lizyml_widget.subprocess_runner import SubprocessJobResult
+
+    return SubprocessJobResult(
+        job_type="tune",
+        fit_summary={},
+        tune_summary={
+            "best_params": {"learning_rate": 0.07},
+            "best_score": 0.92,
+            "trials": [],
+            "metric_name": "auc",
+            "direction": "maximize",
+            "rounds": [],
+            "boundary_report": None,
+        },
+        eval_table=[],
+        split_summary=[],
+        available_plots=["optimization-history"],
+        model_path=None,
+        tune_state_path=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# INV-#156-A: retune uses the subprocess runner under default strategy
+# ---------------------------------------------------------------------------
+
+
+class TestRetuneRoutesToSubprocessRunner:
+    """The thread fallback added by PR #155 must be gone — retune now goes
+    through ``SubprocessJobRunner`` under the default subprocess strategy."""
+
+    def test_retune_under_subprocess_default_uses_subprocess_runner(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", "/usr/lib/libomp5.so"),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = MagicMock(
+                job_type="tune",
+                fit_summary={},
+                tune_summary={
+                    "best_params": {},
+                    "best_score": 0.9,
+                    "trials": [],
+                    "metric_name": "auc",
+                    "direction": "maximize",
+                    "rounds": [],
+                    "boundary_report": None,
+                },
+                eval_table=[],
+                split_summary=[],
+                available_plots=["optimization-history"],
+                model_path=None,
+            )
+
+            w = _make_widget_with_data()
+            _seed_tune_summary(w)
+            w._service._tune_model = MagicMock()  # P-028 prerequisite
+
+            w.retune(n_trials=5)
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            mock_sp.assert_called_once()
+            mock_thread.assert_not_called()
+            assert w.status == "completed", (
+                f"Expected retune to complete via subprocess runner; "
+                f"got status={w.status!r} error={w.error!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# INV-#156-B/C/D: subprocess retune IPC contract
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessRetuneIpcContract:
+    """``SubprocessJobRunner.run`` for retune must serialise current tune
+    state into the subprocess input and forward ``retune_kwargs``.
+
+    Drives the runner directly so the IPC contract is asserted regardless
+    of whether the supervisor / widget glue is correct.
+    """
+
+    def _make_runner(self) -> tuple[Any, Any, Any]:
+        from lizyml_widget.job_runner import JobSpec, SubprocessJobRunner
+
+        svc = MagicMock()
+        svc.get_dataframe.return_value = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+        svc.get_df_info.return_value = {"target": "y"}
+        # The runner asks the service to write the inbound tune-state blob.
+        svc.export_tune_state_to_path = MagicMock()
+
+        runner = SubprocessJobRunner(svc)
+        spec = JobSpec(
+            job_type="tune",
+            config={"config_version": 1},
+            retune_kwargs={"resume": True, "n_trials": 7, "expand_boundary": False},
+        )
+        return runner, spec, svc
+
+    def test_runner_calls_export_tune_state_to_path_before_subprocess(self) -> None:
+        runner, spec, svc = self._make_runner()
+        captured: dict[str, Any] = {}
+
+        def fake_run(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            # By the time run_job_subprocess is invoked, the parent must
+            # have already exported the current tune state.
+            assert svc.export_tune_state_to_path.called, (
+                "INV-#156-B: subprocess retune must export tune state BEFORE "
+                "spawning the child process"
+            )
+            return _stub_subprocess_result()
+
+        with patch("lizyml_widget.job_runner.run_job_subprocess", side_effect=fake_run):
+            runner.run(
+                spec,
+                on_progress=lambda *a, **kw: None,
+                cancel_event=threading.Event(),
+            )
+
+        # The path passed to export must equal the path forwarded to
+        # run_job_subprocess.
+        export_call = svc.export_tune_state_to_path.call_args
+        assert export_call is not None
+        export_path = export_call.args[0] if export_call.args else export_call.kwargs.get("path")
+        assert isinstance(export_path, str)
+        assert captured.get("tune_state_in_path") == export_path
+
+    def test_runner_forwards_retune_kwargs_to_subprocess(self) -> None:
+        runner, spec, _svc = self._make_runner()
+        captured: dict[str, Any] = {}
+
+        def fake_run(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _stub_subprocess_result()
+
+        with patch("lizyml_widget.job_runner.run_job_subprocess", side_effect=fake_run):
+            runner.run(
+                spec,
+                on_progress=lambda *a, **kw: None,
+                cancel_event=threading.Event(),
+            )
+
+        assert captured.get("retune_kwargs") == {
+            "resume": True,
+            "n_trials": 7,
+            "expand_boundary": False,
+        }
+
+    def test_runner_cleans_up_tune_state_in_path_on_success(self) -> None:
+        runner, spec, _svc = self._make_runner()
+        captured: dict[str, Any] = {}
+
+        def fake_run(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            # The runner allocates a tempfile path and points us at it. We
+            # touch the path to simulate the subprocess writing into it.
+            path = kwargs["tune_state_in_path"]
+            Path(path).write_bytes(b"stub")
+            return _stub_subprocess_result()
+
+        with patch("lizyml_widget.job_runner.run_job_subprocess", side_effect=fake_run):
+            runner.run(
+                spec,
+                on_progress=lambda *a, **kw: None,
+                cancel_event=threading.Event(),
+            )
+
+        path = captured.get("tune_state_in_path")
+        assert isinstance(path, str)
+        assert not Path(path).exists(), (
+            f"INV-#156-D: tune-state input path must be cleaned up; still exists at {path!r}"
+        )
+
+    def test_runner_cleans_up_tune_state_in_path_on_subprocess_error(self) -> None:
+        runner, spec, _svc = self._make_runner()
+        captured_path: dict[str, str] = {}
+
+        def fake_run(**kwargs: Any) -> Any:
+            captured_path["p"] = kwargs["tune_state_in_path"]
+            Path(kwargs["tune_state_in_path"]).write_bytes(b"stub")
+            raise RuntimeError("subprocess crashed")
+
+        with (
+            patch("lizyml_widget.job_runner.run_job_subprocess", side_effect=fake_run),
+            pytest.raises(RuntimeError, match="subprocess crashed"),
+        ):
+            runner.run(
+                spec,
+                on_progress=lambda *a, **kw: None,
+                cancel_event=threading.Event(),
+            )
+
+        path = captured_path["p"]
+        assert not Path(path).exists(), (
+            f"INV-#156-D: tune-state input path must still be cleaned up "
+            f"on subprocess error; still exists at {path!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-#156-E: subprocess entry retune branch wires the adapter correctly
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessEntryRetuneBranch:
+    """The subprocess child must call ``adapter.restore_tune_state`` from
+    the inbound path before invoking ``adapter.tune(resume=True, ...)``.
+    """
+
+    def test_run_job_retune_restores_tune_state_then_calls_tune_with_resume(
+        self, tmp_path: Path
+    ) -> None:
+        from lizyml_widget._subprocess_entry import run_job
+
+        df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [0, 1, 0, 1]})
+        tune_state_in = tmp_path / "tune_state.pkl"
+        tune_state_in.write_bytes(b"opaque")  # adapter handles this
+
+        mock_summary = MagicMock()
+        mock_summary.best_params = {"lr": 0.07}
+        mock_summary.best_score = 0.92
+        mock_summary.trials = []
+        mock_summary.metric_name = "auc"
+        mock_summary.direction = "maximize"
+        mock_summary.rounds = []
+        mock_summary.boundary_report = None
+
+        mock_adapter = MagicMock()
+        mock_adapter.tune.return_value = mock_summary
+        mock_adapter.evaluate_table.return_value = []
+        mock_adapter.split_summary.return_value = []
+        mock_adapter.available_plots.return_value = ["optimization-history"]
+
+        call_log: list[str] = []
+        mock_adapter.restore_tune_state.side_effect = lambda *a, **kw: call_log.append(
+            "restore_tune_state"
+        )
+        mock_adapter.tune.side_effect = lambda *a, **kw: call_log.append("tune") or mock_summary
+
+        import io
+
+        output = io.BytesIO()
+        with patch(
+            "lizyml_widget._subprocess_entry._create_adapter",
+            return_value=mock_adapter,
+        ):
+            run_job(
+                job_type="tune",
+                config={"model": {"name": "lgbm"}},
+                df=df,
+                target="y",
+                model_out_path=None,
+                output=output,
+                tune_state_out_path=str(tmp_path / "out.pkl"),
+                retune_kwargs={"resume": True, "n_trials": 7, "expand_boundary": False},
+                tune_state_in_path=str(tune_state_in),
+            )
+
+        # The order matters: restore_tune_state must run before tune so the
+        # study handle is attached when adapter.tune fires.
+        assert call_log == ["restore_tune_state", "tune"], call_log
+        # adapter.tune received the resume kwargs.
+        tune_kwargs = mock_adapter.tune.call_args.kwargs
+        assert tune_kwargs.get("resume") is True
+        assert tune_kwargs.get("n_trials") == 7
+        assert tune_kwargs.get("expand_boundary") is False
+
+
+# ---------------------------------------------------------------------------
+# INV-#156-F: RetuneSubprocessUnsupportedError is gone
+# ---------------------------------------------------------------------------
+
+
+class TestRetuneSubprocessUnsupportedRemoval:
+    """The PR #155 thread fallback was the last reason
+    ``RetuneSubprocessUnsupportedError`` existed. Once subprocess retune is
+    supported, both the class and the ``RETUNE_SUBPROCESS_UNSUPPORTED``
+    error code are dead weight.
+    """
+
+    def test_retune_subprocess_unsupported_error_class_is_removed(self) -> None:
+        import lizyml_widget.job_runner as jr
+
+        assert not hasattr(jr, "RetuneSubprocessUnsupportedError"), (
+            "INV-#156-F: RetuneSubprocessUnsupportedError must be removed "
+            "after subprocess retune resume lands"
+        )
+
+    def test_widget_does_not_translate_retune_subprocess_unsupported(self) -> None:
+        """The supervisor's specialised ``except`` for
+        ``RetuneSubprocessUnsupportedError`` must be removed alongside the
+        class. The catch-all path remains the safety net."""
+        from lizyml_widget import widget as widget_module
+
+        src = Path(widget_module.__file__).read_text()
+        assert "RetuneSubprocessUnsupportedError" not in src, (
+            "INV-#156-F: widget.py must not import or reference RetuneSubprocessUnsupportedError"
+        )
+        assert "RETUNE_SUBPROCESS_UNSUPPORTED" not in src, (
+            "INV-#156-F: widget.py must not surface RETUNE_SUBPROCESS_UNSUPPORTED to the JS layer"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INV-#156-G/H: end-to-end perf bounds (slow)
+# ---------------------------------------------------------------------------
+
+
+def _libgomp_loaded() -> bool:
+    """Force-load lightgbm and check whether libgomp ends up in /proc/self/maps.
+
+    Mirrors ``openmp_detect._ensure_lightgbm_imported`` so the slow perf
+    tests do not silently skip when run from a fresh pytest session
+    (where lightgbm has not yet been imported by any other path).
+    """
+    if sys.platform != "linux":
+        return False
+    try:
+        import lightgbm  # noqa: F401
+    except Exception:  # pragma: no cover - defensive
+        return False
+    try:
+        with open("/proc/self/maps") as f:
+            return any("libgomp" in line for line in f)
+    except OSError:
+        return False
+
+
+def _make_perf_widget(n_rows: int = 100_000) -> Any:
+    """Build a real LizyWidget on a synthetic binary classification task.
+
+    Used by the slow perf tests; mirrors the reproducer used during the
+    #156 investigation.
+    """
+    import numpy as np
+
+    from lizyml_widget.widget import LizyWidget
+
+    rng = np.random.default_rng(0)
+    n_cols = 50
+    cols = {f"f{i}": rng.random(n_rows, dtype=np.float64) for i in range(n_cols)}
+    cols["y"] = (rng.random(n_rows) > 0.5).astype(int)
+    df = pd.DataFrame(cols)
+
+    w = LizyWidget()
+    w.load(df, target="y")
+    cfg = dict(w.config)
+    tuning = dict(cfg.get("tuning") or {})
+    optuna = dict(tuning.get("optuna") or {})
+    params = dict(optuna.get("params") or {})
+    params["n_trials"] = 3
+    optuna["params"] = params
+    tuning["optuna"] = optuna
+    cfg["tuning"] = tuning
+    w.set_config(cfg)
+    return w
+
+
+def _real_strategy_patch() -> Any:
+    """Override conftest's autouse thread-strategy patch.
+
+    ``conftest.py`` patches ``lizyml_widget.widget.get_execution_strategy`` to
+    return ``("thread", None)`` for the entire suite (so mock-adapter tests
+    do not accidentally spawn subprocesses). The slow perf tests in this
+    module need the *real* strategy detection — production behaviour on
+    libgomp must be ``("subprocess", libomp_path)``. This helper re-patches
+    inside the test, replacing conftest's value with the real return.
+    """
+    from lizyml_widget.openmp_detect import _reset_libgomp_cache, get_execution_strategy
+
+    _reset_libgomp_cache()
+    return patch(
+        "lizyml_widget.widget.get_execution_strategy",
+        side_effect=get_execution_strategy,
+    )
+
+
+def _per_trial(elapsed: float, n_trials: int = 3) -> float:
+    return elapsed / n_trials
+
+
+@pytest.mark.slow
+def test_clean_retune_within_subprocess_tune_perf_bound() -> None:
+    """INV-#156-G: with no main-thread parallel-region trigger between
+    tune and retune, per-trial retune wall-clock must be within 1.2x of
+    subprocess tune.
+
+    PR #155 measured this at 1.43x (thread fallback) — Option A's
+    subprocess retune resume should land within 1.2x because the same
+    subprocess startup amortises ~3 trials' worth of pool-affinity-free
+    OpenMP work.
+    """
+    if sys.platform != "linux":
+        pytest.skip("subprocess default + libgomp catastrophe is Linux-only")
+    if not _libgomp_loaded():
+        pytest.skip("libgomp not loaded — perf bound only meaningful on libgomp hosts")
+
+    os.environ.pop("LZW_FORCE_THREAD", None)
+
+    with _real_strategy_patch():
+        w = _make_perf_widget()
+
+        t0 = time.perf_counter()
+        w.tune(timeout=600)
+        tune_elapsed = time.perf_counter() - t0
+        assert w.status == "completed", f"Tune failed: {w.error!r}"
+        assert w._execution_strategy == "subprocess", (
+            f"Test pre-condition: strategy must be subprocess, got {w._execution_strategy!r}"
+        )
+
+        t1 = time.perf_counter()
+        w.retune(n_trials=3, timeout=600)
+        retune_elapsed = time.perf_counter() - t1
+        assert w.status == "completed", f"Retune failed: {w.error!r}"
+
+    tune_per = _per_trial(tune_elapsed)
+    retune_per = _per_trial(retune_elapsed)
+    ratio = retune_per / tune_per if tune_per > 0 else float("inf")
+
+    UPPER_BOUND = 1.2
+    assert ratio < UPPER_BOUND, (
+        f"INV-#156-G regression: clean retune per-trial wall {retune_per:.2f}s "
+        f"is {ratio:.2f}x subprocess tune per-trial {tune_per:.2f}s "
+        f"(bound {UPPER_BOUND}x). PR #155 baseline was ~1.43x; Option A "
+        f"should land within 1.2x."
+    )
+
+
+@pytest.mark.slow
+def test_catastrophe_path_retune_within_subprocess_tune_perf_bound() -> None:
+    """INV-#156-H: tune → main-thread booster.predict → retune must NOT
+    regress to the libgomp pool-affinity catastrophe (~11x slowdown
+    measured under PR #155). Per-trial retune wall-clock must be within
+    1.5x of subprocess tune.
+
+    This test specifically guards against the issue #156 root cause: PR
+    #155's thread fallback re-bound the libgomp pool to the parent main
+    thread once any predict / SHAP call fired, causing 109s retune for
+    a 14s clean baseline.
+    """
+    if sys.platform != "linux":
+        pytest.skip("catastrophe path is Linux-libgomp-only")
+    if not _libgomp_loaded():
+        pytest.skip("libgomp not loaded — bound only meaningful on libgomp hosts")
+
+    os.environ.pop("LZW_FORCE_THREAD", None)
+
+    with _real_strategy_patch():
+        w = _make_perf_widget()
+
+        t0 = time.perf_counter()
+        w.tune(timeout=600)
+        tune_elapsed = time.perf_counter() - t0
+        assert w.status == "completed", f"Tune failed: {w.error!r}"
+        assert w._execution_strategy == "subprocess", (
+            f"Test pre-condition: strategy must be subprocess, got {w._execution_strategy!r}"
+        )
+
+        # Force a parent-main-thread libgomp parallel-region entry. Under PR
+        # #155 this would bind the pool to the main thread and the next
+        # worker-thread retune would hit ~36s/trial.
+        import lightgbm as lgb
+        import numpy as np
+
+        rng = np.random.default_rng(42)
+        X_small = rng.random((500, 50))
+        y_small = (rng.random(500) > 0.5).astype(int)
+        booster_holder: dict[str, Any] = {}
+
+        def _fit_in_worker() -> None:
+            ds = lgb.Dataset(X_small, label=y_small)
+            booster_holder["b"] = lgb.train(
+                {
+                    "objective": "binary",
+                    "metric": "binary_logloss",
+                    "verbose": -1,
+                    "num_threads": 0,
+                },
+                ds,
+                num_boost_round=20,
+            )
+
+        th = threading.Thread(target=_fit_in_worker, daemon=False)
+        th.start()
+        th.join()
+        booster = booster_holder["b"]
+        # Multiple predict calls so the parallel region is firmly established
+        # on the parent main thread.
+        for _ in range(3):
+            _ = booster.predict(X_small)
+
+        t1 = time.perf_counter()
+        w.retune(n_trials=3, timeout=600)
+        retune_elapsed = time.perf_counter() - t1
+        assert w.status == "completed", f"Retune failed: {w.error!r}"
+
+    tune_per = _per_trial(tune_elapsed)
+    retune_per = _per_trial(retune_elapsed)
+    ratio = retune_per / tune_per if tune_per > 0 else float("inf")
+
+    UPPER_BOUND = 1.5
+    assert ratio < UPPER_BOUND, (
+        f"INV-#156-H regression: catastrophe-path retune per-trial wall "
+        f"{retune_per:.2f}s is {ratio:.2f}x subprocess tune per-trial "
+        f"{tune_per:.2f}s (bound {UPPER_BOUND}x). PR #155 hit ~11x "
+        f"because thread retune re-bound libgomp to the parent main "
+        f"thread; subprocess retune resume should not regress."
+    )

--- a/tests/regression/test_reg_156_subprocess_retune.py
+++ b/tests/regression/test_reg_156_subprocess_retune.py
@@ -292,6 +292,50 @@ class TestSubprocessRetuneIpcContract:
             f"INV-#156-D: tune-state input path must be cleaned up; still exists at {path!r}"
         )
 
+    def test_runner_cleans_up_all_tempfiles_when_export_fails(self) -> None:
+        """INV-#156-D extension: when ``service.export_tune_state_to_path``
+        raises (e.g. no prior tune, OSError mid-pickle), the runner must
+        clean up *all three* tempfiles allocated before the subprocess
+        spawn — ``model_out_path`` (mkdtemp), ``tune_state_out_path``,
+        AND ``tune_state_in_path`` — and re-raise the original exception.
+        Otherwise long-lived Jupyter kernels leak temp files on every
+        misuse of ``w.retune()`` without a prior tune."""
+        from lizyml_widget.job_runner import JobSpec, SubprocessJobRunner
+
+        svc = MagicMock()
+        svc.get_dataframe.return_value = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+        svc.get_df_info.return_value = {"target": "y"}
+        svc.export_tune_state_to_path = MagicMock(
+            side_effect=ValueError("no prior tune"),
+        )
+
+        runner = SubprocessJobRunner(svc)
+        spec = JobSpec(
+            job_type="tune",
+            config={"config_version": 1},
+            retune_kwargs={"resume": True, "n_trials": 5},
+        )
+
+        with (
+            patch("lizyml_widget.job_runner.run_job_subprocess") as mock_run,
+            pytest.raises(ValueError, match="no prior tune"),
+        ):
+            runner.run(
+                spec,
+                on_progress=lambda *a, **kw: None,
+                cancel_event=threading.Event(),
+            )
+
+        # The subprocess must NOT have been spawned (export failed first).
+        mock_run.assert_not_called()
+        # Tempfile paths are passed to ``export_tune_state_to_path`` only —
+        # we can recover them via the mock call args.
+        export_path = svc.export_tune_state_to_path.call_args.args[0]
+        assert not Path(export_path).exists(), (
+            f"tune_state_in_path must be cleaned up on export failure; "
+            f"still exists at {export_path!r}"
+        )
+
     def test_runner_cleans_up_tune_state_in_path_on_subprocess_error(self) -> None:
         runner, spec, _svc = self._make_runner()
         captured_path: dict[str, str] = {}
@@ -630,6 +674,24 @@ def test_clean_retune_within_subprocess_tune_perf_bound() -> None:
         f"(bound {UPPER_BOUND}x). PR #155 baseline was ~1.43x; Option A "
         f"should land within 1.2x."
     )
+
+    # INV-#156-J (functional, not just perf): rounds must accumulate.
+    # The original P-038 implementation only round-tripped
+    # ``_tuning_result`` and ``_study`` — which made retune *appear* to
+    # succeed (status=completed, badge ✓) while silently overwriting the
+    # rounds list. Slow-path perf bounds did not catch this because
+    # per-trial wall-clock is normal in either case. Adding a contents
+    # assertion here pins the rounds-accumulation contract empirically.
+    rounds = w.tune_summary.get("rounds") or []
+    assert len(rounds) == 2, (
+        f"INV-#156-J: subprocess retune must accumulate rounds; got "
+        f"{len(rounds)} round(s) — {rounds!r}. The P-038 ``adapter."
+        f"export_tune_state`` must round-trip ``_rounds`` / "
+        f"``_round_number`` / ``_space`` / ``_used_default_space`` so "
+        f"``Model.tune(resume=True)`` builds the cumulative rounds list."
+    )
+    assert rounds[0].get("round") == 1
+    assert rounds[1].get("round") == 2
 
 
 @pytest.mark.slow

--- a/tests/test_adapter_tune_state.py
+++ b/tests/test_adapter_tune_state.py
@@ -44,6 +44,22 @@ def _fake_tuning_result() -> Any:
     )
 
 
+def _attach_tune_state_defaults(model: Any) -> None:
+    """Set picklable values for P-038 round-bookkeeping attrs on a mock model.
+
+    ``MagicMock`` auto-creates attributes as nested mocks, which break
+    ``pickle.dumps`` inside ``export_tune_state``. The P-037-era tests in
+    this module never set these attributes; this helper makes them
+    deterministic and pickle-safe so the same fixtures keep working
+    after P-038 added ``_rounds`` / ``_round_number`` / ``_space`` /
+    ``_used_default_space`` to the export blob.
+    """
+    model._round_number = 1
+    model._rounds = []
+    model._space = None
+    model._used_default_space = False
+
+
 class TestExportTuneState:
     """``export_tune_state`` writes a pickle blob containing ``_tuning_result``."""
 
@@ -52,6 +68,7 @@ class TestExportTuneState:
         model = MagicMock()
         model._tuning_result = _fake_tuning_result()
         model._study = None  # InMemory absent
+        _attach_tune_state_defaults(model)
 
         out_path = tmp_path / "tune_state.pkl"
         adapter.export_tune_state(model, str(out_path))
@@ -79,6 +96,7 @@ class TestExportTuneState:
         model._tuning_result = _fake_tuning_result()
         # InMemoryStorage is pickleable; use a simple sentinel-pickleable object.
         model._study = {"trials": [1, 2, 3]}  # dict pickles cleanly
+        _attach_tune_state_defaults(model)
 
         out = tmp_path / "tune_state.pkl"
         adapter.export_tune_state(model, str(out))
@@ -100,6 +118,7 @@ class TestExportTuneState:
                 raise TypeError(msg)
 
         model._study = _UnpickleableStudy()
+        _attach_tune_state_defaults(model)
 
         out = tmp_path / "tune_state.pkl"
         adapter.export_tune_state(model, str(out))
@@ -207,6 +226,7 @@ class TestRoundTrip:
         producer = MagicMock()
         producer._tuning_result = original
         producer._study = None
+        _attach_tune_state_defaults(producer)
 
         path = tmp_path / "rt.pkl"
         adapter.export_tune_state(producer, str(path))

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -22,7 +22,6 @@ import pytest
 from lizyml_widget.job_runner import (
     JobResult,
     JobSpec,
-    RetuneSubprocessUnsupportedError,
     SubprocessJobRunner,
     ThreadJobRunner,
 )
@@ -173,20 +172,56 @@ class TestSubprocessJobRunnerNormal:
         assert SubprocessJobRunner(mock_service).kind == "subprocess"
 
 
-class TestSubprocessJobRunnerRetuneRejection:
-    def test_retune_raises_unsupported_error(self, mock_service: Any) -> None:
+class TestSubprocessJobRunnerRetuneResume:
+    """P-038: subprocess retune resume forwards retune_kwargs and
+    tune_state_in_path to ``run_job_subprocess`` after exporting the
+    parent's current tune state.
+    """
+
+    def test_retune_forwards_kwargs_and_exports_tune_state(self, mock_service: Any) -> None:
+        from lizyml_widget.subprocess_runner import SubprocessJobResult
+
         runner = SubprocessJobRunner(mock_service)
         spec = JobSpec(
             job_type="tune",
             config={},
             retune_kwargs={"resume": True, "n_trials": 5},
         )
-        with pytest.raises(RetuneSubprocessUnsupportedError, match="subprocess"):
+        captured: dict[str, Any] = {}
+
+        def fake_run(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SubprocessJobResult(
+                job_type="tune",
+                fit_summary={},
+                tune_summary={
+                    "best_params": {},
+                    "best_score": 0.0,
+                    "trials": [],
+                    "metric_name": "auc",
+                    "direction": "maximize",
+                    "rounds": [],
+                    "boundary_report": None,
+                },
+                eval_table=[],
+                split_summary=[],
+                available_plots=[],
+                model_path=None,
+            )
+
+        with patch("lizyml_widget.job_runner.run_job_subprocess", side_effect=fake_run):
             runner.run(
                 spec,
                 on_progress=lambda *a, **kw: None,
                 cancel_event=threading.Event(),
             )
+
+        # The parent must call export_tune_state_to_path before spawning.
+        mock_service.export_tune_state_to_path.assert_called_once()
+        # The path written by the parent must reach the subprocess input.
+        export_path = mock_service.export_tune_state_to_path.call_args.args[0]
+        assert captured.get("tune_state_in_path") == export_path
+        assert captured.get("retune_kwargs") == {"resume": True, "n_trials": 5}
 
 
 class TestSubprocessJobRunnerCancel:

--- a/tests/test_retune_launcher.py
+++ b/tests/test_retune_launcher.py
@@ -666,36 +666,36 @@ class TestRetuneAction:
 # ──────────────────────────────────────────────────────────────
 
 
-class TestRetuneSubprocessRejection:
-    """P-032: re-tune via SubprocessJobRunner raises RetuneSubprocessUnsupportedError.
-
-    The supervisor turns this into the ``RETUNE_SUBPROCESS_UNSUPPORTED`` error
-    code on the widget. These tests drive the runner + supervisor directly
-    rather than spawning a real subprocess.
+class TestRetuneSubprocessResume:
+    """P-038: subprocess retune resume — the previously-rejected path is now
+    the supported path. The runner serialises tune state into a temp file
+    and the subprocess restores it before invoking adapter.tune(resume=True).
     """
 
-    def test_subprocess_runner_rejects_retune_kwargs(self) -> None:
-        """SubprocessJobRunner.run raises immediately for any retune_kwargs."""
+    def test_subprocess_runner_fails_fast_when_no_prior_tune(self) -> None:
+        """``service.export_tune_state_to_path`` raises when ``_tune_model``
+        is unset; the subprocess never spawns and the temp file is cleaned up.
+        """
         import threading
 
-        from lizyml_widget.job_runner import (
-            JobSpec,
-            RetuneSubprocessUnsupportedError,
-            SubprocessJobRunner,
-        )
+        from lizyml_widget.job_runner import JobSpec, SubprocessJobRunner
 
         w = _make_widget()
+        # No prior tune happened on this widget — service._tune_model is None.
         runner = SubprocessJobRunner(w._service)
         spec = JobSpec(
             job_type="tune",
             config={"config_version": 1},
             retune_kwargs={"resume": True, "n_trials": 10},
         )
-        with pytest.raises(RetuneSubprocessUnsupportedError, match="subprocess"):
+        with pytest.raises(ValueError, match="no prior tune"):
             runner.run(spec, on_progress=lambda *a, **kw: None, cancel_event=threading.Event())
 
-    def test_supervise_translates_unsupported_error_to_traitlet(self) -> None:
-        """End-to-end: subprocess runner + retune → widget.error code is set."""
+    def test_supervise_surfaces_retune_failure_as_internal_error(self) -> None:
+        """When subprocess retune fails (e.g. no prior tune), the supervisor
+        translates the exception into the generic ``INTERNAL_ERROR`` /
+        ``BACKEND_ERROR`` paths — there is no longer a dedicated
+        ``RETUNE_SUBPROCESS_UNSUPPORTED`` code (P-038)."""
         from lizyml_widget.job_runner import JobSpec, SubprocessJobRunner
 
         w = _make_widget()
@@ -711,8 +711,10 @@ class TestRetuneSubprocessRejection:
         w._supervise(runner, spec)
 
         assert w.status == "failed"
-        assert w.error["code"] == "RETUNE_SUBPROCESS_UNSUPPORTED"
-        assert "subprocess" in w.error["message"].lower()
+        # No more dedicated RETUNE_SUBPROCESS_UNSUPPORTED code; the error
+        # bubbles up under the generic boundaries.
+        assert w.error.get("code") != "RETUNE_SUBPROCESS_UNSUPPORTED"
+        assert w.error["code"] in {"INTERNAL_ERROR", "BACKEND_ERROR", "SUBPROCESS_ERROR"}
 
     def test_subprocess_runner_accepts_normal_tune_when_retune_kwargs_is_none(
         self,


### PR DESCRIPTION
Closes #154.

## Summary

Hotfix for three regressions surfaced by P-036 (subprocess as the default execution strategy on Linux + libgomp). All addressed in a single PR; no Proposal needed (no public API change).

## What changed

- **Bug A — retune auto-fallback to thread runner under default subprocess strategy.** ``widget._run_job`` now detects `retune_kwargs ≠ None ∧ strategy == "subprocess"` and routes that one job through `ThreadJobRunner`. Initial tune still uses subprocess to preserve the P-036 / #147 perf win. Fallback notice logs once per widget instance.
- **Bug B — fix stale remediation message.** Subprocess retune rejection (still reachable via direct runner construction in tests / explicit opt-in) now points users to `LZW_FORCE_THREAD=1` instead of the no-op `LZW_FORCE_SUBPROCESS=1`.
- **Bug C — bound subprocess Fit overhead with a slow regression test.** New `pytest.mark.slow` test asserts subprocess Fit completes within 30s under default strategy. Threshold is generous (vs measured ~1.6s standalone) to absorb pytest-test-order interaction with the existing #147 perf test (which leaks ~120 libgomp threads in the parent, dramatically slowing `subprocess.Popen`). Catches catastrophic regressions (15x+) without flaking.

Plus release-prep:

- **README**: documents `LZW_FORCE_THREAD=1` opt-out for Fit-heavy small-DF workflows; tabulates the typical wall-clock trade-off.
- **CHANGELOG**: promote `[Unreleased]` content to `[0.9.0] - 2026-05-09`; collapse the placeholder `[0.9.0] - 2026-05-08` (P-030 only) into the same release entry.
- **pyproject.toml**: add `Bug Tracker` and `Changelog` URLs in `[project.urls]`.

## Test-gap analysis (why CI didn't catch this)

The unit test pyramid mocked too low to see the user flow:

| Existing test | Layer | Why it didn't catch the regression |
|---|---|---|
| `TestServiceResumePath` | Service | Service layer never sees the runner choice |
| `TestWidgetRetuneApi` | Widget API | `w._service.tune` mocked → bypasses `_run_job` |
| `TestRetuneSubprocessRejection` | Runner | **Pinned the rejection AS expected contract** |
| `TestSupervisorTranslatesUnsupportedError` | Supervisor | Asserted only `"subprocess" in message.lower()` — broken guidance text still satisfied this |

New `tests/regression/test_reg_154_default_strategy_retune.py` exercises `_run_job → runner.run` under a mocked `("subprocess", path)` strategy and pins the post-fix contract.

## Verified

- [x] Default-strategy `w.tune() → w.retune()` succeeds end-to-end on this WSL2 + libgomp host (no env-var changes; status=`completed`, no `RETUNE_SUBPROCESS_UNSUPPORTED`)
- [x] Initial tune still uses subprocess (regression-tested, verifies #147 perf win is preserved)
- [x] Rejection message contains literal `LZW_FORCE_THREAD` and not `LZW_FORCE_SUBPROCESS` (regression-tested)
- [x] All quality gates green: `pytest` 968 passed / `pytest -m slow` 3 passed / `ruff check` / `ruff format --check` / `mypy --no-incremental` / `pnpm test` 331 passed / `eslint` / `uv build` (sdist + wheel)

## Test plan

- [ ] Reviewer confirms the auto-fallback decision is in `_run_job` (single point of strategy choice) rather than scattered through callers
- [ ] Reviewer confirms the slow Fit-overhead bound (30s) is acceptable as a "catastrophic regression" detector vs a tight overhead bound
- [ ] CI green on develop base

## Out of scope

- #128 — subprocess retune resume (P-037 already wired the tune-state IPC, but the runner still rejects retune; long-term fix tracked separately)
- #129 — lizyml 0.12 resumable Optuna storage exposure
