### PR TITLE
feat(ci,test): P-039 Phase 4 — ML-call import lint gate (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src/lizyml_widget/
 
+      - name: ML-call lint (P-039 Phase 4)
+        # Block direct ML library imports outside the BackendExecutor /
+        # adapter / subprocess-entry / openmp-detect allowlist. Enforces
+        # INV-H structurally so a future contributor cannot silently
+        # re-introduce parent-main-thread ML calls outside the funnel.
+        # See HISTORY.md P-039 Phase 4.
+        run: uv run python scripts/lint_ml_imports.py
+
       - name: Test (pytest)
         run: uv run pytest --cov=lizyml_widget --cov-report=term-missing --cov-fail-under=80 -q
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1412,7 +1412,7 @@ UI は Search Space の `mode=Fixed/Range/Choice` のような表示用 state �
 
 ---
 
-### 6.4 状態機械不変条件 (INV-A..G)
+### 6.4 状態機械不変条件 (INV-A..H)
 
 並行性 / 状態機械 / リソース所有権を扱うコードに対して、`~/.claude/rules/common/invariants-first.md`
 に従い不変条件を宣言する。各 INV は `tests/test_invariants.py` に対応する RED-then-GREEN テストを持ち、
@@ -1427,6 +1427,7 @@ runtime assert / breadcrumb log として `_supervise` / `_run_job` に encode �
 | **INV-E** | `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。 | round が降順になる、または同一ラウンドで `round` 値が +1 ずれる（P-029 オフバイワンの再発）。 |
 | **INV-F** | `tune_summary.boundary_report.dims` は各 search space 次元を過不足なく一度ずつ列挙する。ラウンド差分ではなく累積スナップショット。 | dims が重複する、または search space に存在する次元が dims に欠ける。 |
 | **INV-G** | `WidgetService._libgomp_pool_owner` が `"main"` のとき `ThreadJobRunner` で Tune/Fit/Retune を起動しない（自動的に `SubprocessJobRunner` へ re-route するか、`LZW_FORCE_THREAD=1` のとき WARN を出して thread 続行）。`predict` / SHAP plot 等が parent main thread で libgomp parallel region に入った後の thread runner 起動は GCC #108494 で 10-50x 劣化するため。 | `w.tune() → w.predict(df) → w.fit()` のシーケンスで thread runner が選ばれ、catastrophe path（10-50x 劣化）が発火する。 |
+| **INV-H** | ML library（`lightgbm` / `shap` / `xgboost` / `lizyml`）への直接 import / 呼出は、Adapter 系（`adapter.py` / `adapter_*.py`）/ `BackendExecutor` / `_subprocess_entry.py` / `openmp_detect.py` のいずれかの内部からのみ発生する。caller-thread の ML 呼出は必ず `WidgetService._executor.run_ml(op, ml_kind=...)` を経由する。例外承認は対象行に `# noqa: ML-CALL` コメント + 理由を残し、PR body に動機を記載する。`scripts/lint_ml_imports.py` が CI gate を強制する（P-039 Phase 4）。 | `widget.py` / `service.py` / `widget_actions.py` 等が `import lightgbm` / `import shap` を直接行い、libgomp pool affinity を主スレッドで bind する catastrophe を再導入する。 |
 
 `_libgomp_pool_owner` の状態遷移（P-039 Phase 2）:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CI gate: ML library imports outside the BackendExecutor / Adapter
+  layer fail CI** (P-039 Phase 4 / INV-H,
+  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
+  New ``scripts/lint_ml_imports.py`` walks every ``.py`` file under
+  ``src/lizyml_widget/`` and fails (exit 1) on any import of
+  ``lightgbm`` / ``shap`` / ``xgboost`` / ``lizyml`` that is not in
+  the allowlist (``adapter.py`` / ``adapter_*.py`` / ``backend_executor.py``
+  / ``_subprocess_entry.py`` / ``openmp_detect.py``). The CI quality
+  job runs the lint between mypy and pytest. ``# noqa: ML-CALL``
+  on the offending line is the documented escape hatch — the
+  surrounding docstring / PR body must explain the exception.
+  CLAUDE.md §8 codifies the rule and explicitly tags new caller-
+  thread ML call sites as a change-gate-required category. With
+  Phase 4, P-039 is fully landed: catastrophe class is now blocked
+  by (a) Phase 1 perf-grid catching it on a PR, (b) Phase 2 runtime
+  guard auto-routing it on production, (c) Phase 3 funnel
+  centralising the marking, and (d) Phase 4 lint blocking new call
+  sites at PR review. Issue #160 closes when this PR merges.
 - **BackendExecutor caller-thread ML library funnel** (P-039 Phase 3,
   [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
   New module ``src/lizyml_widget/backend_executor.py`` exposes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案・Phase 1-2 完了 / Phase 3 着手中）
-- **ステータス**: 採択（Phase 1-2: develop マージ済 / Phase 3: 着手中 / Phase 4: 着手前）
+- **日付**: 2026-05-10（提案・Phase 1-3 完了 / Phase 4 着手中）
+- **ステータス**: 採択（Phase 1-3: develop マージ済 / Phase 4: 着手中）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/scripts/lint_ml_imports.py
+++ b/scripts/lint_ml_imports.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""ML library import lint (P-039 Phase 4 / change-gate enforcement).
+
+Fails CI if any production source file in ``src/lizyml_widget/`` imports
+an ML library outside the allowlisted modules. The allowlisted modules
+are the legitimate boundary owners of ML library calls:
+
+- ``adapter.py`` and any ``adapter_*.py`` helper — the canonical
+  Adapter layer that translates LizyML / LightGBM / etc. into the
+  widget's common types.
+- ``backend_executor.py`` — the single caller-thread chokepoint
+  introduced by P-039 Phase 3.
+- ``_subprocess_entry.py`` — the subprocess body, which runs in a
+  different process and therefore cannot bind libgomp on the parent
+  thread.
+- ``openmp_detect.py`` — imports ``lightgbm`` only to populate
+  ``/proc/self/maps`` for the libgomp detection routine; never
+  enters a parallel region itself.
+
+Any other module that needs to import ``lightgbm`` / ``shap`` /
+``xgboost`` / ``lizyml`` must add a ``# noqa: ML-CALL`` comment on
+the offending line and document the reason in the surrounding
+docstring or PR body. This is the structural enforcement for INV-H
+declared in P-039: "lightgbm / shap / xgboost / sklearn API への
+直接呼出は BackendExecutor モジュール外部から発生しない".
+
+Detection patterns:
+
+- ``import lightgbm`` / ``import lightgbm as ...``
+- ``from lightgbm ...``
+- ``import shap`` / ``from shap ...``
+- ``import xgboost`` / ``from xgboost ...``
+- ``import lizyml`` / ``from lizyml ...``
+
+Direct method patterns (``model.predict``, etc.) are intentionally NOT
+matched — they produce too many false positives on attribute access.
+The import gate alone is sufficient: a file cannot use these libraries
+without importing them.
+
+Exit codes:
+- 0 — clean
+- 1 — violations found (printed to stderr)
+
+Run locally:
+    uv run python scripts/lint_ml_imports.py
+
+Run as part of CI:
+    .github/workflows/ci.yml -> ml-call lint job
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Files allowed to import ML libraries directly. All other source
+# files in ``src/lizyml_widget/`` must funnel through one of these.
+ALLOWLISTED_FILES: frozenset[str] = frozenset(
+    {
+        "adapter.py",
+        "adapter_internals.py",
+        "adapter_params.py",
+        "adapter_results.py",
+        "adapter_schema.py",
+        "adapter_views.py",
+        "backend_executor.py",
+        "_subprocess_entry.py",
+        "openmp_detect.py",
+    }
+)
+
+# ML library names whose direct import is gate-required outside the
+# allowlist. Add new ML libraries here as they enter the project.
+ML_LIBRARIES: frozenset[str] = frozenset(
+    {
+        "lightgbm",
+        "shap",
+        "xgboost",
+        "lizyml",
+    }
+)
+
+# Per-line escape hatch comment. A line ending with ``# noqa: ML-CALL``
+# is exempt from the gate (the surrounding docstring / PR body must
+# explain why).
+NOQA_TAG = "# noqa: ML-CALL"
+
+# Build a regex that matches:
+#   import <lib>
+#   import <lib> as ...
+#   from <lib> ...
+#   from <lib>.something ...
+_LIB_ALTERNATION = "|".join(re.escape(name) for name in sorted(ML_LIBRARIES))
+_IMPORT_PATTERN = re.compile(
+    rf"^\s*(?:import\s+(?:{_LIB_ALTERNATION})(?:\s|$|\.|,)"
+    rf"|from\s+(?:{_LIB_ALTERNATION})(?:\s|\.|$))"
+)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (line_number, line_text) for offending imports."""
+    violations: list[tuple[int, str]] = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"WARN: cannot read {path}: {exc}", file=sys.stderr)
+        return violations
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        if NOQA_TAG in line:
+            continue
+        if _IMPORT_PATTERN.match(line):
+            violations.append((line_no, line.rstrip()))
+    return violations
+
+
+def _iter_source_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.name not in ALLOWLISTED_FILES)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    src_root = repo_root / "src" / "lizyml_widget"
+    if not src_root.is_dir():
+        print(f"ERROR: source directory not found: {src_root}", file=sys.stderr)
+        return 1
+
+    total_violations = 0
+    for path in _iter_source_files(src_root):
+        violations = _scan_file(path)
+        if not violations:
+            continue
+        rel = path.relative_to(repo_root)
+        for line_no, line in violations:
+            print(
+                f"{rel}:{line_no}: ML-CALL violation — {line.strip()}",
+                file=sys.stderr,
+            )
+        total_violations += len(violations)
+
+    if total_violations:
+        print(
+            f"\n{total_violations} ML-CALL violation(s) found. "
+            f"Direct ML library imports are only allowed in: "
+            f"{', '.join(sorted(ALLOWLISTED_FILES))}. "
+            f"Add a ``{NOQA_TAG}`` comment with a documented reason if "
+            f"you need an exception, or route the call through "
+            f"``BackendExecutor`` / the Adapter layer. See HISTORY.md "
+            f"P-039 Phase 4 and BLUEPRINT.md §3.2.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ml_call_lint.py
+++ b/tests/test_ml_call_lint.py
@@ -1,0 +1,154 @@
+"""Self-tests for ``scripts/lint_ml_imports.py`` (P-039 Phase 4).
+
+The lint script is the structural enforcement of INV-H: ML library
+imports outside the allowlist must fail CI. These tests pin the
+script's positive and negative paths so a future refactor cannot
+silently break the gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lint_ml_imports.py"
+
+
+@pytest.fixture(scope="module")
+def lint_module() -> object:
+    """Load the lint script as a module so we can call ``main`` and
+    helpers directly without spawning a subprocess."""
+    spec = importlib.util.spec_from_file_location("lint_ml_imports", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["lint_ml_imports"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Detection regex — verifies the patterns the spec calls out.
+# ---------------------------------------------------------------------------
+
+
+class TestImportPattern:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "import lightgbm",
+            "import lightgbm as lgb",
+            "from lightgbm import Booster",
+            "from lightgbm.sklearn import LGBMClassifier",
+            "import shap",
+            "from shap import TreeExplainer",
+            "import xgboost",
+            "from xgboost import Booster",
+            "import lizyml",
+            "from lizyml import Model",
+            "from lizyml.core import something",
+            "    import lightgbm  # nested under indent",
+        ],
+    )
+    def test_matches_disallowed_imports(self, lint_module: object, line: str) -> None:
+        assert lint_module._IMPORT_PATTERN.match(line), (  # type: ignore[attr-defined]
+            f"Pattern should match: {line!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "import os",
+            "from typing import Any",
+            "import lightgbm_helper",  # similar prefix, NOT lightgbm itself
+            "from lightgbmlike import x",  # similar prefix, NOT lightgbm itself
+            "x = 'import lightgbm'",  # string content, not actual import
+            "# import lightgbm  # comment-only is fine via NOQA path",
+        ],
+    )
+    def test_does_not_match_unrelated_lines(self, lint_module: object, line: str) -> None:
+        # NOTE: a leading ``#`` comment line is technically not an import,
+        # so the regex does not match it; the NOQA tag is for actual
+        # imports that need the escape hatch.
+        if line.lstrip().startswith("#"):
+            assert not lint_module._IMPORT_PATTERN.match(line)  # type: ignore[attr-defined]
+            return
+        assert not lint_module._IMPORT_PATTERN.match(line), (  # type: ignore[attr-defined]
+            f"Pattern should NOT match: {line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _scan_file — the per-file driver
+# ---------------------------------------------------------------------------
+
+
+class TestScanFile:
+    def test_clean_file_yields_no_violations(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("import os\nfrom typing import Any\n")
+        assert lint_module._scan_file(f) == []  # type: ignore[attr-defined]
+
+    def test_dirty_file_yields_violations(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "dirty.py"
+        f.write_text("import os\nimport lightgbm\nfrom shap import TreeExplainer\n")
+        violations = lint_module._scan_file(f)  # type: ignore[attr-defined]
+        assert len(violations) == 2
+        assert violations[0][0] == 2
+        assert "lightgbm" in violations[0][1]
+        assert violations[1][0] == 3
+        assert "shap" in violations[1][1]
+
+    def test_noqa_tag_skips_violation(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "noqa.py"
+        f.write_text("import os\nimport lightgbm  # noqa: ML-CALL — needed for env detection\n")
+        assert lint_module._scan_file(f) == []  # type: ignore[attr-defined]
+
+    def test_noqa_only_applies_to_tagged_line(self, tmp_path: Path, lint_module: object) -> None:
+        """A ``# noqa: ML-CALL`` on one line must NOT cover an
+        un-tagged import on a different line."""
+        f = tmp_path / "mixed.py"
+        f.write_text("import lightgbm  # noqa: ML-CALL — env detection only\nimport shap\n")
+        violations = lint_module._scan_file(f)  # type: ignore[attr-defined]
+        assert len(violations) == 1
+        assert "shap" in violations[0][1]
+
+
+# ---------------------------------------------------------------------------
+# main — repo-level integration
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_repo_passes_lint_today(self, lint_module: object) -> None:
+        """The repo at HEAD must be clean — every legitimate ML-using
+        module is in the allowlist."""
+        rc = lint_module.main()  # type: ignore[attr-defined]
+        assert rc == 0, "P-039 Phase 4 lint must pass on a clean develop"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist sanity — every allowlisted file actually exists.
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistSanity:
+    def test_every_allowlisted_file_exists(self, lint_module: object) -> None:
+        src = REPO_ROOT / "src" / "lizyml_widget"
+        for fname in lint_module.ALLOWLISTED_FILES:  # type: ignore[attr-defined]
+            assert (src / fname).is_file(), (
+                f"Allowlisted file {fname!r} does not exist in {src}; "
+                f"a refactor renamed/removed it. Update the lint allowlist."
+            )
+
+    def test_allowlist_does_not_include_widget_or_service(self, lint_module: object) -> None:
+        """Defensive assertion: a future refactor must not allow
+        ``widget.py`` / ``service.py`` to import ML libraries — that
+        would defeat the executor funnel."""
+        assert "widget.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "service.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "widget_actions.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "job_runner.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

P-039 Phase 4 (final phase) of the systemic prevention plan (#160). Adds a CI gate that **fails any merge introducing a direct ML library import outside the canonical owners**, locking in INV-H structurally.

- **`scripts/lint_ml_imports.py`**: greps every ``.py`` under ``src/lizyml_widget/`` for ``import lightgbm`` / ``from lightgbm`` / ``import shap`` / ``import xgboost`` / ``import lizyml`` (and the ``from`` variants). Allowlisted files are the legitimate ML boundary owners: ``adapter.py`` / ``adapter_*.py`` / ``backend_executor.py`` / ``_subprocess_entry.py`` / ``openmp_detect.py``. Per-line escape hatch: ``# noqa: ML-CALL``. Exits 1 with ``file:line`` on violation.
- **CI**: new ``ML-call lint (P-039 Phase 4)`` step in the Quality job runs the script between mypy and pytest. Gates every PR + push to develop / main on the 3.10 / 3.11 / 3.12 matrix.
- **BLUEPRINT.md §6.4**: declares **INV-H** in the invariant table — direct ML library imports are confined to the allowlisted modules, ``# noqa: ML-CALL`` documents exceptions.
- **HISTORY.md P-039**: status → ``accepted (Phase 1-3 merged / Phase 4 in progress)``.

## Why

Phase 3 (PR #164) introduced ``BackendExecutor`` so all caller-thread ML calls funnel through one chokepoint. But that funnel relies on convention — a future contributor adding a new SHAP variant could simply ``import shap`` in ``service.py`` and bypass the funnel without anyone noticing. Phase 4 makes that scenario lint-fail on PR.

With Phase 4 the prevention layers stack as:

1. Phase 1 perf-grid — catches catastrophe on PR (cross-product of historical regressions).
2. Phase 2 runtime guard — auto-routes thread → subprocess in production when state is ``\"main\"``.
3. Phase 3 funnel — centralises marking, eliminates bypass-by-forgetting.
4. **Phase 4 lint — eliminates bypass-by-design (this PR).**

## Invariants

- **INV-H** (new, this PR): ML library imports outside the allowlist fail CI. Pinned by ``test_repo_passes_lint_today`` regression test.
- INV-G (Phase 2): unchanged.

## Failure Paths Covered

- [x] Lint regex matches all listed ML libraries with ``import`` / ``from`` / ``import ... as`` / indented variants
- [x] Lint regex does NOT match similar prefixes (``lightgbm_helper``, ``lightgbmlike``), comments, or string literals
- [x] ``# noqa: ML-CALL`` only exempts the tagged line (not subsequent lines)
- [x] Allowlist sanity: every allowlisted file exists; widget.py / service.py / widget_actions.py / job_runner.py are NOT in the allowlist (defensive)
- [x] Repo HEAD passes lint (so Phase 4 lands clean)

## Test plan

- [x] 25 new fast tests in ``tests/test_ml_call_lint.py``
- [x] 1043 fast tests pass (1018 prior + 25 new), 96.26% coverage
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy --strict`` / ``ml-lint`` clean
- [x] ``pnpm lint`` / ``pnpm test:coverage`` clean
- [x] Lint exits 0 on develop HEAD; exits 1 with file:line on a synthetic violation
- [ ] CI green on all jobs after push

## Phase tracker — final state after merge

- ✅ Phase 0: P-039 Proposal — landed in PR #162
- ✅ Phase 1: parameterised perf grid + libgomp-perf CI job — landed in PR #162
- ✅ Phase 2: INV-G runtime guard — landed in PR #163
- ✅ Phase 3: BackendExecutor funnel — landed in PR #164
- 🚧 **Phase 4: ML-call lint gate — this PR (final)**

## Closes

Closes #160 (full P-039 implementation lands).