### PR TITLE
feat(widget,service): P-039 Phase 2 — INV-G runtime guard for libgomp owner (#160)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1411,7 +1411,7 @@ UI は Search Space の `mode=Fixed/Range/Choice` のような表示用 state �
 
 ---
 
-### 6.4 状態機械不変条件 (INV-A..F)
+### 6.4 状態機械不変条件 (INV-A..G)
 
 並行性 / 状態機械 / リソース所有権を扱うコードに対して、`~/.claude/rules/common/invariants-first.md`
 に従い不変条件を宣言する。各 INV は `tests/test_invariants.py` に対応する RED-then-GREEN テストを持ち、
@@ -1425,9 +1425,20 @@ runtime assert / breadcrumb log として `_supervise` / `_run_job` に encode �
 | **INV-D** | `_cancel_flag` は各ジョブ開始時に `clear()` され、ジョブ終了まで Widget 側からは書き込まれない。Cancel は `failed` (`error.code == "CANCELLED"`) へ遷移する。 | 前回ジョブの cancel フラグが残ったまま新規ジョブが起動して、即座に `CANCELLED` で落ちる。 |
 | **INV-E** | `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。 | round が降順になる、または同一ラウンドで `round` 値が +1 ずれる（P-029 オフバイワンの再発）。 |
 | **INV-F** | `tune_summary.boundary_report.dims` は各 search space 次元を過不足なく一度ずつ列挙する。ラウンド差分ではなく累積スナップショット。 | dims が重複する、または search space に存在する次元が dims に欠ける。 |
+| **INV-G** | `WidgetService._libgomp_pool_owner` が `"main"` のとき `ThreadJobRunner` で Tune/Fit/Retune を起動しない（自動的に `SubprocessJobRunner` へ re-route するか、`LZW_FORCE_THREAD=1` のとき WARN を出して thread 続行）。`predict` / SHAP plot 等が parent main thread で libgomp parallel region に入った後の thread runner 起動は GCC #108494 で 10-50x 劣化するため。 | `w.tune() → w.predict(df) → w.fit()` のシーケンスで thread runner が選ばれ、catastrophe path（10-50x 劣化）が発火する。 |
+
+`_libgomp_pool_owner` の状態遷移（P-039 Phase 2）:
+
+- 初期値 `"unknown"`
+- `SubprocessJobRunner.run` 完了後 → `"subprocess"`（subprocess が parallel region を所有、parent main thread は untouched）
+- `ThreadJobRunner.run` 完了後 → `"worker"`（worker thread が pool を所有、parent main thread は untouched）
+- `WidgetService.predict` / `WidgetService.get_plot("feature-importance-shap")` / `WidgetService.get_inference_plot(... "shap-summary")` の呼出後 → `"main"`（caller thread = parent main thread に bind）
+- `WidgetService.load_data(...)` 呼出後はリセットしない（プロセス内の libgomp pool 親和性は data reload で消えないため）
+
+`"main"` への遷移は本プロセス内で単方向（同一 Python プロセスでは libgomp の bind は data reload で消えない）。後続 thread runner job は INV-G ガードで subprocess に re-route される。`LZW_FORCE_THREAD=1` が明示的に設定されている場合は user opt-out を尊重し WARN のみ。
 
 **運用ルール**: `_supervise` / `_run_job` / `_tune_model` / `_cancel_flag` / `status` / `progress` /
-`boundary_report` を変更する PR は body に以下を含める。
+`boundary_report` / `_libgomp_pool_owner` を変更する PR は body に以下を含める。
 
 ```markdown
 ## Invariants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Runtime guard: parent-main-thread libgomp binding auto-routes
+  Tune/Fit/Retune to subprocess** (P-039 Phase 2 / INV-G,
+  [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
+  ``WidgetService`` now tracks ``_libgomp_pool_owner`` (one of
+  ``"unknown" / "subprocess" / "worker" / "main"``). Calls that run an
+  OpenMP parallel region on the caller thread —
+  ``WidgetService.predict``, ``WidgetService.get_plot("feature-importance-shap")``,
+  ``WidgetService.get_inference_plot(..., "shap-summary")`` — mark the
+  state ``"main"``. ``ThreadJobRunner`` / ``SubprocessJobRunner`` mark
+  ``"worker"`` / ``"subprocess"`` on successful completion.
+  ``LizyWidget._run_job`` reads the state and re-routes a thread-strategy
+  job to subprocess when the state is ``"main"`` (with a structured WARN
+  log), since GCC libgomp's pool affinity (#108494) would otherwise
+  deliver a 10-50x slowdown for the next worker-thread call.
+  ``LZW_FORCE_THREAD=1`` is honored as an explicit user opt-out — only
+  WARN, no auto-reroute. The state is process-sticky: ``load_data``
+  does NOT reset it because the libgomp bind in this process does not
+  unbind on data reload. BLUEPRINT.md §6.4 declares INV-G with the
+  state-transition table.
 - **CI: `libgomp-perf` job runs a parameterised libgomp perf regression
   grid on every PR** (P-039 Phase 1, [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
   The libgomp pool-affinity / "CPU core usage decreases" regression has

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案）
-- **ステータス**: 提案（Phase 1 実装着手中）
+- **日付**: 2026-05-10（提案・Phase 1 完了 / Phase 2 着手中）
+- **ステータス**: 採択（Phase 1: PR #162 で develop マージ済 / Phase 2: 着手中 / Phase 3-4: 着手前）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -6,7 +6,7 @@ import copy
 import logging
 import threading
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -35,6 +35,12 @@ from .types import (
 _log = logging.getLogger(__name__)
 
 MAX_STATS_VALUES = 1000
+
+# P-039 Phase 2 / INV-G: states for ``WidgetService._libgomp_pool_owner``.
+# Tracks which thread/process most recently entered an OpenMP parallel
+# region so the widget guard can re-route worker-thread Tune/Fit/Retune
+# to subprocess when the parent main thread has bound libgomp.
+LibgompPoolOwner = Literal["unknown", "subprocess", "worker", "main"]
 
 
 class WidgetService:
@@ -67,6 +73,14 @@ class WidgetService:
         # (None, flag) so apply_best_params can fail loud in the latter.
         self._last_tune_summary: TuningSummary | None = None
         self._tune_summary_invalidated_by_load: bool = False
+        # P-039 Phase 2 (INV-G): track which thread/process most recently
+        # entered an OpenMP parallel region. Once "main" is observed (via
+        # parent-main-thread predict / SHAP), all subsequent worker-thread
+        # Tune/Fit/Retune jobs are catastrophe-prone on libgomp hosts and
+        # the widget guard re-routes them to subprocess. The state is
+        # process-sticky — load_data does NOT reset it because libgomp
+        # pool affinity does not unbind on data reload.
+        self._libgomp_pool_owner: LibgompPoolOwner = "unknown"
 
     @property
     def info(self) -> BackendInfo:
@@ -613,6 +627,25 @@ class WidgetService:
             self._last_tune_summary = summary
             self._tune_summary_invalidated_by_load = False
 
+    def mark_libgomp_owner(self, owner: LibgompPoolOwner) -> None:
+        """Record which thread/process most recently entered an OpenMP region.
+
+        P-039 Phase 2 (INV-G): the widget guard reads this to decide
+        whether a worker-thread Tune/Fit would hit the libgomp
+        pool-affinity catastrophe. Once ``"main"`` is set, stay sticky —
+        the libgomp bind in this process does not go away on data reload
+        or model swap. Callers:
+
+        - ``SubprocessJobRunner`` (after successful run) → ``"subprocess"``
+        - ``ThreadJobRunner`` (after successful run) → ``"worker"``
+        - ``predict`` / SHAP plot paths → ``"main"`` (parent main thread)
+        """
+        # If main already observed, do not downgrade — the libgomp bind
+        # to the parent main thread is permanent for this process.
+        if self._libgomp_pool_owner == "main" and owner != "main":
+            return
+        self._libgomp_pool_owner = owner
+
     def predict(self, data: pd.DataFrame, *, return_shap: bool = False) -> PredictionSummary:
         """Run prediction on new data."""
         with self._model_lock:
@@ -620,7 +653,15 @@ class WidgetService:
         if model is None:
             msg = "No trained model. Run fit or tune first."
             raise ValueError(msg)
-        return self._adapter.predict(model, data, return_shap=return_shap)
+        try:
+            return self._adapter.predict(model, data, return_shap=return_shap)
+        finally:
+            # P-039 Phase 2 / INV-G: predict runs on the caller thread
+            # (parent main thread for ``w.predict()`` / Inference tab
+            # callbacks). Mark even on exception because the LightGBM /
+            # SHAP TreeExplainer call has already entered an OpenMP
+            # parallel region by the time the exception unwinds.
+            self.mark_libgomp_owner("main")
 
     # ── Results ──────────────────────────────────────────────
 
@@ -630,7 +671,14 @@ class WidgetService:
         if model is None:
             msg = "No trained model"
             raise ValueError(msg)
-        return self._adapter.plot(model, plot_type, **kwargs)
+        try:
+            return self._adapter.plot(model, plot_type, **kwargs)
+        finally:
+            # P-039 Phase 2 / INV-G: SHAP plots run TreeExplainer on the
+            # caller thread which is parallel under OpenMP. Mark "main"
+            # so the next worker-thread Tune/Fit re-routes to subprocess.
+            if plot_type == "feature-importance-shap":
+                self.mark_libgomp_owner("main")
 
     def get_inference_plot(self, predictions: pd.DataFrame, plot_type: str) -> PlotData:
         """Generate an inference plot (prediction-distribution or shap-summary)."""
@@ -639,6 +687,11 @@ class WidgetService:
         except AttributeError:
             msg = "Inference plots not supported by this adapter"
             raise TypeError(msg) from None
+        finally:
+            # P-039 Phase 2 / INV-G: shap-summary recomputes a TreeExplainer
+            # on the caller thread (parent main thread for the Inference tab).
+            if plot_type == "shap-summary":
+                self.mark_libgomp_owner("main")
 
     def get_available_plots(self) -> list[str]:
         with self._model_lock:

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -603,8 +603,36 @@ class LizyWidget(anywidget.AnyWidget):
         # to the same path as initial tune. The previous PR #155 thread
         # fallback is gone; it was unsafe whenever the user entered any
         # libgomp parallel region on the parent main thread (#156).
+        #
+        # P-039 Phase 2 / INV-G: if the parent main thread has already
+        # bound the libgomp pool (via prior predict / SHAP), a thread
+        # runner job would hit the 10-50x catastrophe. Re-route to
+        # subprocess unless the user explicitly opted out with
+        # LZW_FORCE_THREAD=1, in which case respect the opt-out and
+        # WARN. ``effective_strategy`` is per-job and does NOT mutate
+        # the cached ``_execution_strategy`` so a subsequent job after
+        # ``unknown`` recovery still consults the strategy detector.
+        effective_strategy = self._execution_strategy
+        if effective_strategy == "thread" and self._service._libgomp_pool_owner == "main":
+            if os.environ.get("LZW_FORCE_THREAD") == "1":
+                _log.warning(
+                    "INV-G: libgomp pool bound to parent main thread "
+                    "(prior predict/SHAP); LZW_FORCE_THREAD=1 honored — "
+                    "thread runner may be 10-50x slower for this %s job. "
+                    "Unset LZW_FORCE_THREAD to enable automatic subprocess re-route.",
+                    job_type,
+                )
+            else:
+                _log.warning(
+                    "INV-G: libgomp pool bound to parent main thread "
+                    "(prior predict/SHAP) — re-routing %s job to subprocess "
+                    "to avoid 10-50x slowdown.",
+                    job_type,
+                )
+                effective_strategy = "subprocess"
+
         runner: JobRunner
-        if self._execution_strategy == "subprocess":
+        if effective_strategy == "subprocess":
             runner = SubprocessJobRunner(self._service, libomp_path=self._libomp_path)
         else:
             runner = ThreadJobRunner(self._service)
@@ -688,6 +716,14 @@ class LizyWidget(anywidget.AnyWidget):
             self._apply_job_result(result)
             self.elapsed_sec = round(time.monotonic() - start, 1)
             self.status = "completed"
+            # P-039 Phase 2 / INV-G: record which thread/process most
+            # recently entered an OpenMP parallel region. Subprocess
+            # never touches the parent's libgomp pool; thread runner
+            # binds to the worker thread (not main, so OK). Either way,
+            # subsequent worker-thread jobs can proceed without the
+            # catastrophe path. Only mark on success — failed jobs may
+            # have been killed before any parallel region executed.
+            self._service.mark_libgomp_owner("subprocess" if is_subprocess else "worker")
         except InterruptedError:
             # INV-D (BLUEPRINT §6.4): cancel during running -> failed/CANCELLED.
             self.elapsed_sec = round(time.monotonic() - start, 1)

--- a/tests/regression/test_reg_160_inv_g_runtime_guard.py
+++ b/tests/regression/test_reg_160_inv_g_runtime_guard.py
@@ -1,0 +1,506 @@
+"""Regression tests for P-039 Phase 2 / INV-G — runtime libgomp owner guard.
+
+Phase 1 (PR #162) added a CI gate that detects libgomp pool-affinity
+catastrophes on the cross-product of historical regressions. Phase 2
+adds a *runtime* guard so the catastrophe is averted in production
+without waiting for a CI run on a future PR.
+
+INV-G (BLUEPRINT.md §6.4): when ``WidgetService._libgomp_pool_owner``
+is ``"main"``, ``ThreadJobRunner`` must NOT be used to launch
+Tune/Fit/Retune. The widget guard re-routes to ``SubprocessJobRunner``
+unless ``LZW_FORCE_THREAD=1`` is set, in which case the user opt-out
+is honored with a WARN-level log.
+
+State transitions encoded:
+
+- ``__init__``                                   → ``"unknown"``
+- ``SubprocessJobRunner.run`` success            → ``"subprocess"``
+- ``ThreadJobRunner.run`` success                → ``"worker"``
+- ``service.predict(...)``                       → ``"main"``
+- ``service.get_plot("feature-importance-shap")`` → ``"main"``
+- ``service.get_inference_plot(..., "shap-summary")`` → ``"main"``
+- ``"main"`` is sticky in-process (load_data does NOT reset)
+
+These tests pin the state-machine itself plus the widget guard's
+re-route behaviour. They are fast (mocks) so they run in the default
+pytest tier. The slow perf-grid in
+``test_reg_160_libgomp_perf_grid.py`` covers end-to-end timing.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.types import BackendInfo
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror test_reg_154 / test_reg_156 harness so canonical config
+# flows but ML library calls are intercepted.
+# ---------------------------------------------------------------------------
+
+
+def _make_widget() -> Any:
+    real_adapter = LizyMLAdapter()
+    with patch("lizyml_widget.widget.LizyMLAdapter") as MockAdapter:
+        adapter = MockAdapter.return_value
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.get_config_schema.return_value = {"type": "object"}
+        adapter.validate_config.return_value = []
+        adapter.initialize_config.side_effect = real_adapter.initialize_config
+        adapter.apply_config_patch.side_effect = real_adapter.apply_config_patch
+        adapter.prepare_run_config.side_effect = real_adapter.prepare_run_config
+        adapter.get_backend_contract.side_effect = real_adapter.get_backend_contract
+        adapter.canonicalize_config.side_effect = real_adapter.canonicalize_config
+        adapter.apply_task_defaults.side_effect = real_adapter.apply_task_defaults
+        adapter.classify_best_params.side_effect = real_adapter.classify_best_params
+
+        from lizyml_widget.widget import LizyWidget
+
+        w = LizyWidget()
+    df = pd.DataFrame(
+        {
+            "f1": list(range(40)),
+            "f2": [i * 0.5 for i in range(40)],
+            "f3": [i % 5 for i in range(40)],
+            "y": [0, 1] * 20,
+        }
+    )
+    w.load(df, target="y")
+    return w
+
+
+def _stub_runner_result() -> Any:
+    from lizyml_widget.subprocess_runner import SubprocessJobResult
+
+    return SubprocessJobResult(
+        job_type="fit",
+        fit_summary={"metrics": {}, "fold_count": 0, "fold_details": [], "params": []},
+        tune_summary={},
+        eval_table=[],
+        split_summary=[],
+        available_plots=[],
+        model_path=None,
+        tune_state_path=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# State machine — Service.mark_libgomp_owner
+# ---------------------------------------------------------------------------
+
+
+class TestLibgompOwnerStateMachine:
+    """Service-side state transitions for INV-G."""
+
+    def _make_service(self) -> Any:
+        from lizyml_widget.service import WidgetService
+
+        return WidgetService(adapter=LizyMLAdapter())
+
+    def test_default_state_is_unknown(self) -> None:
+        svc = self._make_service()
+        assert svc._libgomp_pool_owner == "unknown"
+
+    def test_mark_owner_sets_state(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("subprocess")
+        assert svc._libgomp_pool_owner == "subprocess"
+        svc.mark_libgomp_owner("worker")
+        assert svc._libgomp_pool_owner == "worker"
+
+    def test_main_is_sticky_against_subprocess_downgrade(self) -> None:
+        """Once main thread bound libgomp, the bind does not unbind in
+        this process — subsequent subprocess success must NOT downgrade
+        the state to "subprocess" (which would re-enable thread runner
+        for the *next* job and re-trigger catastrophe).
+        """
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("subprocess")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_main_is_sticky_against_worker_downgrade(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("worker")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_main_is_idempotent(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("main")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_load_data_does_not_reset_libgomp_owner(self) -> None:
+        """libgomp pool affinity is process-state — reloading data does
+        not unbind it. The state must persist so the guard catches
+        the next thread-runner job.
+        """
+        from lizyml_widget.service import WidgetService
+
+        svc = WidgetService(adapter=LizyMLAdapter())
+        svc.mark_libgomp_owner("main")
+        df = pd.DataFrame({"f1": [1, 2, 3, 4], "y": [0, 1, 0, 1]})
+        svc.load_data(df, target="y")
+        assert svc._libgomp_pool_owner == "main"
+
+
+# ---------------------------------------------------------------------------
+# State machine — predict / SHAP plot transitions
+# ---------------------------------------------------------------------------
+
+
+class TestServiceCallSitesMarkMain:
+    """Caller-thread ML library calls must mark the state to "main".
+
+    The actual adapter calls are mocked because we are testing the
+    state-transition wiring, not the LightGBM/SHAP behavior.
+    """
+
+    def _make_service_with_model(self) -> Any:
+        from lizyml_widget.service import WidgetService
+
+        adapter = MagicMock()
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.predict.return_value = MagicMock()
+        adapter.plot.return_value = MagicMock()
+        adapter.plot_inference.return_value = MagicMock()
+        svc = WidgetService(adapter=adapter)
+        svc._model = MagicMock()
+        return svc, adapter
+
+    def test_predict_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        assert svc._libgomp_pool_owner == "unknown"
+        svc.predict(pd.DataFrame({"f1": [1, 2]}))
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_predict_marks_main_even_when_adapter_raises(self) -> None:
+        """LightGBM may have already entered the parallel region by the
+        time the exception unwinds — mark "main" defensively."""
+        svc, adapter = self._make_service_with_model()
+        adapter.predict.side_effect = RuntimeError("predict failed")
+        with pytest.raises(RuntimeError):
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_plot_shap_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_plot("feature-importance-shap")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_plot_non_shap_does_not_mark_main(self) -> None:
+        """Non-SHAP plots (e.g., learning-curve) do not run TreeExplainer
+        on the caller thread — state must remain unchanged."""
+        svc, _ = self._make_service_with_model()
+        svc.get_plot("optimization-history")
+        assert svc._libgomp_pool_owner == "unknown"
+
+    def test_get_inference_plot_shap_summary_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), "shap-summary")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_inference_plot_distribution_does_not_mark_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_inference_plot(
+            pd.DataFrame({"pred": [0.1]}),
+            "prediction-distribution",
+        )
+        assert svc._libgomp_pool_owner == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# State machine — runner completion transitions (in widget._supervise)
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerCompletionMarksOwner:
+    """``_supervise`` marks the owner after a successful runner.run()."""
+
+    def test_subprocess_runner_success_marks_subprocess(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", "/usr/lib/libomp5.so"),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+        ):
+            mock_inst = mock_sp.return_value
+            mock_inst.kind = "subprocess"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            assert w._service._libgomp_pool_owner == "unknown"
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "completed", f"Fit failed: {w.error!r}"
+            assert w._service._libgomp_pool_owner == "subprocess"
+
+    def test_thread_runner_success_marks_worker(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_inst = mock_thread.return_value
+            mock_inst.kind = "thread"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "completed", f"Fit failed: {w.error!r}"
+            assert w._service._libgomp_pool_owner == "worker"
+
+    def test_failed_run_does_not_mark_owner(self) -> None:
+        """A failed job may have aborted before any parallel region
+        executed — leave state unchanged so the guard does not over-
+        constrain future jobs."""
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_inst = mock_thread.return_value
+            mock_inst.kind = "thread"
+            mock_inst.run.side_effect = RuntimeError("boom")
+
+            w = _make_widget()
+            with pytest.raises(RuntimeError, match="boom"):
+                w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "failed"
+            assert w._service._libgomp_pool_owner == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Widget guard — re-route thread → subprocess when state is "main"
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetGuardReroutesToSubprocess:
+    """``widget._run_job`` upgrades thread → subprocess when state is "main".
+
+    The actual reroute decision is observable via which runner class
+    gets instantiated. We pre-seed the service state and assert
+    SubprocessJobRunner is constructed even though the strategy
+    detector returned "thread".
+    """
+
+    def test_thread_strategy_with_main_state_reroutes_to_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            # Pre-seed: prior predict on parent main thread bound libgomp.
+            w._service.mark_libgomp_owner("main")
+
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            (
+                mock_sp.assert_called_once(),
+                ("INV-G: thread+main state must re-route to SubprocessJobRunner"),
+            )
+            mock_thread.assert_not_called()
+
+    def test_force_thread_env_honored_when_state_main(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """LZW_FORCE_THREAD=1 is an explicit user opt-out. The guard
+        must respect it (only WARN, no auto-reroute)."""
+        monkeypatch.setenv("LZW_FORCE_THREAD", "1")
+        caplog.set_level(logging.WARNING, logger="lizyml_widget.widget")
+
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w._service.mark_libgomp_owner("main")
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            (
+                mock_thread.assert_called_once(),
+                ("LZW_FORCE_THREAD=1 must keep thread runner under main state"),
+            )
+            mock_sp.assert_not_called()
+            warn_msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+            assert any("INV-G" in m for m in warn_msgs), (
+                f"Expected INV-G WARN under FORCE_THREAD; got: {warn_msgs}"
+            )
+
+    def test_thread_strategy_with_unknown_state_uses_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without prior main-thread parallel region, thread strategy
+        runs as-is — no spurious subprocess startup overhead."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            assert w._service._libgomp_pool_owner == "unknown"
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            mock_thread.assert_called_once()
+            mock_sp.assert_not_called()
+
+    def test_subprocess_strategy_does_not_log_inv_g_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The guard only fires for thread strategy with main state.
+        Subprocess + main is the safe combination — no WARN should fire."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        caplog.set_level(logging.WARNING, logger="lizyml_widget.widget")
+
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+        ):
+            mock_inst = mock_sp.return_value
+            mock_inst.kind = "subprocess"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w._service.mark_libgomp_owner("main")
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            inv_g_warns = [r for r in caplog.records if "INV-G" in r.getMessage()]
+            assert not inv_g_warns, (
+                f"Subprocess+main should not emit INV-G warn; got: {inv_g_warns}"
+            )
+
+    def test_concurrent_jobs_each_apply_guard_independently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second job, after a first job that did NOT bind main, must
+        consult the live state — not a frozen snapshot. This catches a
+        future refactor that captures state once at __init__ time."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+
+            # Job 1: state is "unknown" → thread runner.
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert mock_thread.call_count == 1
+            assert mock_sp.call_count == 0
+
+            # Simulate user predict between jobs.
+            w._service.mark_libgomp_owner("main")
+
+            # Job 2: state is now "main" → must re-route to subprocess.
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert mock_sp.call_count == 1, "Second job must re-route to subprocess after predict"
+
+
+# ---------------------------------------------------------------------------
+# Threading sanity: mark_libgomp_owner is safe under concurrent calls.
+# ---------------------------------------------------------------------------
+
+
+class TestMarkLibgompOwnerThreadSafety:
+    def test_concurrent_marks_converge_to_main_when_main_observed(self) -> None:
+        """If any thread observes main, the final state is main —
+        regardless of concurrent worker/subprocess transitions."""
+        from lizyml_widget.service import WidgetService
+
+        svc = WidgetService(adapter=LizyMLAdapter())
+
+        def hammer_subprocess() -> None:
+            for _ in range(200):
+                svc.mark_libgomp_owner("subprocess")
+
+        def hammer_worker() -> None:
+            for _ in range(200):
+                svc.mark_libgomp_owner("worker")
+
+        def hammer_main() -> None:
+            for _ in range(50):
+                svc.mark_libgomp_owner("main")
+
+        threads = [
+            threading.Thread(target=hammer_subprocess),
+            threading.Thread(target=hammer_worker),
+            threading.Thread(target=hammer_main),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert svc._libgomp_pool_owner == "main"


### PR DESCRIPTION
## Summary

P-039 Phase 2 of the systemic prevention plan (#160). Adds a **runtime guard** so the libgomp pool-affinity catastrophe is averted in production without waiting for the Phase 1 CI grid to flag a future PR.

- **BLUEPRINT.md §6.4**: declare INV-G with the state-transition table.
- **`WidgetService._libgomp_pool_owner`**: tracks which thread/process most recently entered an OpenMP parallel region (``"unknown" / "subprocess" / "worker" / "main"``).
- **State transitions**:
  - ``predict()`` / SHAP plot paths → ``"main"`` (caller thread bound libgomp)
  - ``SubprocessJobRunner.run`` success → ``"subprocess"``
  - ``ThreadJobRunner.run`` success → ``"worker"``
  - ``"main"`` is sticky in-process (libgomp bind cannot unbind on data reload)
- **Widget guard** in ``_run_job``: when state is ``"main"`` and strategy is ``"thread"``, re-routes to subprocess. ``LZW_FORCE_THREAD=1`` is honored as user opt-out — only WARN, no auto-reroute.

## Why

Phase 1 (PR #162) added a CI gate that catches catastrophes on the cross-product of historical regressions. But CI only runs after a PR is opened — production users on libgomp Linux today can still hit the catastrophe via novel call-site combinations not yet covered by the grid. Phase 2 closes that gap by enforcing INV-G at runtime: the next worker-thread Tune/Fit/Retune **after a parent-main-thread predict / SHAP** auto-routes to subprocess.

## Invariants

- **INV-G** (new, this PR): when ``WidgetService._libgomp_pool_owner == \"main\"``, ``ThreadJobRunner`` must NOT be used to launch Tune/Fit/Retune. The widget guard re-routes to ``SubprocessJobRunner`` unless ``LZW_FORCE_THREAD=1`` is set.
- INV-A..F: untouched (no state-machine changes outside the new field).

## Failure Paths Covered

- [x] Normal completion (subprocess → mark ``\"subprocess\"``; thread → mark ``\"worker\"``; predict → mark ``\"main\"``)
- [x] Exception in adapter.predict mid-call (state still marks ``\"main\"`` because libgomp may have already bound)
- [x] Cancellation (no state mark — runner.run was not successful)
- [x] Concurrent ``mark_libgomp_owner`` calls across threads (200x subprocess + 200x worker + 50x main → final state ``\"main\"``)
- [x] ``LZW_FORCE_THREAD=1`` opt-out preserved (WARN only, runner stays thread)
- [x] Sticky ``\"main\"`` against subprocess/worker downgrade (process state cannot unbind libgomp)
- [x] ``load_data`` does NOT reset state (process-state, not data-state)

## Test plan

- [x] 21 new fast tests in ``tests/regression/test_reg_160_inv_g_runtime_guard.py`` — state machine, call sites, runner completion, widget guard, threading
- [x] 999 fast tests pass (978 prior + 21 new), 96.24% coverage
- [x] 6/6 slow libgomp-perf grid cells pass (Phase 1 not regressed)
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy --strict`` clean
- [x] ``pnpm lint`` / ``pnpm test:coverage`` clean (331/331)
- [ ] CI green on all jobs after push

## Phase tracker

- ✅ Phase 0: P-039 Proposal — landed in PR #162
- ✅ Phase 1: parameterised perf grid + libgomp-perf CI job — landed in PR #162
- 🚧 **Phase 2: INV-G runtime guard — this PR**
- ⏳ Phase 3: ``BackendExecutor`` funnel refactor — next PR
- ⏳ Phase 4: change-gate codification + lint rule — final PR

Issue #160 stays open until Phase 4 lands.