### PR TITLE
feat(service,backend_executor): P-039 Phase 3 — caller-thread ML library funnel (#160)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -97,6 +97,7 @@ Widget は LizyML の型・契約（`BackendAdapter` Protocol, `TuningResult`, `
 | **UI** | `js/src/` | `backend_contract` / `config` / `df_info` を描画し、ユーザー操作を `action` に変換する。ローカル状態は表示都合（例: Search Space の Mode）に限定する | ML ロジック・Python 直接呼び出し・backend 固有 option set / parameter catalog / step 値のハードコード・full config dict の合成 |
 | **Widget** | `src/lizyml_widget/widget.py` | traitlets 定義・Action 処理・スレッド管理・`msg:custom` 中継 | ML ロジック直接記述、Service の private 状態参照、backend 固有 config 意味論の保持、ジョブ実行時の時系列スナップショット保持（P-035 で `_tune_*_snapshot` を Service の `_last_tune_summary` へ移管済み）|
 | **Service** | `src/lizyml_widget/service.py` | Data タブ由来 state（target / task / columns / CV）の管理、実行前提判定、Adapter 呼び出し調整、canonical config と Data 系 state の結合 | バックエンド固有の default / option set / search space catalog / step 定数の保持 |
+| **BackendExecutor** | `src/lizyml_widget/backend_executor.py` | caller-thread の ML library 呼出（predict / SHAP plot / 推論プロット）の単一 chokepoint。`run_ml(op, ml_kind=...)` で全呼出を funnel し、libgomp owner state（INV-G）の遷移を一元化する。Phase 4 の lint rule で「executor 外部の ML library 直接呼出」を禁止する基盤 | ML 結果の加工・キャッシュ・runner 配下（worker thread / subprocess）のジョブ実行 |
 | **Adapter** | `src/lizyml_widget/adapter.py` | Backend Contract 提供、backend 固有 config default / patch 適用 / 実行前準備、バックエンドライブラリ呼び出し、共通型への変換 | Widget / traitlets の知識 |
 
 `LizyWidget` は backend 差し替え・テスト容易性のため `adapter` をコンストラクタ引数で受け取れる。未指定時のみ既定の `LizyMLAdapter` を使用する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **BackendExecutor caller-thread ML library funnel** (P-039 Phase 3,
+  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
+  New module ``src/lizyml_widget/backend_executor.py`` exposes
+  ``BackendExecutor.run_ml(op, *, ml_kind)`` — a single chokepoint for
+  every caller-thread ML library call. ``WidgetService.predict``,
+  ``WidgetService.get_plot``, and ``WidgetService.get_inference_plot``
+  now route through ``self._executor.run_ml(...)`` instead of marking
+  ``_libgomp_pool_owner`` directly. ``ml_kind`` categorises the call
+  (``predict`` / ``explain`` / ``plot_shap`` / ``plot_other``) so the
+  executor knows which calls bind libgomp pool affinity and which do
+  not. This consolidates Phase 2's owner-state marking into one place
+  and sets up Phase 4 (lint rule) to enforce "no ML library call
+  outside the executor" as a structural invariant. No behavioural
+  change for end users — predict / plot semantics are unchanged.
 - **Runtime guard: parent-main-thread libgomp binding auto-routes
   Tune/Fit/Retune to subprocess** (P-039 Phase 2 / INV-G,
   [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案・Phase 1 完了 / Phase 2 着手中）
-- **ステータス**: 採択（Phase 1: PR #162 で develop マージ済 / Phase 2: 着手中 / Phase 3-4: 着手前）
+- **日付**: 2026-05-10（提案・Phase 1-2 完了 / Phase 3 着手中）
+- **ステータス**: 採択（Phase 1-2: develop マージ済 / Phase 3: 着手中 / Phase 4: 着手前）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/src/lizyml_widget/backend_executor.py
+++ b/src/lizyml_widget/backend_executor.py
@@ -1,0 +1,103 @@
+"""BackendExecutor — caller-thread ML library call funnel (P-039 Phase 3).
+
+Every caller-thread invocation of an ML library function (LightGBM /
+SHAP / etc.) goes through ``BackendExecutor.run_ml``. The executor:
+
+1. Centralises ``WidgetService._libgomp_pool_owner`` marking so the INV-G
+   runtime guard (P-039 Phase 2, ``widget._run_job``) sees a single,
+   consistent "main thread bound libgomp" signal regardless of which
+   adapter method was called.
+2. Provides a single chokepoint for a future scoped routing decision
+   (subprocess offload, dedicated OpenMP-owner thread). Phase 3 runs
+   everything inline on the caller thread; Phase 4 can then enforce
+   "no direct ML library call outside the executor" via lint rule
+   without renaming any call sites.
+
+The runner-side path (``ThreadJobRunner`` / ``SubprocessJobRunner``) is
+*not* funnelled through the executor — runners are the equivalent
+chokepoint for worker-thread / subprocess ML, and ``widget._supervise``
+already calls ``service.mark_libgomp_owner`` after a successful
+``runner.run()``. The executor is only for code that runs *on the same
+thread as the user-facing call* (predict, SHAP / explainability plots).
+
+State transitions performed by the executor:
+
+- ``ml_kind="predict"`` → mark ``"main"`` (OpenMP parallel boost in
+  ``booster.predict`` / etc. binds to caller thread).
+- ``ml_kind="explain"`` / ``ml_kind="plot_shap"`` → mark ``"main"``
+  (SHAP TreeExplainer is parallel under OpenMP).
+- ``ml_kind="plot_other"`` → no state change (Plotly-only plot
+  computation does not enter ML library parallel regions).
+
+Marking happens in a ``finally`` block so that exceptions raised mid-
+parallel-region still update the state defensively (libgomp may have
+already bound by the time the exception unwinds).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, TypeVar
+
+if TYPE_CHECKING:
+    from .service import WidgetService
+
+
+MLKind = Literal["predict", "explain", "plot_shap", "plot_other"]
+"""Categories of caller-thread ML library calls.
+
+- ``predict``: model inference (LightGBM ``booster.predict`` and similar)
+- ``explain``: SHAP value computation (``TreeExplainer.shap_values``)
+- ``plot_shap``: SHAP-based plots (``importance_plot(kind='shap')``)
+- ``plot_other``: non-ML-library plots (learning curves,
+  optimization-history, ROC, etc. — pure plotly / numpy work)
+"""
+
+# Kinds that enter an OpenMP parallel region on the caller thread and
+# therefore bind libgomp's pool affinity. Anything in this set must
+# transition the libgomp owner state to ``"main"``.
+_KINDS_THAT_BIND_LIBGOMP: frozenset[MLKind] = frozenset({"predict", "explain", "plot_shap"})
+
+T = TypeVar("T")
+
+
+class BackendExecutor:
+    """Funnel for caller-thread ML library calls.
+
+    Constructed once per ``WidgetService`` instance and held as
+    ``service._executor``. All of ``service.predict``,
+    ``service.get_plot``, and ``service.get_inference_plot`` route
+    their adapter calls through ``run_ml`` so the libgomp owner state
+    is updated in exactly one place.
+    """
+
+    def __init__(self, service: WidgetService) -> None:
+        self._service = service
+
+    def run_ml(self, op: Callable[[], T], *, ml_kind: MLKind) -> T:
+        """Run an ML library operation on the caller thread.
+
+        Parameters
+        ----------
+        op:
+            Zero-arg callable that performs the ML library call (e.g.
+            ``lambda: adapter.predict(model, df)``).
+        ml_kind:
+            Category of the call. Determines whether to mark the
+            libgomp owner state to ``"main"`` after the call.
+
+        Returns
+        -------
+        The result of ``op()``.
+
+        Raises
+        ------
+        Whatever ``op()`` raises. State marking still happens on the
+        exception path (libgomp may have already entered a parallel
+        region before the exception was raised).
+        """
+        try:
+            return op()
+        finally:
+            if ml_kind in _KINDS_THAT_BIND_LIBGOMP:
+                self._service.mark_libgomp_owner("main")

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -6,11 +6,15 @@ import copy
 import logging
 import threading
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 
 from .adapter import BackendAdapter
+from .backend_executor import BackendExecutor
+
+if TYPE_CHECKING:
+    from .backend_executor import MLKind
 from .service_columns import (
     auto_configure_column,
     calc_feature_summary,
@@ -81,6 +85,12 @@ class WidgetService:
         # process-sticky — load_data does NOT reset it because libgomp
         # pool affinity does not unbind on data reload.
         self._libgomp_pool_owner: LibgompPoolOwner = "unknown"
+        # P-039 Phase 3: caller-thread ML library calls (predict / SHAP)
+        # are routed through this executor so libgomp owner state is
+        # marked in exactly one place. A future phase may extend the
+        # executor to offload predict/SHAP to a subprocess when state
+        # tracking alone is not enough.
+        self._executor = BackendExecutor(self)
 
     @property
     def info(self) -> BackendInfo:
@@ -647,51 +657,64 @@ class WidgetService:
         self._libgomp_pool_owner = owner
 
     def predict(self, data: pd.DataFrame, *, return_shap: bool = False) -> PredictionSummary:
-        """Run prediction on new data."""
+        """Run prediction on new data.
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml`` so the
+        libgomp owner state is marked in exactly one place. The
+        executor enters ``"main"`` after ``adapter.predict`` runs
+        because LightGBM / SHAP TreeExplainer enters an OpenMP parallel
+        region on the caller thread.
+        """
         with self._model_lock:
             model = self._model
         if model is None:
             msg = "No trained model. Run fit or tune first."
             raise ValueError(msg)
-        try:
-            return self._adapter.predict(model, data, return_shap=return_shap)
-        finally:
-            # P-039 Phase 2 / INV-G: predict runs on the caller thread
-            # (parent main thread for ``w.predict()`` / Inference tab
-            # callbacks). Mark even on exception because the LightGBM /
-            # SHAP TreeExplainer call has already entered an OpenMP
-            # parallel region by the time the exception unwinds.
-            self.mark_libgomp_owner("main")
+        return self._executor.run_ml(
+            lambda: self._adapter.predict(model, data, return_shap=return_shap),
+            ml_kind="predict",
+        )
 
     # ── Results ──────────────────────────────────────────────
 
     def get_plot(self, plot_type: str, **kwargs: Any) -> PlotData:
+        """Render a plot for the trained model.
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml``. SHAP
+        plots are tagged ``"plot_shap"`` so the executor marks the
+        libgomp owner state to ``"main"`` (TreeExplainer is OpenMP-
+        parallel on the caller thread); other plots are tagged
+        ``"plot_other"`` and do not change state.
+        """
         with self._model_lock:
             model = self._model
         if model is None:
             msg = "No trained model"
             raise ValueError(msg)
-        try:
-            return self._adapter.plot(model, plot_type, **kwargs)
-        finally:
-            # P-039 Phase 2 / INV-G: SHAP plots run TreeExplainer on the
-            # caller thread which is parallel under OpenMP. Mark "main"
-            # so the next worker-thread Tune/Fit re-routes to subprocess.
-            if plot_type == "feature-importance-shap":
-                self.mark_libgomp_owner("main")
+        ml_kind: MLKind = "plot_shap" if plot_type == "feature-importance-shap" else "plot_other"
+        return self._executor.run_ml(
+            lambda: self._adapter.plot(model, plot_type, **kwargs),
+            ml_kind=ml_kind,
+        )
 
     def get_inference_plot(self, predictions: pd.DataFrame, plot_type: str) -> PlotData:
-        """Generate an inference plot (prediction-distribution or shap-summary)."""
-        try:
-            return self._adapter.plot_inference(predictions, plot_type)
-        except AttributeError:
-            msg = "Inference plots not supported by this adapter"
-            raise TypeError(msg) from None
-        finally:
-            # P-039 Phase 2 / INV-G: shap-summary recomputes a TreeExplainer
-            # on the caller thread (parent main thread for the Inference tab).
-            if plot_type == "shap-summary":
-                self.mark_libgomp_owner("main")
+        """Generate an inference plot (prediction-distribution or shap-summary).
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml``.
+        ``shap-summary`` is tagged ``"plot_shap"`` (TreeExplainer
+        recomputed on the caller thread); other plots are
+        ``"plot_other"``.
+        """
+        ml_kind: MLKind = "plot_shap" if plot_type == "shap-summary" else "plot_other"
+
+        def _run() -> PlotData:
+            try:
+                return self._adapter.plot_inference(predictions, plot_type)
+            except AttributeError:
+                msg = "Inference plots not supported by this adapter"
+                raise TypeError(msg) from None
+
+        return self._executor.run_ml(_run, ml_kind=ml_kind)
 
     def get_available_plots(self) -> list[str]:
         with self._model_lock:

--- a/tests/regression/test_reg_160_backend_executor_funnel.py
+++ b/tests/regression/test_reg_160_backend_executor_funnel.py
@@ -1,0 +1,160 @@
+"""Funnel-contract tests for P-039 Phase 3 (BackendExecutor).
+
+The architectural guarantee for Phase 3 is that **every caller-thread
+ML library call site** in the widget routes through the executor.
+Phase 4 (lint rule) will enforce this against future changes; this
+file pins the current state so a regression that bypasses the
+executor surfaces in fast tier instead of as silent INV-G drift.
+
+The contracts:
+
+- ``service.predict`` calls ``executor.run_ml(..., ml_kind="predict")``
+- ``service.get_plot("feature-importance-shap")`` calls ``run_ml(..., ml_kind="plot_shap")``
+- ``service.get_plot("<other>")`` calls ``run_ml(..., ml_kind="plot_other")``
+- ``service.get_inference_plot(..., "shap-summary")`` calls ``run_ml(..., ml_kind="plot_shap")``
+- ``service.get_inference_plot(..., "<other>")`` calls ``run_ml(..., ml_kind="plot_other")``
+
+We patch the executor's ``run_ml`` to assert the funnel without
+running the underlying mock adapter twice. The end-state INV-G
+transitions are pinned separately by ``test_reg_160_inv_g_runtime_guard``;
+this file is the funnel-shape contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def _make_service_with_model() -> Any:
+    from lizyml_widget.service import WidgetService
+
+    adapter = MagicMock()
+    adapter.predict.return_value = MagicMock()
+    adapter.plot.return_value = MagicMock()
+    adapter.plot_inference.return_value = MagicMock()
+    svc = WidgetService(adapter=adapter)
+    svc._model = MagicMock()
+    return svc, adapter
+
+
+class TestPredictFunnel:
+    def test_predict_routes_through_executor_with_predict_kind(self) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == "predict"
+        adapter.predict.assert_called_once()
+
+    def test_predict_does_not_call_adapter_outside_executor(self) -> None:
+        """If ``run_ml`` is intercepted to *not* call the operation,
+        the adapter must not be touched. This catches a refactor that
+        accidentally calls the adapter twice (once in the funnel and
+        once outside)."""
+        svc, adapter = _make_service_with_model()
+
+        with patch.object(svc._executor, "run_ml", return_value=MagicMock()) as mock_run:
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+
+        mock_run.assert_called_once()
+        adapter.predict.assert_not_called()
+
+
+class TestGetPlotFunnel:
+    @pytest.mark.parametrize(
+        "plot_type, expected_kind",
+        [
+            ("feature-importance-shap", "plot_shap"),
+            ("learning-curve", "plot_other"),
+            ("optimization-history", "plot_other"),
+        ],
+    )
+    def test_get_plot_routes_through_executor_with_correct_kind(
+        self, plot_type: str, expected_kind: str
+    ) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.get_plot(plot_type)
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == expected_kind
+        adapter.plot.assert_called_once()
+
+
+class TestGetInferencePlotFunnel:
+    @pytest.mark.parametrize(
+        "plot_type, expected_kind",
+        [
+            ("shap-summary", "plot_shap"),
+            ("prediction-distribution", "plot_other"),
+        ],
+    )
+    def test_get_inference_plot_routes_through_executor_with_correct_kind(
+        self, plot_type: str, expected_kind: str
+    ) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), plot_type)
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == expected_kind
+        adapter.plot_inference.assert_called_once()
+
+    def test_inference_plot_attribute_error_translates_to_type_error(self) -> None:
+        """Existing AttributeError → TypeError translation must survive
+        the executor refactor (regression for adapter without
+        ``plot_inference``)."""
+        svc, adapter = _make_service_with_model()
+        adapter.plot_inference.side_effect = AttributeError("no plot_inference on this adapter")
+
+        with pytest.raises(TypeError, match="Inference plots not supported by this adapter"):
+            svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), "shap-summary")
+
+
+class TestExecutorIsServiceOwned:
+    """``service._executor`` is the canonical executor instance.
+
+    Phase 4 lint will rely on this — every ML call must reach the
+    executor stored on the service that constructed the adapter calls.
+    A future refactor must not introduce a per-call executor or a
+    module-global instance.
+    """
+
+    def test_service_holds_executor_reference(self) -> None:
+        svc, _ = _make_service_with_model()
+        from lizyml_widget.backend_executor import BackendExecutor
+
+        assert isinstance(svc._executor, BackendExecutor)
+
+    def test_executor_back_reference_points_to_owning_service(self) -> None:
+        svc, _ = _make_service_with_model()
+        assert svc._executor._service is svc

--- a/tests/test_backend_executor.py
+++ b/tests/test_backend_executor.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``BackendExecutor`` (P-039 Phase 3).
+
+The executor is the caller-thread chokepoint for ML library calls.
+Phase 3's behavioral guarantee is narrow: ``run_ml`` invokes the
+provided callable, returns its result (or re-raises), and marks the
+service's libgomp owner state to ``"main"`` for kinds that bind
+libgomp.
+
+Phase 4 (lint rule) will enforce that no ML library call site exists
+outside the executor module — these tests pin the executor's own
+contract so that enforcement has a stable target.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizyml_widget.backend_executor import BackendExecutor
+
+
+def _make_executor() -> tuple[BackendExecutor, MagicMock]:
+    svc = MagicMock()
+    svc._libgomp_pool_owner = "unknown"
+
+    def _mark(owner: str) -> None:
+        if svc._libgomp_pool_owner == "main" and owner != "main":
+            return
+        svc._libgomp_pool_owner = owner
+
+    svc.mark_libgomp_owner.side_effect = _mark
+    return BackendExecutor(svc), svc
+
+
+# ---------------------------------------------------------------------------
+# Return value / exception transparency
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlBehavior:
+    def test_returns_callable_result(self) -> None:
+        ex, _ = _make_executor()
+        assert ex.run_ml(lambda: 42, ml_kind="plot_other") == 42
+
+    def test_runs_callable_exactly_once(self) -> None:
+        ex, _ = _make_executor()
+        op = MagicMock(return_value="ok")
+        ex.run_ml(op, ml_kind="predict")
+        assert op.call_count == 1
+
+    def test_propagates_callable_exception(self) -> None:
+        ex, _ = _make_executor()
+
+        def boom() -> None:
+            raise RuntimeError("op failed")
+
+        with pytest.raises(RuntimeError, match="op failed"):
+            ex.run_ml(boom, ml_kind="predict")
+
+
+# ---------------------------------------------------------------------------
+# Owner-state marking — only kinds that bind libgomp transition to "main"
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlOwnerMarking:
+    @pytest.mark.parametrize("kind", ["predict", "explain", "plot_shap"])
+    def test_libgomp_binding_kinds_mark_main(self, kind: str) -> None:
+        ex, svc = _make_executor()
+        ex.run_ml(lambda: None, ml_kind=kind)  # type: ignore[arg-type]
+        svc.mark_libgomp_owner.assert_called_once_with("main")
+
+    def test_plot_other_does_not_mark_main(self) -> None:
+        ex, svc = _make_executor()
+        ex.run_ml(lambda: None, ml_kind="plot_other")
+        svc.mark_libgomp_owner.assert_not_called()
+
+    def test_marks_main_even_when_callable_raises(self) -> None:
+        """LightGBM may have already entered the parallel region by the
+        time the exception unwinds — defensively mark "main" so the
+        next worker-thread Tune/Fit re-routes regardless."""
+        ex, svc = _make_executor()
+
+        def boom() -> None:
+            raise RuntimeError("op failed")
+
+        with pytest.raises(RuntimeError):
+            ex.run_ml(boom, ml_kind="predict")
+
+        svc.mark_libgomp_owner.assert_called_once_with("main")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — multiple threads each get their own state transition.
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlThreadSafety:
+    def test_concurrent_run_ml_calls_all_record_main(self) -> None:
+        ex, svc = _make_executor()
+
+        def work() -> int:
+            ex.run_ml(lambda: 1, ml_kind="predict")
+            return 1
+
+        threads = [threading.Thread(target=work) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Every thread should have hit mark_libgomp_owner("main").
+        assert svc.mark_libgomp_owner.call_count == 20
+        for call in svc.mark_libgomp_owner.call_args_list:
+            assert call.args == ("main",)


### PR DESCRIPTION
## Summary

P-039 Phase 3 of the systemic prevention plan (#160). Introduces ``BackendExecutor`` — a single caller-thread chokepoint for all ML library calls (predict / SHAP / plot computations). Phase 2 added INV-G state tracking; Phase 3 centralises the marking so the libgomp owner state is updated in exactly one module, and Phase 4 (lint rule) gets a clean target.

- **New module** `src/lizyml_widget/backend_executor.py` exposes `BackendExecutor.run_ml(op, *, ml_kind)`. ``ml_kind`` ∈ ``predict | explain | plot_shap | plot_other``. The executor invokes ``op()``, returns the result (or re-raises), and marks ``service._libgomp_pool_owner = \"main\"`` in ``finally`` for kinds that bind libgomp.
- ``WidgetService`` constructs ``self._executor = BackendExecutor(self)`` once. ``predict`` / ``get_plot`` / ``get_inference_plot`` route through ``self._executor.run_ml(...)`` with the appropriate ``ml_kind``. Direct ``mark_libgomp_owner(\"main\")`` calls in those methods are removed.
- Runner-side path (``ThreadJobRunner`` / ``SubprocessJobRunner``) is **NOT** funnelled through the executor — runners are the equivalent chokepoint for worker / subprocess execution.

## Why

Phase 2 fixed the *runtime symptom* (auto-route to subprocess when state is ``\"main\"``). But the marking logic was scattered across 3 service methods. A future contributor adding a new caller-thread ML call (e.g. a new SHAP variant) could easily forget to mark — silently re-introducing the catastrophe class.

Phase 3 makes it **structurally impossible to bypass marking**: every ML library call goes through ``run_ml(..., ml_kind=...)``, and Phase 4 will lint-fail any ``import lightgbm`` / ``adapter.predict`` outside the executor module.

## Invariants

- INV-G (Phase 2): unchanged. State transitions are now performed inside the executor instead of the service methods, but the externally-observable transitions are identical.
- **Funnel contract** (Phase 3): ``service.predict`` / ``service.get_plot`` / ``service.get_inference_plot`` MUST route through ``service._executor.run_ml`` with the correct ``ml_kind``. Pinned by the new ``test_reg_160_backend_executor_funnel.py`` regression suite.

## Failure Paths Covered

- [x] Normal completion — funnel returns the underlying result transparently.
- [x] Exception in adapter call — re-raised; ``\"main\"`` still marked because libgomp may have already bound.
- [x] AttributeError → TypeError translation in ``get_inference_plot`` survives the refactor.
- [x] Concurrent ``run_ml`` calls — 20 threads each mark ``\"main\"`` independently (thread-safety pinned).
- [x] All existing INV-G state-transition tests (21) pass without modification.
- [x] Slow libgomp-perf grid (6 cells) passes — Phase 1 not regressed.

## Test plan

- [x] 19 new fast tests (10 executor unit + 9 funnel-contract regression)
- [x] 1018 fast tests pass (999 prior + 19 new), 96.26% coverage
- [x] 6/6 slow libgomp-perf grid cells pass
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy --strict`` clean
- [x] ``pnpm lint`` / ``pnpm test:coverage`` clean (331/331)
- [ ] CI green on all jobs after push

## Phase tracker

- ✅ Phase 0: P-039 Proposal — landed in PR #162
- ✅ Phase 1: parameterised perf grid + libgomp-perf CI job — landed in PR #162
- ✅ Phase 2: INV-G runtime guard — landed in PR #163
- 🚧 **Phase 3: BackendExecutor funnel — this PR**
- ⏳ Phase 4: change-gate codification + lint rule — final PR

Issue #160 stays open until Phase 4 lands.