### PR TITLE
[docs-only] docs(changelog): cut v0.10.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-10
+
 ### Added
 - **CI gate: ML library imports outside the BackendExecutor / Adapter
   layer fail CI** (P-039 Phase 4 / INV-H,


### PR DESCRIPTION
## Summary

Pre-release CHANGELOG cut: rename ``[Unreleased]`` → ``[0.10.0] - 2026-05-10`` and add an empty ``[Unreleased]`` header for future work.

The renamed section contains the P-039 Phase 1-4 entries that landed since v0.9.0:

- Phase 1: parameterised libgomp perf grid + libgomp-perf CI job (#162)
- Phase 2: INV-G runtime guard for libgomp owner (#163)
- Phase 3: BackendExecutor caller-thread funnel (#164)
- Phase 4: ML-call import lint gate (#165)

## Why

``scripts/release.py`` extracts release notes from the ``[X.Y.Z]`` section. Without this rename it cannot find ``[0.10.0]`` and aborts.

## Test plan

- [x] CHANGELOG.md still parses (ordering: Unreleased → 0.10.0 → 0.9.0 → ...)
- [ ] Trivial 2-line change; CI auto-passes