### PR TITLE
feat(ci,test): P-039 Phase 1 — libgomp perf grid + CI gate (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,45 @@ jobs:
       - name: Test (pytest)
         run: uv run pytest --cov=lizyml_widget --cov-report=term-missing --cov-fail-under=80 -q
 
+  libgomp-perf:
+    # P-039 Phase 1 / Layer 4. Runs the parameterised libgomp perf grid
+    # (test_reg_160_libgomp_perf_grid.py) on ubuntu-latest, which ships
+    # with libgomp by default. The grid asserts INV-#160-A: per-unit
+    # wall-clock of every {intermediate × next_op} cell stays within
+    # 1.5x of an op-matched clean baseline. This blocks merges that
+    # silently re-introduce the 10-50x libgomp pool-affinity slowdown
+    # family (#147 / #154 / #156). See HISTORY.md P-039.
+    name: libgomp perf (slow regression grid)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Confirm libgomp is loaded on the runner
+        # Sanity check — if this prints nothing, the grid would skip
+        # silently and the gate would be a no-op. The grid imports
+        # lightgbm so libgomp shows up in /proc/self/maps post-import.
+        run: |
+          uv run python -c "
+          import lightgbm  # noqa: F401
+          with open('/proc/self/maps') as f:
+              hits = [l for l in f if 'libgomp' in l]
+          assert hits, 'libgomp not loaded — perf grid would skip; CI gate would be ineffective'
+          print('libgomp loaded:', hits[0].strip())
+          "
+
+      - name: Run libgomp perf grid (slow tier)
+        run: uv run pytest -m slow tests/regression/test_reg_160_libgomp_perf_grid.py -v
+
   distribution:
     name: Distribution check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CI: `libgomp-perf` job runs a parameterised libgomp perf regression
+  grid on every PR** (P-039 Phase 1, [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
+  The libgomp pool-affinity / "CPU core usage decreases" regression has
+  reoccurred four times in this codebase
+  ([#147](https://github.com/nbx-liz/LizyML-Widget/issues/147) /
+  [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154) /
+  [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156) /
+  [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)). Each
+  prior fix only pinned the *specific* path observed — a future code
+  change could silently re-introduce the same class of 10-50x slowdown
+  via a new ML call site. P-039 Phase 1 closes that gap by adding a
+  dedicated CI job that runs ``tests/regression/test_reg_160_libgomp_perf_grid.py``
+  on ``ubuntu-latest`` (libgomp by default). The grid covers the
+  cross-product ``{intermediate parent-thread op ∈ noop /
+  main_thread_predict / main_thread_fit_predict}`` × ``{next ML op ∈
+  retune / fit}`` and asserts INV-#160-A: per-unit wall-clock of every
+  cell stays within 1.5x of an op-matched clean baseline. The grid uses
+  small datasets (5k × 20, 2 trials) so the job fits the CI budget;
+  catastrophe is not dataset-size dependent so the 1.5x bound retains
+  its expressiveness on small data. Phases 2-4 (runtime INV-G guard,
+  ``BackendExecutor`` funnel, change-gate codification) are tracked
+  under [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160) and
+  ship in follow-up PRs.
+
 ## [0.9.0] - 2026-05-09
 
 ### Fixed

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,51 @@
 ## LizyML-Widget 仕様変更履歴
 
+### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
+
+- **日付**: 2026-05-10（提案）
+- **ステータス**: 提案（Phase 1 実装着手中）
+- **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
+- **背景**:
+  - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。
+  - 同一 root cause: GCC libgomp は OpenMP parallel region に最初に入った thread に thread pool を bind する。LightGBM / SHAP は OpenMP を多用する。Jupyter / anywidget 環境では `widget._run_job → ThreadJobRunner`, `widget.predict(df)`, `widget_actions.handle_run_inference → service.predict`, `adapter.plot(model, "feature-importance-shap")` のいずれかが parent main thread で OpenMP region に入った瞬間、後続の worker-thread 上の Tune / Fit / Retune が catastrophe path に入る。
+  - PR #155 thread fallback / P-038 subprocess retune resume / P-036 subprocess default は **既知の call site** を 1 つずつ塞いだが、**将来追加される 5 つ目の call site** を構造的に防ぐ仕組みは無い。
+- **提案内容**: 段階的な防御層（defense in depth）。各 Layer は独立に着手可能だが、Phase の順序で着手する。
+  - **Layer 1（Architectural — Phase 3）**: `BackendExecutor` 抽象を `WidgetService` 配下に新設し、すべての ML library 呼出（predict / SHAP / model 内部 plot 等）を必ず通す。executor は execution strategy を見て inline / subprocess / dedicated-OpenMP-owner-thread を選ぶ。`service.predict` / `service.get_inference_plot`（SHAP 含む経路）/ `adapter.plot(... feature-importance-shap)` を funnel する。
+  - **Layer 2（Runtime invariant guard — Phase 2）**: BLUEPRINT.md §6.4 に **INV-G** を追加 — "post-subprocess-tune において parent main thread の libgomp parallel region が次の worker-thread Tune/Fit/Retune より先に発生してはならない"。`service._libgomp_pool_owner_known: Literal["subprocess","main","worker","unknown"]` を追加し、`SubprocessJobRunner.run` 完了時に `"subprocess"` をセット、parent main thread の predict/SHAP 経路で `"main"` をセット、worker-thread Tune/Fit 起動前に検査して `"main"` の場合 subprocess に re-route または WARN log。
+  - **Layer 3（Test grid — Phase 1）**: `tests/regression/test_reg_160_libgomp_perf_grid.py` を新設。`{intermediate ∈ noop / main_thread_predict / main_thread_fit_predict}` × `{next_op ∈ retune / fit}` の cross-product で per-trial wall-clock を baseline subprocess tune の 1.5x 以内に pin。#154（clean → retune）と #156（predict → retune catastrophe）の両方を grid の異なる cell で再現可能にする。
+  - **Layer 4（CI — Phase 1）**: `.github/workflows/ci.yml` に `libgomp-perf` job を追加し `ubuntu-latest`（libgomp by default）で `pytest -m slow tests/regression/test_reg_160_libgomp_perf_grid.py` を毎 PR 実行。catastrophe を CI ブロッカーにする。既存 `test_reg_147_openmp_perf.py` / `test_reg_156_subprocess_retune.py` は dataset サイズが GitHub runner にとって過大なため別経路（developer / nightly）で動かす（本 Proposal では grid のみを CI gate に組み込む）。
+  - **Layer 5（Change-gate — Phase 4）**: `~/.claude/rules/project/change-gate.md`（global rule）と `CLAUDE.md` に "ML library への直接呼出（lightgbm / shap / xgboost / sklearn）を `BackendExecutor` 外部に追加する" を gate-required category として追記。pre-commit / ruff custom rule で `import lightgbm` / `import shap` / `model.predict` 等が executor module 外部に出現したら fail。`# noqa: ML-CALL` allowlist comment で例外承認。
+- **Phase 構成と本 Proposal のスコープ**:
+  - **Phase 0**: 本 Proposal の HISTORY.md 追加（**本コミットで完了**）
+  - **Phase 1**: Layer 3 + Layer 4（**本 PR で着手** — CI gate と parameterised grid）
+  - **Phase 2**: Layer 2（INV-G + 実行時ガード — 別 PR）
+  - **Phase 3**: Layer 1（`BackendExecutor` refactor — 別 PR、blast radius 最大）
+  - **Phase 4**: Layer 5（change-gate codification + lint rule — 別 PR）
+- **Invariants（本 Proposal が宣言する将来不変条件）**:
+  - INV-G（Phase 2 で encode）: post-subprocess-tune において、parent main thread の libgomp parallel region が次の worker-thread Tune/Fit/Retune より先に観測されない（観測された場合は subprocess に re-route または WARN）。
+  - INV-H（Phase 3 で encode）: lightgbm / shap / xgboost / sklearn API への直接呼出は `BackendExecutor` モジュール外部から発生しない（type system + lint で enforce）。
+  - INV-I（Phase 1 で encode、本 PR）: `tests/regression/test_reg_160_libgomp_perf_grid.py` の各 cell について per-trial wall-clock が baseline subprocess tune の 1.5x 以内（catastrophe 検出のみ。absolute perf budget は別 grid で扱う）。
+- **Phase 1 影響範囲（本 PR）**:
+  - `tests/regression/test_reg_160_libgomp_perf_grid.py` — 新規（parameterised grid + 1.5x bound）
+  - `.github/workflows/ci.yml` — 新規 job `libgomp-perf` を追加
+  - `HISTORY.md` — 本 Proposal
+  - `CHANGELOG.md` — `[Unreleased]` セクションに Phase 1 entry を追加
+- **互換性**:
+  - 公開 API・traitlets・JS UI の変更なし（Phase 1 は test + CI のみ）
+  - `pytest -m slow` は引き続き opt-in。新 grid は CI で自動実行されるが、ローカル開発では `-m slow` を明示しない限り skip
+- **代替案（却下）**:
+  - **案A**: Phase 1 で既存 `test_reg_147` / `test_reg_156` をそのまま CI に乗せる → GitHub Actions 2-core runner で 100k × 50 dataset は per-job 30 分超になる。Phase 1 で別 grid を新設し dataset を 5k × 20 まで縮小する方が PR latency 影響が小さい。catastrophe は dataset サイズに依存しないので 1.5x bound は同じ表現力を持つ。
+  - **案B**: Phase 3（`BackendExecutor`）から先に着手 → blast radius が公開 Python API（`w.predict(df)` の async 化検討）まで及ぶ。既知 call site の incremental 修正（P-036 / P-038）と異なり、Proposal 単位の合意形成と段階的 migration が必要。Phase 1 が CI を gate に入れる時点で historical regression class は捕捉できるため、Phase 3 を急ぐ便益が小さい。
+  - **案C**: `LD_PRELOAD=libomp` の wrapper script 配布で GCC bug 自体を回避 → ユーザの環境管理に踏み込みすぎる（Out of scope per #160）。
+- **受け入れ基準（Phase 1）**:
+  - [ ] `tests/regression/test_reg_160_libgomp_perf_grid.py` が `intermediate × next_op` の cross-product を `@pytest.mark.parametrize` で表現する。
+  - [ ] 各 cell の per-trial wall-clock が baseline subprocess tune の 1.5x 以内であることを assert する（libgomp 非搭載環境では skip）。
+  - [ ] `.github/workflows/ci.yml` に `libgomp-perf` job が存在し、`pull_request` トリガで `ubuntu-latest` 上で grid を実行する。
+  - [ ] grid を意図的に regress させると（例: 1.5x bound を 1.0x に絞る）CI が fail することを手元で確認する。
+  - [ ] 既存品質ゲート（`pytest`, `ruff check`, `ruff format --check`, `mypy --strict`, `pnpm test:coverage`, `pnpm lint`）全 green。
+- **本 Proposal の終了条件**:
+  - Phase 1 〜 Phase 4 すべてが develop にマージされる。本 Proposal 自体は Phase 1 PR がマージされた時点で「decision: 採択」とし、Phase 2-4 はそれぞれ独立 PR で着手する。
+
 ### P-038: subprocess Retune Resume を P-037 の tune state IPC を input 方向に拡張して実装（#154 thread fallback の置換）
 
 - **日付**: 2026-05-09（提案・決定・実装）

--- a/tests/regression/test_reg_160_libgomp_perf_grid.py
+++ b/tests/regression/test_reg_160_libgomp_perf_grid.py
@@ -1,0 +1,334 @@
+"""Parameterised libgomp perf regression grid for P-039 / issue #160.
+
+Phase 1 / Layer 3 of the systemic prevention plan declared in P-039
+(see HISTORY.md). The four historical regressions in the libgomp
+pool-affinity family (#147 / #154 / #156 / #158) all share one root
+cause — GCC libgomp binds the OpenMP thread pool to the first thread
+that enters a parallel region, and any subsequent worker-thread call
+gets a 10-50x penalty (GCC bug #108494). Each prior regression test
+pinned a *specific* path; none of them covered the cross-product of
+"what happened on the parent main thread before the next ML op".
+
+This grid asserts the catastrophe-class invariant directly:
+
+INV-#160-A: for every combination of {intermediate parent-thread op}
+× {next ML op}, the per-trial wall-clock of the next op stays within
+1.5x of the baseline subprocess tune. A failure indicates that some
+parent-main-thread libgomp parallel region has bound the pool
+affinity such that a follow-up worker-thread Tune/Fit/Retune is
+running on the wrong thread.
+
+The dataset is intentionally smaller than the existing
+``test_reg_147_openmp_perf.py`` / ``test_reg_156_subprocess_retune.py``
+tests so the grid fits inside the GitHub Actions ``libgomp-perf`` CI
+job budget (~5-10 min total). Catastrophe is *not* dataset-size
+dependent (libgomp pool affinity is a per-region constant cost), so
+the 1.5x ratio remains expressive on small data.
+
+The grid is gated on Linux + libgomp; non-libgomp hosts skip
+because the bound is meaningless without the underlying GCC bug.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip helpers — mirror the openmp_detect logic so the grid doesn't silently
+# pass on a fresh kernel where lightgbm has not been imported yet.
+# ---------------------------------------------------------------------------
+
+
+def _libgomp_loaded() -> bool:
+    if sys.platform != "linux":
+        return False
+    try:
+        import lightgbm  # noqa: F401
+    except Exception:  # pragma: no cover - defensive
+        return False
+    try:
+        with open("/proc/self/maps") as f:
+            return any("libgomp" in line for line in f)
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="libgomp pool-affinity bug is Linux-only",
+    ),
+    pytest.mark.skipif(
+        not _libgomp_loaded(),
+        reason="libgomp not loaded — 1.5x bound only meaningful on libgomp hosts",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_perf_widget(n_rows: int = 5_000, n_trials: int = 2) -> Any:
+    """Build a minimal LizyWidget for the grid.
+
+    Smaller than ``test_reg_156_subprocess_retune._make_perf_widget`` so
+    the grid fits the CI job budget. Catastrophe-class regressions are
+    not dataset-size dependent — a 5k row tune is enough to drive 10-50x
+    pool-affinity slowdowns on libgomp hosts.
+    """
+    import numpy as np
+
+    from lizyml_widget.widget import LizyWidget
+
+    rng = np.random.default_rng(0)
+    n_cols = 20
+    cols = {f"f{i}": rng.random(n_rows, dtype=np.float64) for i in range(n_cols)}
+    cols["y"] = (rng.random(n_rows) > 0.5).astype(int)
+    df = pd.DataFrame(cols)
+
+    w = LizyWidget()
+    w.load(df, target="y")
+    cfg = dict(w.config)
+    tuning = dict(cfg.get("tuning") or {})
+    optuna = dict(tuning.get("optuna") or {})
+    params = dict(optuna.get("params") or {})
+    params["n_trials"] = n_trials
+    optuna["params"] = params
+    tuning["optuna"] = optuna
+    cfg["tuning"] = tuning
+    w.set_config(cfg)
+    return w
+
+
+def _real_strategy_patch() -> Any:
+    """Override conftest's autouse thread-strategy patch.
+
+    ``conftest.py`` patches ``lizyml_widget.widget.get_execution_strategy`` to
+    return ``("thread", None)`` for the entire suite. The grid needs the
+    real production strategy ``("subprocess", libomp_path)`` on libgomp
+    hosts.
+    """
+    from lizyml_widget.openmp_detect import _reset_libgomp_cache, get_execution_strategy
+
+    _reset_libgomp_cache()
+    return patch(
+        "lizyml_widget.widget.get_execution_strategy",
+        side_effect=get_execution_strategy,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Intermediate-op helpers — drive the parent main thread into a libgomp
+# parallel region in the same way real users would (predict / fit + predict).
+# ---------------------------------------------------------------------------
+
+
+def _run_intermediate_noop(_w: Any) -> None:
+    """No parent-main-thread libgomp activity. Baseline cell."""
+
+
+def _run_intermediate_main_thread_predict(_w: Any) -> None:
+    """Reproduce ``w.predict(test_df)`` semantics without holding a model.
+
+    A ``booster.predict`` call on the parent main thread is sufficient to
+    bind libgomp's pool affinity to that thread (#156 root cause).
+    """
+    import lightgbm as lgb
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    X = rng.random((500, 20))
+    y = (rng.random(500) > 0.5).astype(int)
+
+    booster_holder: dict[str, Any] = {}
+
+    def _fit_in_worker() -> None:
+        ds = lgb.Dataset(X, label=y)
+        booster_holder["b"] = lgb.train(
+            {
+                "objective": "binary",
+                "metric": "binary_logloss",
+                "verbose": -1,
+                "num_threads": 0,
+            },
+            ds,
+            num_boost_round=20,
+        )
+
+    th = threading.Thread(target=_fit_in_worker, daemon=False)
+    th.start()
+    th.join()
+    booster = booster_holder["b"]
+    for _ in range(3):
+        _ = booster.predict(X)
+
+
+def _run_intermediate_main_thread_fit_predict(_w: Any) -> None:
+    """Heavier variant: both fit AND predict on the parent main thread.
+
+    Some users call ``lgb.train`` directly from notebook cells (outside
+    the widget). This cell pins that path: no worker offload at all.
+    """
+    import lightgbm as lgb
+    import numpy as np
+
+    rng = np.random.default_rng(7)
+    X = rng.random((500, 20))
+    y = (rng.random(500) > 0.5).astype(int)
+    ds = lgb.Dataset(X, label=y)
+    booster = lgb.train(
+        {
+            "objective": "binary",
+            "metric": "binary_logloss",
+            "verbose": -1,
+            "num_threads": 0,
+        },
+        ds,
+        num_boost_round=20,
+    )
+    for _ in range(3):
+        _ = booster.predict(X)
+
+
+_INTERMEDIATES = {
+    "noop": _run_intermediate_noop,
+    "main_thread_predict": _run_intermediate_main_thread_predict,
+    "main_thread_fit_predict": _run_intermediate_main_thread_fit_predict,
+}
+
+
+# ---------------------------------------------------------------------------
+# Op runners — both baseline and measured runs use the SAME op type so the
+# comparison cancels out fixed subprocess startup / dataset reload / model
+# serialisation overhead. Only catastrophe-level (libgomp pool affinity)
+# slowdowns remain visible in the ratio.
+# ---------------------------------------------------------------------------
+
+
+_RETUNE_TRIALS = 2
+_TUNE_PRIMER_TRIALS = 2
+
+
+def _prime_for_retune_cell(w: Any) -> None:
+    """Run a clean tune so the widget has tune state for the retune cells.
+
+    The actual baseline measurement is the FIRST retune (post-tune); the
+    measured run is the SECOND retune (post-intermediate). Both retunes
+    pay identical fixed overheads (subprocess startup, study restore,
+    model serialisation), so the ratio cleanly isolates libgomp
+    pool-affinity effects.
+    """
+    w.tune(timeout=600)
+    assert w.status == "completed", f"Primer tune failed: {w.error!r}"
+    assert w._execution_strategy == "subprocess", (
+        f"Pre-condition: strategy must be subprocess on libgomp host, got {w._execution_strategy!r}"
+    )
+
+
+def _run_retune_per_trial(w: Any) -> float:
+    t0 = time.perf_counter()
+    w.retune(n_trials=_RETUNE_TRIALS, timeout=600)
+    elapsed = time.perf_counter() - t0
+    assert w.status == "completed", f"Retune failed: {w.error!r}"
+    return elapsed / _RETUNE_TRIALS
+
+
+def _run_fit_seconds(w: Any) -> float:
+    t0 = time.perf_counter()
+    w.fit(timeout=600)
+    elapsed = time.perf_counter() - t0
+    assert w.status == "completed", f"Fit failed: {w.error!r}"
+    return elapsed
+
+
+_OP_RUNNERS = {
+    "retune": _run_retune_per_trial,
+    "fit": _run_fit_seconds,
+}
+
+
+# ---------------------------------------------------------------------------
+# The grid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "intermediate",
+    ["noop", "main_thread_predict", "main_thread_fit_predict"],
+)
+@pytest.mark.parametrize("next_op", ["retune", "fit"])
+def test_no_libgomp_perf_catastrophe(intermediate: str, next_op: str) -> None:
+    """INV-#160-A: cross-product perf grid.
+
+    For every combination of ``{intermediate parent-thread op}`` ×
+    ``{next ML op}``, per-unit wall-clock of the post-intermediate op
+    must stay within 1.5x of a pre-intermediate op-matched baseline.
+    Both runs are the SAME op type on the SAME widget, so subprocess
+    startup / dataset reload / model serialisation overheads cancel
+    out and only catastrophe-level (libgomp pool affinity) slowdowns
+    remain visible in the ratio.
+
+    Test shape:
+
+      [tune primer if next_op == retune]
+      run #1 (clean baseline)            <- baseline_per_unit
+      intermediate parent-main-thread op
+      run #2 (measured)                  <- next_per_unit
+      assert next / baseline < 1.5
+
+    Cells that exercise historical regressions:
+
+    * ``(noop, retune)`` — #154 clean retune path; PR #155 broke this
+      with the spurious ``RetuneSubprocessUnsupportedError``. P-038
+      pins it within 1.2x in the dedicated #156 test; this grid uses
+      the looser 1.5x bound for CI runner variance.
+    * ``(main_thread_predict, retune)`` — #156 catastrophe path;
+      ``w.tune() → w.predict(test_df) → w.retune()`` regressed to ~11x
+      under PR #155 thread fallback. P-038 keeps it within 1.2x; the
+      grid pins the 1.5x catastrophe ceiling.
+    * ``(main_thread_fit_predict, fit)`` — covers a pattern where the
+      user runs lightgbm directly in a cell, then later kicks off a
+      widget Fit that gets stuck on the bound pool.
+    """
+    os.environ.pop("LZW_FORCE_THREAD", None)
+
+    with _real_strategy_patch():
+        w = _make_perf_widget()
+
+        if next_op == "retune":
+            _prime_for_retune_cell(w)
+
+        baseline_per_unit = _OP_RUNNERS[next_op](w)
+
+        # Intermediate parent-main-thread op (or noop). After this point
+        # the libgomp pool may be bound to the parent main thread.
+        _INTERMEDIATES[intermediate](w)
+
+        # Measured run — same op as baseline so fixed overheads amortise
+        # identically and only catastrophe-level slowdowns survive.
+        next_per_unit = _OP_RUNNERS[next_op](w)
+
+    ratio = next_per_unit / baseline_per_unit if baseline_per_unit > 0 else float("inf")
+
+    UPPER_BOUND = 1.5
+    assert ratio < UPPER_BOUND, (
+        f"INV-#160-A regression: next_op={next_op!r} after "
+        f"intermediate={intermediate!r} per-unit wall {next_per_unit:.2f}s "
+        f"is {ratio:.2f}x op-matched clean baseline {baseline_per_unit:.2f}s "
+        f"(bound {UPPER_BOUND}x). "
+        f"This indicates a libgomp pool-affinity catastrophe — most "
+        f"likely a new code path that runs an OpenMP parallel region "
+        f"on the parent main thread before the next ML op fires. See "
+        f"P-039 in HISTORY.md."
+    )


### PR DESCRIPTION
## Summary

P-039 Phase 0 + Phase 1 of the systemic prevention plan for the libgomp / OpenMP pool-affinity regression family (#147 / #154 / #156 / #158).

- **Phase 0**: HISTORY.md proposal P-039 declaring the 5-layer defense plan and 4-phase rollout.
- **Phase 1 — Layer 3**: `tests/regression/test_reg_160_libgomp_perf_grid.py` — parameterised perf grid covering `{intermediate parent-thread op} × {next ML op}`. INV-#160-A: per-cell wall-clock within 1.5x of an op-matched clean baseline. Each cell runs the same op type twice so subprocess startup / dataset reload / model serialisation overheads cancel out and only catastrophe-class (libgomp pool affinity) slowdowns remain visible.
- **Phase 1 — Layer 4**: `.github/workflows/ci.yml` — new `libgomp-perf` CI job runs the grid on `ubuntu-latest` (libgomp by default) on every PR. Sanity step verifies libgomp is loaded so the gate cannot silently no-op.

Phases 2-4 (runtime INV-G guard, `BackendExecutor` funnel, change-gate codification) are tracked under #160 and ship in follow-up PRs.

## Why

The libgomp pool-affinity / "CPU core usage decreases" regression has reoccurred **four times** in this codebase, each time as a different proximate symptom but with the same root cause (GCC bug #108494 — libgomp binds the OpenMP thread pool to the first thread that enters a parallel region; subsequent worker-thread calls pay 10-50x penalty). Each fix only pinned the *specific* path observed (P-020, P-036, PR #155, P-038). No architectural guard prevents a future contributor from adding a fifth call site that re-triggers the same class of regression.

This PR is the minimum viable defense: a CI gate that fails any merge that introduces a catastrophe-class slowdown anywhere in the cross-product of historical regression patterns.

## Invariants

- **INV-#160-A** (Phase 1, this PR): for every cell of the grid, the post-intermediate per-unit wall-clock stays within 1.5x of the op-matched clean baseline.
- INV-G, INV-H, INV-I (Phase 2+): declared in P-039 but not encoded yet. Tracked under #160.

## Failure Paths Covered

The grid covers the cross-product directly:

| intermediate \ next_op  | retune | fit |
|---|---|---|
| `noop`                   | ✅ #154 clean baseline path | ✅ |
| `main_thread_predict`    | ✅ #156 catastrophe path (~11x) | ✅ |
| `main_thread_fit_predict`| ✅ | ✅ direct lightgbm-from-cell flow |

Out of scope (tracked separately):
- Timeout / cancellation interleaving with libgomp (Phase 2 INV-G)
- New ML call sites added outside `BackendExecutor` (Phase 3+4)

## Test plan

- [x] `pytest -m slow tests/regression/test_reg_160_libgomp_perf_grid.py` — 6/6 pass in ~40s on libgomp host
- [x] `pytest --cov=lizyml_widget --cov-fail-under=80 -q` — 978 passed, 96.25% coverage
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --strict src/lizyml_widget/` — clean
- [x] `pnpm lint` / `pnpm test:coverage` — clean (31/31 vitest files pass)
- [x] CI: `libgomp-perf` job runs the grid; sanity step asserts libgomp is loaded so the gate cannot silently no-op
- [ ] CI: green on all jobs after push

## Closes

Phase 1 of #160 (issue stays open until Phase 4 lands).