### PR TITLE
release: v0.10.0 — LizyML-Widget 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,45 @@ jobs:
       - name: Test (pytest)
         run: uv run pytest --cov=lizyml_widget --cov-report=term-missing --cov-fail-under=80 -q
 
+  libgomp-perf:
+    # P-039 Phase 1 / Layer 4. Runs the parameterised libgomp perf grid
+    # (test_reg_160_libgomp_perf_grid.py) on ubuntu-latest, which ships
+    # with libgomp by default. The grid asserts INV-#160-A: per-unit
+    # wall-clock of every {intermediate × next_op} cell stays within
+    # 1.5x of an op-matched clean baseline. This blocks merges that
+    # silently re-introduce the 10-50x libgomp pool-affinity slowdown
+    # family (#147 / #154 / #156). See HISTORY.md P-039.
+    name: libgomp perf (slow regression grid)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Confirm libgomp is loaded on the runner
+        # Sanity check — if this prints nothing, the grid would skip
+        # silently and the gate would be a no-op. The grid imports
+        # lightgbm so libgomp shows up in /proc/self/maps post-import.
+        run: |
+          uv run python -c "
+          import lightgbm  # noqa: F401
+          with open('/proc/self/maps') as f:
+              hits = [l for l in f if 'libgomp' in l]
+          assert hits, 'libgomp not loaded — perf grid would skip; CI gate would be ineffective'
+          print('libgomp loaded:', hits[0].strip())
+          "
+
+      - name: Run libgomp perf grid (slow tier)
+        run: uv run pytest -m slow tests/regression/test_reg_160_libgomp_perf_grid.py -v
+
   distribution:
     name: Distribution check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src/lizyml_widget/
 
+      - name: ML-call lint (P-039 Phase 4)
+        # Block direct ML library imports outside the BackendExecutor /
+        # adapter / subprocess-entry / openmp-detect allowlist. Enforces
+        # INV-H structurally so a future contributor cannot silently
+        # re-introduce parent-main-thread ML calls outside the funnel.
+        # See HISTORY.md P-039 Phase 4.
+        run: uv run python scripts/lint_ml_imports.py
+
       - name: Test (pytest)
         run: uv run pytest --cov=lizyml_widget --cov-report=term-missing --cov-fail-under=80 -q
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1412,7 +1412,7 @@ UI は Search Space の `mode=Fixed/Range/Choice` のような表示用 state �
 
 ---
 
-### 6.4 状態機械不変条件 (INV-A..G)
+### 6.4 状態機械不変条件 (INV-A..H)
 
 並行性 / 状態機械 / リソース所有権を扱うコードに対して、`~/.claude/rules/common/invariants-first.md`
 に従い不変条件を宣言する。各 INV は `tests/test_invariants.py` に対応する RED-then-GREEN テストを持ち、
@@ -1427,6 +1427,7 @@ runtime assert / breadcrumb log として `_supervise` / `_run_job` に encode �
 | **INV-E** | `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。 | round が降順になる、または同一ラウンドで `round` 値が +1 ずれる（P-029 オフバイワンの再発）。 |
 | **INV-F** | `tune_summary.boundary_report.dims` は各 search space 次元を過不足なく一度ずつ列挙する。ラウンド差分ではなく累積スナップショット。 | dims が重複する、または search space に存在する次元が dims に欠ける。 |
 | **INV-G** | `WidgetService._libgomp_pool_owner` が `"main"` のとき `ThreadJobRunner` で Tune/Fit/Retune を起動しない（自動的に `SubprocessJobRunner` へ re-route するか、`LZW_FORCE_THREAD=1` のとき WARN を出して thread 続行）。`predict` / SHAP plot 等が parent main thread で libgomp parallel region に入った後の thread runner 起動は GCC #108494 で 10-50x 劣化するため。 | `w.tune() → w.predict(df) → w.fit()` のシーケンスで thread runner が選ばれ、catastrophe path（10-50x 劣化）が発火する。 |
+| **INV-H** | ML library（`lightgbm` / `shap` / `xgboost` / `lizyml`）への直接 import / 呼出は、Adapter 系（`adapter.py` / `adapter_*.py`）/ `BackendExecutor` / `_subprocess_entry.py` / `openmp_detect.py` のいずれかの内部からのみ発生する。caller-thread の ML 呼出は必ず `WidgetService._executor.run_ml(op, ml_kind=...)` を経由する。例外承認は対象行に `# noqa: ML-CALL` コメント + 理由を残し、PR body に動機を記載する。`scripts/lint_ml_imports.py` が CI gate を強制する（P-039 Phase 4）。 | `widget.py` / `service.py` / `widget_actions.py` 等が `import lightgbm` / `import shap` を直接行い、libgomp pool affinity を主スレッドで bind する catastrophe を再導入する。 |
 
 `_libgomp_pool_owner` の状態遷移（P-039 Phase 2）:
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -97,6 +97,7 @@ Widget は LizyML の型・契約（`BackendAdapter` Protocol, `TuningResult`, `
 | **UI** | `js/src/` | `backend_contract` / `config` / `df_info` を描画し、ユーザー操作を `action` に変換する。ローカル状態は表示都合（例: Search Space の Mode）に限定する | ML ロジック・Python 直接呼び出し・backend 固有 option set / parameter catalog / step 値のハードコード・full config dict の合成 |
 | **Widget** | `src/lizyml_widget/widget.py` | traitlets 定義・Action 処理・スレッド管理・`msg:custom` 中継 | ML ロジック直接記述、Service の private 状態参照、backend 固有 config 意味論の保持、ジョブ実行時の時系列スナップショット保持（P-035 で `_tune_*_snapshot` を Service の `_last_tune_summary` へ移管済み）|
 | **Service** | `src/lizyml_widget/service.py` | Data タブ由来 state（target / task / columns / CV）の管理、実行前提判定、Adapter 呼び出し調整、canonical config と Data 系 state の結合 | バックエンド固有の default / option set / search space catalog / step 定数の保持 |
+| **BackendExecutor** | `src/lizyml_widget/backend_executor.py` | caller-thread の ML library 呼出（predict / SHAP plot / 推論プロット）の単一 chokepoint。`run_ml(op, ml_kind=...)` で全呼出を funnel し、libgomp owner state（INV-G）の遷移を一元化する。Phase 4 の lint rule で「executor 外部の ML library 直接呼出」を禁止する基盤 | ML 結果の加工・キャッシュ・runner 配下（worker thread / subprocess）のジョブ実行 |
 | **Adapter** | `src/lizyml_widget/adapter.py` | Backend Contract 提供、backend 固有 config default / patch 適用 / 実行前準備、バックエンドライブラリ呼び出し、共通型への変換 | Widget / traitlets の知識 |
 
 `LizyWidget` は backend 差し替え・テスト容易性のため `adapter` をコンストラクタ引数で受け取れる。未指定時のみ既定の `LizyMLAdapter` を使用する。

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1411,7 +1411,7 @@ UI は Search Space の `mode=Fixed/Range/Choice` のような表示用 state �
 
 ---
 
-### 6.4 状態機械不変条件 (INV-A..F)
+### 6.4 状態機械不変条件 (INV-A..G)
 
 並行性 / 状態機械 / リソース所有権を扱うコードに対して、`~/.claude/rules/common/invariants-first.md`
 に従い不変条件を宣言する。各 INV は `tests/test_invariants.py` に対応する RED-then-GREEN テストを持ち、
@@ -1425,9 +1425,20 @@ runtime assert / breadcrumb log として `_supervise` / `_run_job` に encode �
 | **INV-D** | `_cancel_flag` は各ジョブ開始時に `clear()` され、ジョブ終了まで Widget 側からは書き込まれない。Cancel は `failed` (`error.code == "CANCELLED"`) へ遷移する。 | 前回ジョブの cancel フラグが残ったまま新規ジョブが起動して、即座に `CANCELLED` で落ちる。 |
 | **INV-E** | `progress.round` は単一の tune 呼び出し（resume 含む）内で単調非減少。 | round が降順になる、または同一ラウンドで `round` 値が +1 ずれる（P-029 オフバイワンの再発）。 |
 | **INV-F** | `tune_summary.boundary_report.dims` は各 search space 次元を過不足なく一度ずつ列挙する。ラウンド差分ではなく累積スナップショット。 | dims が重複する、または search space に存在する次元が dims に欠ける。 |
+| **INV-G** | `WidgetService._libgomp_pool_owner` が `"main"` のとき `ThreadJobRunner` で Tune/Fit/Retune を起動しない（自動的に `SubprocessJobRunner` へ re-route するか、`LZW_FORCE_THREAD=1` のとき WARN を出して thread 続行）。`predict` / SHAP plot 等が parent main thread で libgomp parallel region に入った後の thread runner 起動は GCC #108494 で 10-50x 劣化するため。 | `w.tune() → w.predict(df) → w.fit()` のシーケンスで thread runner が選ばれ、catastrophe path（10-50x 劣化）が発火する。 |
+
+`_libgomp_pool_owner` の状態遷移（P-039 Phase 2）:
+
+- 初期値 `"unknown"`
+- `SubprocessJobRunner.run` 完了後 → `"subprocess"`（subprocess が parallel region を所有、parent main thread は untouched）
+- `ThreadJobRunner.run` 完了後 → `"worker"`（worker thread が pool を所有、parent main thread は untouched）
+- `WidgetService.predict` / `WidgetService.get_plot("feature-importance-shap")` / `WidgetService.get_inference_plot(... "shap-summary")` の呼出後 → `"main"`（caller thread = parent main thread に bind）
+- `WidgetService.load_data(...)` 呼出後はリセットしない（プロセス内の libgomp pool 親和性は data reload で消えないため）
+
+`"main"` への遷移は本プロセス内で単方向（同一 Python プロセスでは libgomp の bind は data reload で消えない）。後続 thread runner job は INV-G ガードで subprocess に re-route される。`LZW_FORCE_THREAD=1` が明示的に設定されている場合は user opt-out を尊重し WARN のみ。
 
 **運用ルール**: `_supervise` / `_run_job` / `_tune_model` / `_cancel_flag` / `status` / `progress` /
-`boundary_report` を変更する PR は body に以下を含める。
+`boundary_report` / `_libgomp_pool_owner` を変更する PR は body に以下を含める。
 
 ```markdown
 ## Invariants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-10
+
 ### Added
 - **CI gate: ML library imports outside the BackendExecutor / Adapter
   layer fail CI** (P-039 Phase 4 / INV-H,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Runtime guard: parent-main-thread libgomp binding auto-routes
+  Tune/Fit/Retune to subprocess** (P-039 Phase 2 / INV-G,
+  [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
+  ``WidgetService`` now tracks ``_libgomp_pool_owner`` (one of
+  ``"unknown" / "subprocess" / "worker" / "main"``). Calls that run an
+  OpenMP parallel region on the caller thread —
+  ``WidgetService.predict``, ``WidgetService.get_plot("feature-importance-shap")``,
+  ``WidgetService.get_inference_plot(..., "shap-summary")`` — mark the
+  state ``"main"``. ``ThreadJobRunner`` / ``SubprocessJobRunner`` mark
+  ``"worker"`` / ``"subprocess"`` on successful completion.
+  ``LizyWidget._run_job`` reads the state and re-routes a thread-strategy
+  job to subprocess when the state is ``"main"`` (with a structured WARN
+  log), since GCC libgomp's pool affinity (#108494) would otherwise
+  deliver a 10-50x slowdown for the next worker-thread call.
+  ``LZW_FORCE_THREAD=1`` is honored as an explicit user opt-out — only
+  WARN, no auto-reroute. The state is process-sticky: ``load_data``
+  does NOT reset it because the libgomp bind in this process does not
+  unbind on data reload. BLUEPRINT.md §6.4 declares INV-G with the
+  state-transition table.
 - **CI: `libgomp-perf` job runs a parameterised libgomp perf regression
   grid on every PR** (P-039 Phase 1, [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
   The libgomp pool-affinity / "CPU core usage decreases" regression has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CI gate: ML library imports outside the BackendExecutor / Adapter
+  layer fail CI** (P-039 Phase 4 / INV-H,
+  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
+  New ``scripts/lint_ml_imports.py`` walks every ``.py`` file under
+  ``src/lizyml_widget/`` and fails (exit 1) on any import of
+  ``lightgbm`` / ``shap`` / ``xgboost`` / ``lizyml`` that is not in
+  the allowlist (``adapter.py`` / ``adapter_*.py`` / ``backend_executor.py``
+  / ``_subprocess_entry.py`` / ``openmp_detect.py``). The CI quality
+  job runs the lint between mypy and pytest. ``# noqa: ML-CALL``
+  on the offending line is the documented escape hatch — the
+  surrounding docstring / PR body must explain the exception.
+  CLAUDE.md §8 codifies the rule and explicitly tags new caller-
+  thread ML call sites as a change-gate-required category. With
+  Phase 4, P-039 is fully landed: catastrophe class is now blocked
+  by (a) Phase 1 perf-grid catching it on a PR, (b) Phase 2 runtime
+  guard auto-routing it on production, (c) Phase 3 funnel
+  centralising the marking, and (d) Phase 4 lint blocking new call
+  sites at PR review. Issue #160 closes when this PR merges.
 - **BackendExecutor caller-thread ML library funnel** (P-039 Phase 3,
   [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
   New module ``src/lizyml_widget/backend_executor.py`` exposes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CI: `libgomp-perf` job runs a parameterised libgomp perf regression
+  grid on every PR** (P-039 Phase 1, [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
+  The libgomp pool-affinity / "CPU core usage decreases" regression has
+  reoccurred four times in this codebase
+  ([#147](https://github.com/nbx-liz/LizyML-Widget/issues/147) /
+  [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154) /
+  [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156) /
+  [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)). Each
+  prior fix only pinned the *specific* path observed — a future code
+  change could silently re-introduce the same class of 10-50x slowdown
+  via a new ML call site. P-039 Phase 1 closes that gap by adding a
+  dedicated CI job that runs ``tests/regression/test_reg_160_libgomp_perf_grid.py``
+  on ``ubuntu-latest`` (libgomp by default). The grid covers the
+  cross-product ``{intermediate parent-thread op ∈ noop /
+  main_thread_predict / main_thread_fit_predict}`` × ``{next ML op ∈
+  retune / fit}`` and asserts INV-#160-A: per-unit wall-clock of every
+  cell stays within 1.5x of an op-matched clean baseline. The grid uses
+  small datasets (5k × 20, 2 trials) so the job fits the CI budget;
+  catastrophe is not dataset-size dependent so the 1.5x bound retains
+  its expressiveness on small data. Phases 2-4 (runtime INV-G guard,
+  ``BackendExecutor`` funnel, change-gate codification) are tracked
+  under [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160) and
+  ship in follow-up PRs.
+
 ## [0.9.0] - 2026-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **BackendExecutor caller-thread ML library funnel** (P-039 Phase 3,
+  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
+  New module ``src/lizyml_widget/backend_executor.py`` exposes
+  ``BackendExecutor.run_ml(op, *, ml_kind)`` — a single chokepoint for
+  every caller-thread ML library call. ``WidgetService.predict``,
+  ``WidgetService.get_plot``, and ``WidgetService.get_inference_plot``
+  now route through ``self._executor.run_ml(...)`` instead of marking
+  ``_libgomp_pool_owner`` directly. ``ml_kind`` categorises the call
+  (``predict`` / ``explain`` / ``plot_shap`` / ``plot_other``) so the
+  executor knows which calls bind libgomp pool affinity and which do
+  not. This consolidates Phase 2's owner-state marking into one place
+  and sets up Phase 4 (lint rule) to enforce "no ML library call
+  outside the executor" as a structural invariant. No behavioural
+  change for end users — predict / plot semantics are unchanged.
 - **Runtime guard: parent-main-thread libgomp binding auto-routes
   Tune/Fit/Retune to subprocess** (P-039 Phase 2 / INV-G,
   [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案・Phase 1-2 完了 / Phase 3 着手中）
-- **ステータス**: 採択（Phase 1-2: develop マージ済 / Phase 3: 着手中 / Phase 4: 着手前）
+- **日付**: 2026-05-10（提案・Phase 1-3 完了 / Phase 4 着手中）
+- **ステータス**: 採択（Phase 1-3: develop マージ済 / Phase 4: 着手中）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,51 @@
 ## LizyML-Widget 仕様変更履歴
 
+### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
+
+- **日付**: 2026-05-10（提案）
+- **ステータス**: 提案（Phase 1 実装着手中）
+- **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
+- **背景**:
+  - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。
+  - 同一 root cause: GCC libgomp は OpenMP parallel region に最初に入った thread に thread pool を bind する。LightGBM / SHAP は OpenMP を多用する。Jupyter / anywidget 環境では `widget._run_job → ThreadJobRunner`, `widget.predict(df)`, `widget_actions.handle_run_inference → service.predict`, `adapter.plot(model, "feature-importance-shap")` のいずれかが parent main thread で OpenMP region に入った瞬間、後続の worker-thread 上の Tune / Fit / Retune が catastrophe path に入る。
+  - PR #155 thread fallback / P-038 subprocess retune resume / P-036 subprocess default は **既知の call site** を 1 つずつ塞いだが、**将来追加される 5 つ目の call site** を構造的に防ぐ仕組みは無い。
+- **提案内容**: 段階的な防御層（defense in depth）。各 Layer は独立に着手可能だが、Phase の順序で着手する。
+  - **Layer 1（Architectural — Phase 3）**: `BackendExecutor` 抽象を `WidgetService` 配下に新設し、すべての ML library 呼出（predict / SHAP / model 内部 plot 等）を必ず通す。executor は execution strategy を見て inline / subprocess / dedicated-OpenMP-owner-thread を選ぶ。`service.predict` / `service.get_inference_plot`（SHAP 含む経路）/ `adapter.plot(... feature-importance-shap)` を funnel する。
+  - **Layer 2（Runtime invariant guard — Phase 2）**: BLUEPRINT.md §6.4 に **INV-G** を追加 — "post-subprocess-tune において parent main thread の libgomp parallel region が次の worker-thread Tune/Fit/Retune より先に発生してはならない"。`service._libgomp_pool_owner_known: Literal["subprocess","main","worker","unknown"]` を追加し、`SubprocessJobRunner.run` 完了時に `"subprocess"` をセット、parent main thread の predict/SHAP 経路で `"main"` をセット、worker-thread Tune/Fit 起動前に検査して `"main"` の場合 subprocess に re-route または WARN log。
+  - **Layer 3（Test grid — Phase 1）**: `tests/regression/test_reg_160_libgomp_perf_grid.py` を新設。`{intermediate ∈ noop / main_thread_predict / main_thread_fit_predict}` × `{next_op ∈ retune / fit}` の cross-product で per-trial wall-clock を baseline subprocess tune の 1.5x 以内に pin。#154（clean → retune）と #156（predict → retune catastrophe）の両方を grid の異なる cell で再現可能にする。
+  - **Layer 4（CI — Phase 1）**: `.github/workflows/ci.yml` に `libgomp-perf` job を追加し `ubuntu-latest`（libgomp by default）で `pytest -m slow tests/regression/test_reg_160_libgomp_perf_grid.py` を毎 PR 実行。catastrophe を CI ブロッカーにする。既存 `test_reg_147_openmp_perf.py` / `test_reg_156_subprocess_retune.py` は dataset サイズが GitHub runner にとって過大なため別経路（developer / nightly）で動かす（本 Proposal では grid のみを CI gate に組み込む）。
+  - **Layer 5（Change-gate — Phase 4）**: `~/.claude/rules/project/change-gate.md`（global rule）と `CLAUDE.md` に "ML library への直接呼出（lightgbm / shap / xgboost / sklearn）を `BackendExecutor` 外部に追加する" を gate-required category として追記。pre-commit / ruff custom rule で `import lightgbm` / `import shap` / `model.predict` 等が executor module 外部に出現したら fail。`# noqa: ML-CALL` allowlist comment で例外承認。
+- **Phase 構成と本 Proposal のスコープ**:
+  - **Phase 0**: 本 Proposal の HISTORY.md 追加（**本コミットで完了**）
+  - **Phase 1**: Layer 3 + Layer 4（**本 PR で着手** — CI gate と parameterised grid）
+  - **Phase 2**: Layer 2（INV-G + 実行時ガード — 別 PR）
+  - **Phase 3**: Layer 1（`BackendExecutor` refactor — 別 PR、blast radius 最大）
+  - **Phase 4**: Layer 5（change-gate codification + lint rule — 別 PR）
+- **Invariants（本 Proposal が宣言する将来不変条件）**:
+  - INV-G（Phase 2 で encode）: post-subprocess-tune において、parent main thread の libgomp parallel region が次の worker-thread Tune/Fit/Retune より先に観測されない（観測された場合は subprocess に re-route または WARN）。
+  - INV-H（Phase 3 で encode）: lightgbm / shap / xgboost / sklearn API への直接呼出は `BackendExecutor` モジュール外部から発生しない（type system + lint で enforce）。
+  - INV-I（Phase 1 で encode、本 PR）: `tests/regression/test_reg_160_libgomp_perf_grid.py` の各 cell について per-trial wall-clock が baseline subprocess tune の 1.5x 以内（catastrophe 検出のみ。absolute perf budget は別 grid で扱う）。
+- **Phase 1 影響範囲（本 PR）**:
+  - `tests/regression/test_reg_160_libgomp_perf_grid.py` — 新規（parameterised grid + 1.5x bound）
+  - `.github/workflows/ci.yml` — 新規 job `libgomp-perf` を追加
+  - `HISTORY.md` — 本 Proposal
+  - `CHANGELOG.md` — `[Unreleased]` セクションに Phase 1 entry を追加
+- **互換性**:
+  - 公開 API・traitlets・JS UI の変更なし（Phase 1 は test + CI のみ）
+  - `pytest -m slow` は引き続き opt-in。新 grid は CI で自動実行されるが、ローカル開発では `-m slow` を明示しない限り skip
+- **代替案（却下）**:
+  - **案A**: Phase 1 で既存 `test_reg_147` / `test_reg_156` をそのまま CI に乗せる → GitHub Actions 2-core runner で 100k × 50 dataset は per-job 30 分超になる。Phase 1 で別 grid を新設し dataset を 5k × 20 まで縮小する方が PR latency 影響が小さい。catastrophe は dataset サイズに依存しないので 1.5x bound は同じ表現力を持つ。
+  - **案B**: Phase 3（`BackendExecutor`）から先に着手 → blast radius が公開 Python API（`w.predict(df)` の async 化検討）まで及ぶ。既知 call site の incremental 修正（P-036 / P-038）と異なり、Proposal 単位の合意形成と段階的 migration が必要。Phase 1 が CI を gate に入れる時点で historical regression class は捕捉できるため、Phase 3 を急ぐ便益が小さい。
+  - **案C**: `LD_PRELOAD=libomp` の wrapper script 配布で GCC bug 自体を回避 → ユーザの環境管理に踏み込みすぎる（Out of scope per #160）。
+- **受け入れ基準（Phase 1）**:
+  - [ ] `tests/regression/test_reg_160_libgomp_perf_grid.py` が `intermediate × next_op` の cross-product を `@pytest.mark.parametrize` で表現する。
+  - [ ] 各 cell の per-trial wall-clock が baseline subprocess tune の 1.5x 以内であることを assert する（libgomp 非搭載環境では skip）。
+  - [ ] `.github/workflows/ci.yml` に `libgomp-perf` job が存在し、`pull_request` トリガで `ubuntu-latest` 上で grid を実行する。
+  - [ ] grid を意図的に regress させると（例: 1.5x bound を 1.0x に絞る）CI が fail することを手元で確認する。
+  - [ ] 既存品質ゲート（`pytest`, `ruff check`, `ruff format --check`, `mypy --strict`, `pnpm test:coverage`, `pnpm lint`）全 green。
+- **本 Proposal の終了条件**:
+  - Phase 1 〜 Phase 4 すべてが develop にマージされる。本 Proposal 自体は Phase 1 PR がマージされた時点で「decision: 採択」とし、Phase 2-4 はそれぞれ独立 PR で着手する。
+
 ### P-038: subprocess Retune Resume を P-037 の tune state IPC を input 方向に拡張して実装（#154 thread fallback の置換）
 
 - **日付**: 2026-05-09（提案・決定・実装）

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案）
-- **ステータス**: 提案（Phase 1 実装着手中）
+- **日付**: 2026-05-10（提案・Phase 1 完了 / Phase 2 着手中）
+- **ステータス**: 採択（Phase 1: PR #162 で develop マージ済 / Phase 2: 着手中 / Phase 3-4: 着手前）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,8 @@
 
 ### P-039: libgomp / OpenMP プール親和性回帰の体系的予防（policy(openmp,perf) — #147 / #154 / #156 retrospective）
 
-- **日付**: 2026-05-10（提案・Phase 1 完了 / Phase 2 着手中）
-- **ステータス**: 採択（Phase 1: PR #162 で develop マージ済 / Phase 2: 着手中 / Phase 3-4: 着手前）
+- **日付**: 2026-05-10（提案・Phase 1-2 完了 / Phase 3 着手中）
+- **ステータス**: 採択（Phase 1-2: develop マージ済 / Phase 3: 着手中 / Phase 4: 着手前）
 - **関連 Issue**: [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)（本 Proposal の元 issue）, [#147](https://github.com/nbx-liz/LizyML-Widget/issues/147)（P-036 motivating case）, [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154)（PR #155 motivating case）, [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156)（P-038 motivating case）, [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)（同累積劣化、follow-up）
 - **背景**:
   - libgomp プール親和性問題（GCC bug [#108494](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108494)）に起因する 10-50x スローダウンが、本 codebase で **4 回** 異なる近接症状として再発した。各回ごとに reactive な修正（P-020, P-036, PR #155 thread fallback, P-038 subprocess retune resume）を入れ、learned skill を書き、specific path を pin する regression test を追加してきたが、**新規 ML 呼出経路を追加することで同種クラスの回帰を再導入できる構造的弱点が残っている**。

--- a/scripts/lint_ml_imports.py
+++ b/scripts/lint_ml_imports.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""ML library import lint (P-039 Phase 4 / change-gate enforcement).
+
+Fails CI if any production source file in ``src/lizyml_widget/`` imports
+an ML library outside the allowlisted modules. The allowlisted modules
+are the legitimate boundary owners of ML library calls:
+
+- ``adapter.py`` and any ``adapter_*.py`` helper — the canonical
+  Adapter layer that translates LizyML / LightGBM / etc. into the
+  widget's common types.
+- ``backend_executor.py`` — the single caller-thread chokepoint
+  introduced by P-039 Phase 3.
+- ``_subprocess_entry.py`` — the subprocess body, which runs in a
+  different process and therefore cannot bind libgomp on the parent
+  thread.
+- ``openmp_detect.py`` — imports ``lightgbm`` only to populate
+  ``/proc/self/maps`` for the libgomp detection routine; never
+  enters a parallel region itself.
+
+Any other module that needs to import ``lightgbm`` / ``shap`` /
+``xgboost`` / ``lizyml`` must add a ``# noqa: ML-CALL`` comment on
+the offending line and document the reason in the surrounding
+docstring or PR body. This is the structural enforcement for INV-H
+declared in P-039: "lightgbm / shap / xgboost / sklearn API への
+直接呼出は BackendExecutor モジュール外部から発生しない".
+
+Detection patterns:
+
+- ``import lightgbm`` / ``import lightgbm as ...``
+- ``from lightgbm ...``
+- ``import shap`` / ``from shap ...``
+- ``import xgboost`` / ``from xgboost ...``
+- ``import lizyml`` / ``from lizyml ...``
+
+Direct method patterns (``model.predict``, etc.) are intentionally NOT
+matched — they produce too many false positives on attribute access.
+The import gate alone is sufficient: a file cannot use these libraries
+without importing them.
+
+Exit codes:
+- 0 — clean
+- 1 — violations found (printed to stderr)
+
+Run locally:
+    uv run python scripts/lint_ml_imports.py
+
+Run as part of CI:
+    .github/workflows/ci.yml -> ml-call lint job
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Files allowed to import ML libraries directly. All other source
+# files in ``src/lizyml_widget/`` must funnel through one of these.
+ALLOWLISTED_FILES: frozenset[str] = frozenset(
+    {
+        "adapter.py",
+        "adapter_internals.py",
+        "adapter_params.py",
+        "adapter_results.py",
+        "adapter_schema.py",
+        "adapter_views.py",
+        "backend_executor.py",
+        "_subprocess_entry.py",
+        "openmp_detect.py",
+    }
+)
+
+# ML library names whose direct import is gate-required outside the
+# allowlist. Add new ML libraries here as they enter the project.
+ML_LIBRARIES: frozenset[str] = frozenset(
+    {
+        "lightgbm",
+        "shap",
+        "xgboost",
+        "lizyml",
+    }
+)
+
+# Per-line escape hatch comment. A line ending with ``# noqa: ML-CALL``
+# is exempt from the gate (the surrounding docstring / PR body must
+# explain why).
+NOQA_TAG = "# noqa: ML-CALL"
+
+# Build a regex that matches:
+#   import <lib>
+#   import <lib> as ...
+#   from <lib> ...
+#   from <lib>.something ...
+_LIB_ALTERNATION = "|".join(re.escape(name) for name in sorted(ML_LIBRARIES))
+_IMPORT_PATTERN = re.compile(
+    rf"^\s*(?:import\s+(?:{_LIB_ALTERNATION})(?:\s|$|\.|,)"
+    rf"|from\s+(?:{_LIB_ALTERNATION})(?:\s|\.|$))"
+)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (line_number, line_text) for offending imports."""
+    violations: list[tuple[int, str]] = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"WARN: cannot read {path}: {exc}", file=sys.stderr)
+        return violations
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        if NOQA_TAG in line:
+            continue
+        if _IMPORT_PATTERN.match(line):
+            violations.append((line_no, line.rstrip()))
+    return violations
+
+
+def _iter_source_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.name not in ALLOWLISTED_FILES)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    src_root = repo_root / "src" / "lizyml_widget"
+    if not src_root.is_dir():
+        print(f"ERROR: source directory not found: {src_root}", file=sys.stderr)
+        return 1
+
+    total_violations = 0
+    for path in _iter_source_files(src_root):
+        violations = _scan_file(path)
+        if not violations:
+            continue
+        rel = path.relative_to(repo_root)
+        for line_no, line in violations:
+            print(
+                f"{rel}:{line_no}: ML-CALL violation — {line.strip()}",
+                file=sys.stderr,
+            )
+        total_violations += len(violations)
+
+    if total_violations:
+        print(
+            f"\n{total_violations} ML-CALL violation(s) found. "
+            f"Direct ML library imports are only allowed in: "
+            f"{', '.join(sorted(ALLOWLISTED_FILES))}. "
+            f"Add a ``{NOQA_TAG}`` comment with a documented reason if "
+            f"you need an exception, or route the call through "
+            f"``BackendExecutor`` / the Adapter layer. See HISTORY.md "
+            f"P-039 Phase 4 and BLUEPRINT.md §3.2.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lizyml_widget/backend_executor.py
+++ b/src/lizyml_widget/backend_executor.py
@@ -1,0 +1,103 @@
+"""BackendExecutor — caller-thread ML library call funnel (P-039 Phase 3).
+
+Every caller-thread invocation of an ML library function (LightGBM /
+SHAP / etc.) goes through ``BackendExecutor.run_ml``. The executor:
+
+1. Centralises ``WidgetService._libgomp_pool_owner`` marking so the INV-G
+   runtime guard (P-039 Phase 2, ``widget._run_job``) sees a single,
+   consistent "main thread bound libgomp" signal regardless of which
+   adapter method was called.
+2. Provides a single chokepoint for a future scoped routing decision
+   (subprocess offload, dedicated OpenMP-owner thread). Phase 3 runs
+   everything inline on the caller thread; Phase 4 can then enforce
+   "no direct ML library call outside the executor" via lint rule
+   without renaming any call sites.
+
+The runner-side path (``ThreadJobRunner`` / ``SubprocessJobRunner``) is
+*not* funnelled through the executor — runners are the equivalent
+chokepoint for worker-thread / subprocess ML, and ``widget._supervise``
+already calls ``service.mark_libgomp_owner`` after a successful
+``runner.run()``. The executor is only for code that runs *on the same
+thread as the user-facing call* (predict, SHAP / explainability plots).
+
+State transitions performed by the executor:
+
+- ``ml_kind="predict"`` → mark ``"main"`` (OpenMP parallel boost in
+  ``booster.predict`` / etc. binds to caller thread).
+- ``ml_kind="explain"`` / ``ml_kind="plot_shap"`` → mark ``"main"``
+  (SHAP TreeExplainer is parallel under OpenMP).
+- ``ml_kind="plot_other"`` → no state change (Plotly-only plot
+  computation does not enter ML library parallel regions).
+
+Marking happens in a ``finally`` block so that exceptions raised mid-
+parallel-region still update the state defensively (libgomp may have
+already bound by the time the exception unwinds).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, TypeVar
+
+if TYPE_CHECKING:
+    from .service import WidgetService
+
+
+MLKind = Literal["predict", "explain", "plot_shap", "plot_other"]
+"""Categories of caller-thread ML library calls.
+
+- ``predict``: model inference (LightGBM ``booster.predict`` and similar)
+- ``explain``: SHAP value computation (``TreeExplainer.shap_values``)
+- ``plot_shap``: SHAP-based plots (``importance_plot(kind='shap')``)
+- ``plot_other``: non-ML-library plots (learning curves,
+  optimization-history, ROC, etc. — pure plotly / numpy work)
+"""
+
+# Kinds that enter an OpenMP parallel region on the caller thread and
+# therefore bind libgomp's pool affinity. Anything in this set must
+# transition the libgomp owner state to ``"main"``.
+_KINDS_THAT_BIND_LIBGOMP: frozenset[MLKind] = frozenset({"predict", "explain", "plot_shap"})
+
+T = TypeVar("T")
+
+
+class BackendExecutor:
+    """Funnel for caller-thread ML library calls.
+
+    Constructed once per ``WidgetService`` instance and held as
+    ``service._executor``. All of ``service.predict``,
+    ``service.get_plot``, and ``service.get_inference_plot`` route
+    their adapter calls through ``run_ml`` so the libgomp owner state
+    is updated in exactly one place.
+    """
+
+    def __init__(self, service: WidgetService) -> None:
+        self._service = service
+
+    def run_ml(self, op: Callable[[], T], *, ml_kind: MLKind) -> T:
+        """Run an ML library operation on the caller thread.
+
+        Parameters
+        ----------
+        op:
+            Zero-arg callable that performs the ML library call (e.g.
+            ``lambda: adapter.predict(model, df)``).
+        ml_kind:
+            Category of the call. Determines whether to mark the
+            libgomp owner state to ``"main"`` after the call.
+
+        Returns
+        -------
+        The result of ``op()``.
+
+        Raises
+        ------
+        Whatever ``op()`` raises. State marking still happens on the
+        exception path (libgomp may have already entered a parallel
+        region before the exception was raised).
+        """
+        try:
+            return op()
+        finally:
+            if ml_kind in _KINDS_THAT_BIND_LIBGOMP:
+                self._service.mark_libgomp_owner("main")

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -6,7 +6,7 @@ import copy
 import logging
 import threading
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -35,6 +35,12 @@ from .types import (
 _log = logging.getLogger(__name__)
 
 MAX_STATS_VALUES = 1000
+
+# P-039 Phase 2 / INV-G: states for ``WidgetService._libgomp_pool_owner``.
+# Tracks which thread/process most recently entered an OpenMP parallel
+# region so the widget guard can re-route worker-thread Tune/Fit/Retune
+# to subprocess when the parent main thread has bound libgomp.
+LibgompPoolOwner = Literal["unknown", "subprocess", "worker", "main"]
 
 
 class WidgetService:
@@ -67,6 +73,14 @@ class WidgetService:
         # (None, flag) so apply_best_params can fail loud in the latter.
         self._last_tune_summary: TuningSummary | None = None
         self._tune_summary_invalidated_by_load: bool = False
+        # P-039 Phase 2 (INV-G): track which thread/process most recently
+        # entered an OpenMP parallel region. Once "main" is observed (via
+        # parent-main-thread predict / SHAP), all subsequent worker-thread
+        # Tune/Fit/Retune jobs are catastrophe-prone on libgomp hosts and
+        # the widget guard re-routes them to subprocess. The state is
+        # process-sticky — load_data does NOT reset it because libgomp
+        # pool affinity does not unbind on data reload.
+        self._libgomp_pool_owner: LibgompPoolOwner = "unknown"
 
     @property
     def info(self) -> BackendInfo:
@@ -613,6 +627,25 @@ class WidgetService:
             self._last_tune_summary = summary
             self._tune_summary_invalidated_by_load = False
 
+    def mark_libgomp_owner(self, owner: LibgompPoolOwner) -> None:
+        """Record which thread/process most recently entered an OpenMP region.
+
+        P-039 Phase 2 (INV-G): the widget guard reads this to decide
+        whether a worker-thread Tune/Fit would hit the libgomp
+        pool-affinity catastrophe. Once ``"main"`` is set, stay sticky —
+        the libgomp bind in this process does not go away on data reload
+        or model swap. Callers:
+
+        - ``SubprocessJobRunner`` (after successful run) → ``"subprocess"``
+        - ``ThreadJobRunner`` (after successful run) → ``"worker"``
+        - ``predict`` / SHAP plot paths → ``"main"`` (parent main thread)
+        """
+        # If main already observed, do not downgrade — the libgomp bind
+        # to the parent main thread is permanent for this process.
+        if self._libgomp_pool_owner == "main" and owner != "main":
+            return
+        self._libgomp_pool_owner = owner
+
     def predict(self, data: pd.DataFrame, *, return_shap: bool = False) -> PredictionSummary:
         """Run prediction on new data."""
         with self._model_lock:
@@ -620,7 +653,15 @@ class WidgetService:
         if model is None:
             msg = "No trained model. Run fit or tune first."
             raise ValueError(msg)
-        return self._adapter.predict(model, data, return_shap=return_shap)
+        try:
+            return self._adapter.predict(model, data, return_shap=return_shap)
+        finally:
+            # P-039 Phase 2 / INV-G: predict runs on the caller thread
+            # (parent main thread for ``w.predict()`` / Inference tab
+            # callbacks). Mark even on exception because the LightGBM /
+            # SHAP TreeExplainer call has already entered an OpenMP
+            # parallel region by the time the exception unwinds.
+            self.mark_libgomp_owner("main")
 
     # ── Results ──────────────────────────────────────────────
 
@@ -630,7 +671,14 @@ class WidgetService:
         if model is None:
             msg = "No trained model"
             raise ValueError(msg)
-        return self._adapter.plot(model, plot_type, **kwargs)
+        try:
+            return self._adapter.plot(model, plot_type, **kwargs)
+        finally:
+            # P-039 Phase 2 / INV-G: SHAP plots run TreeExplainer on the
+            # caller thread which is parallel under OpenMP. Mark "main"
+            # so the next worker-thread Tune/Fit re-routes to subprocess.
+            if plot_type == "feature-importance-shap":
+                self.mark_libgomp_owner("main")
 
     def get_inference_plot(self, predictions: pd.DataFrame, plot_type: str) -> PlotData:
         """Generate an inference plot (prediction-distribution or shap-summary)."""
@@ -639,6 +687,11 @@ class WidgetService:
         except AttributeError:
             msg = "Inference plots not supported by this adapter"
             raise TypeError(msg) from None
+        finally:
+            # P-039 Phase 2 / INV-G: shap-summary recomputes a TreeExplainer
+            # on the caller thread (parent main thread for the Inference tab).
+            if plot_type == "shap-summary":
+                self.mark_libgomp_owner("main")
 
     def get_available_plots(self) -> list[str]:
         with self._model_lock:

--- a/src/lizyml_widget/service.py
+++ b/src/lizyml_widget/service.py
@@ -6,11 +6,15 @@ import copy
 import logging
 import threading
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
 
 from .adapter import BackendAdapter
+from .backend_executor import BackendExecutor
+
+if TYPE_CHECKING:
+    from .backend_executor import MLKind
 from .service_columns import (
     auto_configure_column,
     calc_feature_summary,
@@ -81,6 +85,12 @@ class WidgetService:
         # process-sticky — load_data does NOT reset it because libgomp
         # pool affinity does not unbind on data reload.
         self._libgomp_pool_owner: LibgompPoolOwner = "unknown"
+        # P-039 Phase 3: caller-thread ML library calls (predict / SHAP)
+        # are routed through this executor so libgomp owner state is
+        # marked in exactly one place. A future phase may extend the
+        # executor to offload predict/SHAP to a subprocess when state
+        # tracking alone is not enough.
+        self._executor = BackendExecutor(self)
 
     @property
     def info(self) -> BackendInfo:
@@ -647,51 +657,64 @@ class WidgetService:
         self._libgomp_pool_owner = owner
 
     def predict(self, data: pd.DataFrame, *, return_shap: bool = False) -> PredictionSummary:
-        """Run prediction on new data."""
+        """Run prediction on new data.
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml`` so the
+        libgomp owner state is marked in exactly one place. The
+        executor enters ``"main"`` after ``adapter.predict`` runs
+        because LightGBM / SHAP TreeExplainer enters an OpenMP parallel
+        region on the caller thread.
+        """
         with self._model_lock:
             model = self._model
         if model is None:
             msg = "No trained model. Run fit or tune first."
             raise ValueError(msg)
-        try:
-            return self._adapter.predict(model, data, return_shap=return_shap)
-        finally:
-            # P-039 Phase 2 / INV-G: predict runs on the caller thread
-            # (parent main thread for ``w.predict()`` / Inference tab
-            # callbacks). Mark even on exception because the LightGBM /
-            # SHAP TreeExplainer call has already entered an OpenMP
-            # parallel region by the time the exception unwinds.
-            self.mark_libgomp_owner("main")
+        return self._executor.run_ml(
+            lambda: self._adapter.predict(model, data, return_shap=return_shap),
+            ml_kind="predict",
+        )
 
     # ── Results ──────────────────────────────────────────────
 
     def get_plot(self, plot_type: str, **kwargs: Any) -> PlotData:
+        """Render a plot for the trained model.
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml``. SHAP
+        plots are tagged ``"plot_shap"`` so the executor marks the
+        libgomp owner state to ``"main"`` (TreeExplainer is OpenMP-
+        parallel on the caller thread); other plots are tagged
+        ``"plot_other"`` and do not change state.
+        """
         with self._model_lock:
             model = self._model
         if model is None:
             msg = "No trained model"
             raise ValueError(msg)
-        try:
-            return self._adapter.plot(model, plot_type, **kwargs)
-        finally:
-            # P-039 Phase 2 / INV-G: SHAP plots run TreeExplainer on the
-            # caller thread which is parallel under OpenMP. Mark "main"
-            # so the next worker-thread Tune/Fit re-routes to subprocess.
-            if plot_type == "feature-importance-shap":
-                self.mark_libgomp_owner("main")
+        ml_kind: MLKind = "plot_shap" if plot_type == "feature-importance-shap" else "plot_other"
+        return self._executor.run_ml(
+            lambda: self._adapter.plot(model, plot_type, **kwargs),
+            ml_kind=ml_kind,
+        )
 
     def get_inference_plot(self, predictions: pd.DataFrame, plot_type: str) -> PlotData:
-        """Generate an inference plot (prediction-distribution or shap-summary)."""
-        try:
-            return self._adapter.plot_inference(predictions, plot_type)
-        except AttributeError:
-            msg = "Inference plots not supported by this adapter"
-            raise TypeError(msg) from None
-        finally:
-            # P-039 Phase 2 / INV-G: shap-summary recomputes a TreeExplainer
-            # on the caller thread (parent main thread for the Inference tab).
-            if plot_type == "shap-summary":
-                self.mark_libgomp_owner("main")
+        """Generate an inference plot (prediction-distribution or shap-summary).
+
+        P-039 Phase 3: routed through ``BackendExecutor.run_ml``.
+        ``shap-summary`` is tagged ``"plot_shap"`` (TreeExplainer
+        recomputed on the caller thread); other plots are
+        ``"plot_other"``.
+        """
+        ml_kind: MLKind = "plot_shap" if plot_type == "shap-summary" else "plot_other"
+
+        def _run() -> PlotData:
+            try:
+                return self._adapter.plot_inference(predictions, plot_type)
+            except AttributeError:
+                msg = "Inference plots not supported by this adapter"
+                raise TypeError(msg) from None
+
+        return self._executor.run_ml(_run, ml_kind=ml_kind)
 
     def get_available_plots(self) -> list[str]:
         with self._model_lock:

--- a/src/lizyml_widget/widget.py
+++ b/src/lizyml_widget/widget.py
@@ -603,8 +603,36 @@ class LizyWidget(anywidget.AnyWidget):
         # to the same path as initial tune. The previous PR #155 thread
         # fallback is gone; it was unsafe whenever the user entered any
         # libgomp parallel region on the parent main thread (#156).
+        #
+        # P-039 Phase 2 / INV-G: if the parent main thread has already
+        # bound the libgomp pool (via prior predict / SHAP), a thread
+        # runner job would hit the 10-50x catastrophe. Re-route to
+        # subprocess unless the user explicitly opted out with
+        # LZW_FORCE_THREAD=1, in which case respect the opt-out and
+        # WARN. ``effective_strategy`` is per-job and does NOT mutate
+        # the cached ``_execution_strategy`` so a subsequent job after
+        # ``unknown`` recovery still consults the strategy detector.
+        effective_strategy = self._execution_strategy
+        if effective_strategy == "thread" and self._service._libgomp_pool_owner == "main":
+            if os.environ.get("LZW_FORCE_THREAD") == "1":
+                _log.warning(
+                    "INV-G: libgomp pool bound to parent main thread "
+                    "(prior predict/SHAP); LZW_FORCE_THREAD=1 honored — "
+                    "thread runner may be 10-50x slower for this %s job. "
+                    "Unset LZW_FORCE_THREAD to enable automatic subprocess re-route.",
+                    job_type,
+                )
+            else:
+                _log.warning(
+                    "INV-G: libgomp pool bound to parent main thread "
+                    "(prior predict/SHAP) — re-routing %s job to subprocess "
+                    "to avoid 10-50x slowdown.",
+                    job_type,
+                )
+                effective_strategy = "subprocess"
+
         runner: JobRunner
-        if self._execution_strategy == "subprocess":
+        if effective_strategy == "subprocess":
             runner = SubprocessJobRunner(self._service, libomp_path=self._libomp_path)
         else:
             runner = ThreadJobRunner(self._service)
@@ -688,6 +716,14 @@ class LizyWidget(anywidget.AnyWidget):
             self._apply_job_result(result)
             self.elapsed_sec = round(time.monotonic() - start, 1)
             self.status = "completed"
+            # P-039 Phase 2 / INV-G: record which thread/process most
+            # recently entered an OpenMP parallel region. Subprocess
+            # never touches the parent's libgomp pool; thread runner
+            # binds to the worker thread (not main, so OK). Either way,
+            # subsequent worker-thread jobs can proceed without the
+            # catastrophe path. Only mark on success — failed jobs may
+            # have been killed before any parallel region executed.
+            self._service.mark_libgomp_owner("subprocess" if is_subprocess else "worker")
         except InterruptedError:
             # INV-D (BLUEPRINT §6.4): cancel during running -> failed/CANCELLED.
             self.elapsed_sec = round(time.monotonic() - start, 1)

--- a/tests/regression/test_reg_160_backend_executor_funnel.py
+++ b/tests/regression/test_reg_160_backend_executor_funnel.py
@@ -1,0 +1,160 @@
+"""Funnel-contract tests for P-039 Phase 3 (BackendExecutor).
+
+The architectural guarantee for Phase 3 is that **every caller-thread
+ML library call site** in the widget routes through the executor.
+Phase 4 (lint rule) will enforce this against future changes; this
+file pins the current state so a regression that bypasses the
+executor surfaces in fast tier instead of as silent INV-G drift.
+
+The contracts:
+
+- ``service.predict`` calls ``executor.run_ml(..., ml_kind="predict")``
+- ``service.get_plot("feature-importance-shap")`` calls ``run_ml(..., ml_kind="plot_shap")``
+- ``service.get_plot("<other>")`` calls ``run_ml(..., ml_kind="plot_other")``
+- ``service.get_inference_plot(..., "shap-summary")`` calls ``run_ml(..., ml_kind="plot_shap")``
+- ``service.get_inference_plot(..., "<other>")`` calls ``run_ml(..., ml_kind="plot_other")``
+
+We patch the executor's ``run_ml`` to assert the funnel without
+running the underlying mock adapter twice. The end-state INV-G
+transitions are pinned separately by ``test_reg_160_inv_g_runtime_guard``;
+this file is the funnel-shape contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def _make_service_with_model() -> Any:
+    from lizyml_widget.service import WidgetService
+
+    adapter = MagicMock()
+    adapter.predict.return_value = MagicMock()
+    adapter.plot.return_value = MagicMock()
+    adapter.plot_inference.return_value = MagicMock()
+    svc = WidgetService(adapter=adapter)
+    svc._model = MagicMock()
+    return svc, adapter
+
+
+class TestPredictFunnel:
+    def test_predict_routes_through_executor_with_predict_kind(self) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == "predict"
+        adapter.predict.assert_called_once()
+
+    def test_predict_does_not_call_adapter_outside_executor(self) -> None:
+        """If ``run_ml`` is intercepted to *not* call the operation,
+        the adapter must not be touched. This catches a refactor that
+        accidentally calls the adapter twice (once in the funnel and
+        once outside)."""
+        svc, adapter = _make_service_with_model()
+
+        with patch.object(svc._executor, "run_ml", return_value=MagicMock()) as mock_run:
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+
+        mock_run.assert_called_once()
+        adapter.predict.assert_not_called()
+
+
+class TestGetPlotFunnel:
+    @pytest.mark.parametrize(
+        "plot_type, expected_kind",
+        [
+            ("feature-importance-shap", "plot_shap"),
+            ("learning-curve", "plot_other"),
+            ("optimization-history", "plot_other"),
+        ],
+    )
+    def test_get_plot_routes_through_executor_with_correct_kind(
+        self, plot_type: str, expected_kind: str
+    ) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.get_plot(plot_type)
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == expected_kind
+        adapter.plot.assert_called_once()
+
+
+class TestGetInferencePlotFunnel:
+    @pytest.mark.parametrize(
+        "plot_type, expected_kind",
+        [
+            ("shap-summary", "plot_shap"),
+            ("prediction-distribution", "plot_other"),
+        ],
+    )
+    def test_get_inference_plot_routes_through_executor_with_correct_kind(
+        self, plot_type: str, expected_kind: str
+    ) -> None:
+        svc, adapter = _make_service_with_model()
+        captured: dict[str, Any] = {}
+
+        original = svc._executor.run_ml
+
+        def spy(op: Any, *, ml_kind: str) -> Any:
+            captured["ml_kind"] = ml_kind
+            return original(op, ml_kind=ml_kind)  # type: ignore[arg-type]
+
+        with patch.object(svc._executor, "run_ml", side_effect=spy) as mock_run:
+            svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), plot_type)
+
+        assert mock_run.call_count == 1
+        assert captured["ml_kind"] == expected_kind
+        adapter.plot_inference.assert_called_once()
+
+    def test_inference_plot_attribute_error_translates_to_type_error(self) -> None:
+        """Existing AttributeError → TypeError translation must survive
+        the executor refactor (regression for adapter without
+        ``plot_inference``)."""
+        svc, adapter = _make_service_with_model()
+        adapter.plot_inference.side_effect = AttributeError("no plot_inference on this adapter")
+
+        with pytest.raises(TypeError, match="Inference plots not supported by this adapter"):
+            svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), "shap-summary")
+
+
+class TestExecutorIsServiceOwned:
+    """``service._executor`` is the canonical executor instance.
+
+    Phase 4 lint will rely on this — every ML call must reach the
+    executor stored on the service that constructed the adapter calls.
+    A future refactor must not introduce a per-call executor or a
+    module-global instance.
+    """
+
+    def test_service_holds_executor_reference(self) -> None:
+        svc, _ = _make_service_with_model()
+        from lizyml_widget.backend_executor import BackendExecutor
+
+        assert isinstance(svc._executor, BackendExecutor)
+
+    def test_executor_back_reference_points_to_owning_service(self) -> None:
+        svc, _ = _make_service_with_model()
+        assert svc._executor._service is svc

--- a/tests/regression/test_reg_160_inv_g_runtime_guard.py
+++ b/tests/regression/test_reg_160_inv_g_runtime_guard.py
@@ -1,0 +1,506 @@
+"""Regression tests for P-039 Phase 2 / INV-G — runtime libgomp owner guard.
+
+Phase 1 (PR #162) added a CI gate that detects libgomp pool-affinity
+catastrophes on the cross-product of historical regressions. Phase 2
+adds a *runtime* guard so the catastrophe is averted in production
+without waiting for a CI run on a future PR.
+
+INV-G (BLUEPRINT.md §6.4): when ``WidgetService._libgomp_pool_owner``
+is ``"main"``, ``ThreadJobRunner`` must NOT be used to launch
+Tune/Fit/Retune. The widget guard re-routes to ``SubprocessJobRunner``
+unless ``LZW_FORCE_THREAD=1`` is set, in which case the user opt-out
+is honored with a WARN-level log.
+
+State transitions encoded:
+
+- ``__init__``                                   → ``"unknown"``
+- ``SubprocessJobRunner.run`` success            → ``"subprocess"``
+- ``ThreadJobRunner.run`` success                → ``"worker"``
+- ``service.predict(...)``                       → ``"main"``
+- ``service.get_plot("feature-importance-shap")`` → ``"main"``
+- ``service.get_inference_plot(..., "shap-summary")`` → ``"main"``
+- ``"main"`` is sticky in-process (load_data does NOT reset)
+
+These tests pin the state-machine itself plus the widget guard's
+re-route behaviour. They are fast (mocks) so they run in the default
+pytest tier. The slow perf-grid in
+``test_reg_160_libgomp_perf_grid.py`` covers end-to-end timing.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lizyml_widget.adapter import LizyMLAdapter
+from lizyml_widget.types import BackendInfo
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror test_reg_154 / test_reg_156 harness so canonical config
+# flows but ML library calls are intercepted.
+# ---------------------------------------------------------------------------
+
+
+def _make_widget() -> Any:
+    real_adapter = LizyMLAdapter()
+    with patch("lizyml_widget.widget.LizyMLAdapter") as MockAdapter:
+        adapter = MockAdapter.return_value
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.get_config_schema.return_value = {"type": "object"}
+        adapter.validate_config.return_value = []
+        adapter.initialize_config.side_effect = real_adapter.initialize_config
+        adapter.apply_config_patch.side_effect = real_adapter.apply_config_patch
+        adapter.prepare_run_config.side_effect = real_adapter.prepare_run_config
+        adapter.get_backend_contract.side_effect = real_adapter.get_backend_contract
+        adapter.canonicalize_config.side_effect = real_adapter.canonicalize_config
+        adapter.apply_task_defaults.side_effect = real_adapter.apply_task_defaults
+        adapter.classify_best_params.side_effect = real_adapter.classify_best_params
+
+        from lizyml_widget.widget import LizyWidget
+
+        w = LizyWidget()
+    df = pd.DataFrame(
+        {
+            "f1": list(range(40)),
+            "f2": [i * 0.5 for i in range(40)],
+            "f3": [i % 5 for i in range(40)],
+            "y": [0, 1] * 20,
+        }
+    )
+    w.load(df, target="y")
+    return w
+
+
+def _stub_runner_result() -> Any:
+    from lizyml_widget.subprocess_runner import SubprocessJobResult
+
+    return SubprocessJobResult(
+        job_type="fit",
+        fit_summary={"metrics": {}, "fold_count": 0, "fold_details": [], "params": []},
+        tune_summary={},
+        eval_table=[],
+        split_summary=[],
+        available_plots=[],
+        model_path=None,
+        tune_state_path=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# State machine — Service.mark_libgomp_owner
+# ---------------------------------------------------------------------------
+
+
+class TestLibgompOwnerStateMachine:
+    """Service-side state transitions for INV-G."""
+
+    def _make_service(self) -> Any:
+        from lizyml_widget.service import WidgetService
+
+        return WidgetService(adapter=LizyMLAdapter())
+
+    def test_default_state_is_unknown(self) -> None:
+        svc = self._make_service()
+        assert svc._libgomp_pool_owner == "unknown"
+
+    def test_mark_owner_sets_state(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("subprocess")
+        assert svc._libgomp_pool_owner == "subprocess"
+        svc.mark_libgomp_owner("worker")
+        assert svc._libgomp_pool_owner == "worker"
+
+    def test_main_is_sticky_against_subprocess_downgrade(self) -> None:
+        """Once main thread bound libgomp, the bind does not unbind in
+        this process — subsequent subprocess success must NOT downgrade
+        the state to "subprocess" (which would re-enable thread runner
+        for the *next* job and re-trigger catastrophe).
+        """
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("subprocess")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_main_is_sticky_against_worker_downgrade(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("worker")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_main_is_idempotent(self) -> None:
+        svc = self._make_service()
+        svc.mark_libgomp_owner("main")
+        svc.mark_libgomp_owner("main")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_load_data_does_not_reset_libgomp_owner(self) -> None:
+        """libgomp pool affinity is process-state — reloading data does
+        not unbind it. The state must persist so the guard catches
+        the next thread-runner job.
+        """
+        from lizyml_widget.service import WidgetService
+
+        svc = WidgetService(adapter=LizyMLAdapter())
+        svc.mark_libgomp_owner("main")
+        df = pd.DataFrame({"f1": [1, 2, 3, 4], "y": [0, 1, 0, 1]})
+        svc.load_data(df, target="y")
+        assert svc._libgomp_pool_owner == "main"
+
+
+# ---------------------------------------------------------------------------
+# State machine — predict / SHAP plot transitions
+# ---------------------------------------------------------------------------
+
+
+class TestServiceCallSitesMarkMain:
+    """Caller-thread ML library calls must mark the state to "main".
+
+    The actual adapter calls are mocked because we are testing the
+    state-transition wiring, not the LightGBM/SHAP behavior.
+    """
+
+    def _make_service_with_model(self) -> Any:
+        from lizyml_widget.service import WidgetService
+
+        adapter = MagicMock()
+        adapter.info = BackendInfo(name="mock", version="0.0.0")
+        adapter.predict.return_value = MagicMock()
+        adapter.plot.return_value = MagicMock()
+        adapter.plot_inference.return_value = MagicMock()
+        svc = WidgetService(adapter=adapter)
+        svc._model = MagicMock()
+        return svc, adapter
+
+    def test_predict_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        assert svc._libgomp_pool_owner == "unknown"
+        svc.predict(pd.DataFrame({"f1": [1, 2]}))
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_predict_marks_main_even_when_adapter_raises(self) -> None:
+        """LightGBM may have already entered the parallel region by the
+        time the exception unwinds — mark "main" defensively."""
+        svc, adapter = self._make_service_with_model()
+        adapter.predict.side_effect = RuntimeError("predict failed")
+        with pytest.raises(RuntimeError):
+            svc.predict(pd.DataFrame({"f1": [1, 2]}))
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_plot_shap_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_plot("feature-importance-shap")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_plot_non_shap_does_not_mark_main(self) -> None:
+        """Non-SHAP plots (e.g., learning-curve) do not run TreeExplainer
+        on the caller thread — state must remain unchanged."""
+        svc, _ = self._make_service_with_model()
+        svc.get_plot("optimization-history")
+        assert svc._libgomp_pool_owner == "unknown"
+
+    def test_get_inference_plot_shap_summary_marks_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_inference_plot(pd.DataFrame({"pred": [0.1]}), "shap-summary")
+        assert svc._libgomp_pool_owner == "main"
+
+    def test_get_inference_plot_distribution_does_not_mark_main(self) -> None:
+        svc, _ = self._make_service_with_model()
+        svc.get_inference_plot(
+            pd.DataFrame({"pred": [0.1]}),
+            "prediction-distribution",
+        )
+        assert svc._libgomp_pool_owner == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# State machine — runner completion transitions (in widget._supervise)
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerCompletionMarksOwner:
+    """``_supervise`` marks the owner after a successful runner.run()."""
+
+    def test_subprocess_runner_success_marks_subprocess(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", "/usr/lib/libomp5.so"),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+        ):
+            mock_inst = mock_sp.return_value
+            mock_inst.kind = "subprocess"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            assert w._service._libgomp_pool_owner == "unknown"
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "completed", f"Fit failed: {w.error!r}"
+            assert w._service._libgomp_pool_owner == "subprocess"
+
+    def test_thread_runner_success_marks_worker(self) -> None:
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_inst = mock_thread.return_value
+            mock_inst.kind = "thread"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "completed", f"Fit failed: {w.error!r}"
+            assert w._service._libgomp_pool_owner == "worker"
+
+    def test_failed_run_does_not_mark_owner(self) -> None:
+        """A failed job may have aborted before any parallel region
+        executed — leave state unchanged so the guard does not over-
+        constrain future jobs."""
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_inst = mock_thread.return_value
+            mock_inst.kind = "thread"
+            mock_inst.run.side_effect = RuntimeError("boom")
+
+            w = _make_widget()
+            with pytest.raises(RuntimeError, match="boom"):
+                w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert w.status == "failed"
+            assert w._service._libgomp_pool_owner == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Widget guard — re-route thread → subprocess when state is "main"
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetGuardReroutesToSubprocess:
+    """``widget._run_job`` upgrades thread → subprocess when state is "main".
+
+    The actual reroute decision is observable via which runner class
+    gets instantiated. We pre-seed the service state and assert
+    SubprocessJobRunner is constructed even though the strategy
+    detector returned "thread".
+    """
+
+    def test_thread_strategy_with_main_state_reroutes_to_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            # Pre-seed: prior predict on parent main thread bound libgomp.
+            w._service.mark_libgomp_owner("main")
+
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            (
+                mock_sp.assert_called_once(),
+                ("INV-G: thread+main state must re-route to SubprocessJobRunner"),
+            )
+            mock_thread.assert_not_called()
+
+    def test_force_thread_env_honored_when_state_main(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """LZW_FORCE_THREAD=1 is an explicit user opt-out. The guard
+        must respect it (only WARN, no auto-reroute)."""
+        monkeypatch.setenv("LZW_FORCE_THREAD", "1")
+        caplog.set_level(logging.WARNING, logger="lizyml_widget.widget")
+
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w._service.mark_libgomp_owner("main")
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            (
+                mock_thread.assert_called_once(),
+                ("LZW_FORCE_THREAD=1 must keep thread runner under main state"),
+            )
+            mock_sp.assert_not_called()
+            warn_msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+            assert any("INV-G" in m for m in warn_msgs), (
+                f"Expected INV-G WARN under FORCE_THREAD; got: {warn_msgs}"
+            )
+
+    def test_thread_strategy_with_unknown_state_uses_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without prior main-thread parallel region, thread strategy
+        runs as-is — no spurious subprocess startup overhead."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            assert w._service._libgomp_pool_owner == "unknown"
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            mock_thread.assert_called_once()
+            mock_sp.assert_not_called()
+
+    def test_subprocess_strategy_does_not_log_inv_g_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The guard only fires for thread strategy with main state.
+        Subprocess + main is the safe combination — no WARN should fire."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        caplog.set_level(logging.WARNING, logger="lizyml_widget.widget")
+
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("subprocess", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+        ):
+            mock_inst = mock_sp.return_value
+            mock_inst.kind = "subprocess"
+            mock_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+            w._service.mark_libgomp_owner("main")
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+
+            inv_g_warns = [r for r in caplog.records if "INV-G" in r.getMessage()]
+            assert not inv_g_warns, (
+                f"Subprocess+main should not emit INV-G warn; got: {inv_g_warns}"
+            )
+
+    def test_concurrent_jobs_each_apply_guard_independently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second job, after a first job that did NOT bind main, must
+        consult the live state — not a frozen snapshot. This catches a
+        future refactor that captures state once at __init__ time."""
+        monkeypatch.delenv("LZW_FORCE_THREAD", raising=False)
+        with (
+            patch(
+                "lizyml_widget.widget.get_execution_strategy",
+                return_value=("thread", None),
+            ),
+            patch("lizyml_widget.widget.SubprocessJobRunner") as mock_sp,
+            patch("lizyml_widget.widget.ThreadJobRunner") as mock_thread,
+        ):
+            mock_thread_inst = mock_thread.return_value
+            mock_thread_inst.kind = "thread"
+            mock_thread_inst.run.return_value = _stub_runner_result()
+            mock_sp_inst = mock_sp.return_value
+            mock_sp_inst.kind = "subprocess"
+            mock_sp_inst.run.return_value = _stub_runner_result()
+
+            w = _make_widget()
+
+            # Job 1: state is "unknown" → thread runner.
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert mock_thread.call_count == 1
+            assert mock_sp.call_count == 0
+
+            # Simulate user predict between jobs.
+            w._service.mark_libgomp_owner("main")
+
+            # Job 2: state is now "main" → must re-route to subprocess.
+            w.fit()
+            if w._job_thread:
+                w._job_thread.join(timeout=10)
+            assert mock_sp.call_count == 1, "Second job must re-route to subprocess after predict"
+
+
+# ---------------------------------------------------------------------------
+# Threading sanity: mark_libgomp_owner is safe under concurrent calls.
+# ---------------------------------------------------------------------------
+
+
+class TestMarkLibgompOwnerThreadSafety:
+    def test_concurrent_marks_converge_to_main_when_main_observed(self) -> None:
+        """If any thread observes main, the final state is main —
+        regardless of concurrent worker/subprocess transitions."""
+        from lizyml_widget.service import WidgetService
+
+        svc = WidgetService(adapter=LizyMLAdapter())
+
+        def hammer_subprocess() -> None:
+            for _ in range(200):
+                svc.mark_libgomp_owner("subprocess")
+
+        def hammer_worker() -> None:
+            for _ in range(200):
+                svc.mark_libgomp_owner("worker")
+
+        def hammer_main() -> None:
+            for _ in range(50):
+                svc.mark_libgomp_owner("main")
+
+        threads = [
+            threading.Thread(target=hammer_subprocess),
+            threading.Thread(target=hammer_worker),
+            threading.Thread(target=hammer_main),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert svc._libgomp_pool_owner == "main"

--- a/tests/regression/test_reg_160_libgomp_perf_grid.py
+++ b/tests/regression/test_reg_160_libgomp_perf_grid.py
@@ -1,0 +1,334 @@
+"""Parameterised libgomp perf regression grid for P-039 / issue #160.
+
+Phase 1 / Layer 3 of the systemic prevention plan declared in P-039
+(see HISTORY.md). The four historical regressions in the libgomp
+pool-affinity family (#147 / #154 / #156 / #158) all share one root
+cause — GCC libgomp binds the OpenMP thread pool to the first thread
+that enters a parallel region, and any subsequent worker-thread call
+gets a 10-50x penalty (GCC bug #108494). Each prior regression test
+pinned a *specific* path; none of them covered the cross-product of
+"what happened on the parent main thread before the next ML op".
+
+This grid asserts the catastrophe-class invariant directly:
+
+INV-#160-A: for every combination of {intermediate parent-thread op}
+× {next ML op}, the per-trial wall-clock of the next op stays within
+1.5x of the baseline subprocess tune. A failure indicates that some
+parent-main-thread libgomp parallel region has bound the pool
+affinity such that a follow-up worker-thread Tune/Fit/Retune is
+running on the wrong thread.
+
+The dataset is intentionally smaller than the existing
+``test_reg_147_openmp_perf.py`` / ``test_reg_156_subprocess_retune.py``
+tests so the grid fits inside the GitHub Actions ``libgomp-perf`` CI
+job budget (~5-10 min total). Catastrophe is *not* dataset-size
+dependent (libgomp pool affinity is a per-region constant cost), so
+the 1.5x ratio remains expressive on small data.
+
+The grid is gated on Linux + libgomp; non-libgomp hosts skip
+because the bound is meaningless without the underlying GCC bug.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip helpers — mirror the openmp_detect logic so the grid doesn't silently
+# pass on a fresh kernel where lightgbm has not been imported yet.
+# ---------------------------------------------------------------------------
+
+
+def _libgomp_loaded() -> bool:
+    if sys.platform != "linux":
+        return False
+    try:
+        import lightgbm  # noqa: F401
+    except Exception:  # pragma: no cover - defensive
+        return False
+    try:
+        with open("/proc/self/maps") as f:
+            return any("libgomp" in line for line in f)
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="libgomp pool-affinity bug is Linux-only",
+    ),
+    pytest.mark.skipif(
+        not _libgomp_loaded(),
+        reason="libgomp not loaded — 1.5x bound only meaningful on libgomp hosts",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_perf_widget(n_rows: int = 5_000, n_trials: int = 2) -> Any:
+    """Build a minimal LizyWidget for the grid.
+
+    Smaller than ``test_reg_156_subprocess_retune._make_perf_widget`` so
+    the grid fits the CI job budget. Catastrophe-class regressions are
+    not dataset-size dependent — a 5k row tune is enough to drive 10-50x
+    pool-affinity slowdowns on libgomp hosts.
+    """
+    import numpy as np
+
+    from lizyml_widget.widget import LizyWidget
+
+    rng = np.random.default_rng(0)
+    n_cols = 20
+    cols = {f"f{i}": rng.random(n_rows, dtype=np.float64) for i in range(n_cols)}
+    cols["y"] = (rng.random(n_rows) > 0.5).astype(int)
+    df = pd.DataFrame(cols)
+
+    w = LizyWidget()
+    w.load(df, target="y")
+    cfg = dict(w.config)
+    tuning = dict(cfg.get("tuning") or {})
+    optuna = dict(tuning.get("optuna") or {})
+    params = dict(optuna.get("params") or {})
+    params["n_trials"] = n_trials
+    optuna["params"] = params
+    tuning["optuna"] = optuna
+    cfg["tuning"] = tuning
+    w.set_config(cfg)
+    return w
+
+
+def _real_strategy_patch() -> Any:
+    """Override conftest's autouse thread-strategy patch.
+
+    ``conftest.py`` patches ``lizyml_widget.widget.get_execution_strategy`` to
+    return ``("thread", None)`` for the entire suite. The grid needs the
+    real production strategy ``("subprocess", libomp_path)`` on libgomp
+    hosts.
+    """
+    from lizyml_widget.openmp_detect import _reset_libgomp_cache, get_execution_strategy
+
+    _reset_libgomp_cache()
+    return patch(
+        "lizyml_widget.widget.get_execution_strategy",
+        side_effect=get_execution_strategy,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Intermediate-op helpers — drive the parent main thread into a libgomp
+# parallel region in the same way real users would (predict / fit + predict).
+# ---------------------------------------------------------------------------
+
+
+def _run_intermediate_noop(_w: Any) -> None:
+    """No parent-main-thread libgomp activity. Baseline cell."""
+
+
+def _run_intermediate_main_thread_predict(_w: Any) -> None:
+    """Reproduce ``w.predict(test_df)`` semantics without holding a model.
+
+    A ``booster.predict`` call on the parent main thread is sufficient to
+    bind libgomp's pool affinity to that thread (#156 root cause).
+    """
+    import lightgbm as lgb
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    X = rng.random((500, 20))
+    y = (rng.random(500) > 0.5).astype(int)
+
+    booster_holder: dict[str, Any] = {}
+
+    def _fit_in_worker() -> None:
+        ds = lgb.Dataset(X, label=y)
+        booster_holder["b"] = lgb.train(
+            {
+                "objective": "binary",
+                "metric": "binary_logloss",
+                "verbose": -1,
+                "num_threads": 0,
+            },
+            ds,
+            num_boost_round=20,
+        )
+
+    th = threading.Thread(target=_fit_in_worker, daemon=False)
+    th.start()
+    th.join()
+    booster = booster_holder["b"]
+    for _ in range(3):
+        _ = booster.predict(X)
+
+
+def _run_intermediate_main_thread_fit_predict(_w: Any) -> None:
+    """Heavier variant: both fit AND predict on the parent main thread.
+
+    Some users call ``lgb.train`` directly from notebook cells (outside
+    the widget). This cell pins that path: no worker offload at all.
+    """
+    import lightgbm as lgb
+    import numpy as np
+
+    rng = np.random.default_rng(7)
+    X = rng.random((500, 20))
+    y = (rng.random(500) > 0.5).astype(int)
+    ds = lgb.Dataset(X, label=y)
+    booster = lgb.train(
+        {
+            "objective": "binary",
+            "metric": "binary_logloss",
+            "verbose": -1,
+            "num_threads": 0,
+        },
+        ds,
+        num_boost_round=20,
+    )
+    for _ in range(3):
+        _ = booster.predict(X)
+
+
+_INTERMEDIATES = {
+    "noop": _run_intermediate_noop,
+    "main_thread_predict": _run_intermediate_main_thread_predict,
+    "main_thread_fit_predict": _run_intermediate_main_thread_fit_predict,
+}
+
+
+# ---------------------------------------------------------------------------
+# Op runners — both baseline and measured runs use the SAME op type so the
+# comparison cancels out fixed subprocess startup / dataset reload / model
+# serialisation overhead. Only catastrophe-level (libgomp pool affinity)
+# slowdowns remain visible in the ratio.
+# ---------------------------------------------------------------------------
+
+
+_RETUNE_TRIALS = 2
+_TUNE_PRIMER_TRIALS = 2
+
+
+def _prime_for_retune_cell(w: Any) -> None:
+    """Run a clean tune so the widget has tune state for the retune cells.
+
+    The actual baseline measurement is the FIRST retune (post-tune); the
+    measured run is the SECOND retune (post-intermediate). Both retunes
+    pay identical fixed overheads (subprocess startup, study restore,
+    model serialisation), so the ratio cleanly isolates libgomp
+    pool-affinity effects.
+    """
+    w.tune(timeout=600)
+    assert w.status == "completed", f"Primer tune failed: {w.error!r}"
+    assert w._execution_strategy == "subprocess", (
+        f"Pre-condition: strategy must be subprocess on libgomp host, got {w._execution_strategy!r}"
+    )
+
+
+def _run_retune_per_trial(w: Any) -> float:
+    t0 = time.perf_counter()
+    w.retune(n_trials=_RETUNE_TRIALS, timeout=600)
+    elapsed = time.perf_counter() - t0
+    assert w.status == "completed", f"Retune failed: {w.error!r}"
+    return elapsed / _RETUNE_TRIALS
+
+
+def _run_fit_seconds(w: Any) -> float:
+    t0 = time.perf_counter()
+    w.fit(timeout=600)
+    elapsed = time.perf_counter() - t0
+    assert w.status == "completed", f"Fit failed: {w.error!r}"
+    return elapsed
+
+
+_OP_RUNNERS = {
+    "retune": _run_retune_per_trial,
+    "fit": _run_fit_seconds,
+}
+
+
+# ---------------------------------------------------------------------------
+# The grid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "intermediate",
+    ["noop", "main_thread_predict", "main_thread_fit_predict"],
+)
+@pytest.mark.parametrize("next_op", ["retune", "fit"])
+def test_no_libgomp_perf_catastrophe(intermediate: str, next_op: str) -> None:
+    """INV-#160-A: cross-product perf grid.
+
+    For every combination of ``{intermediate parent-thread op}`` ×
+    ``{next ML op}``, per-unit wall-clock of the post-intermediate op
+    must stay within 1.5x of a pre-intermediate op-matched baseline.
+    Both runs are the SAME op type on the SAME widget, so subprocess
+    startup / dataset reload / model serialisation overheads cancel
+    out and only catastrophe-level (libgomp pool affinity) slowdowns
+    remain visible in the ratio.
+
+    Test shape:
+
+      [tune primer if next_op == retune]
+      run #1 (clean baseline)            <- baseline_per_unit
+      intermediate parent-main-thread op
+      run #2 (measured)                  <- next_per_unit
+      assert next / baseline < 1.5
+
+    Cells that exercise historical regressions:
+
+    * ``(noop, retune)`` — #154 clean retune path; PR #155 broke this
+      with the spurious ``RetuneSubprocessUnsupportedError``. P-038
+      pins it within 1.2x in the dedicated #156 test; this grid uses
+      the looser 1.5x bound for CI runner variance.
+    * ``(main_thread_predict, retune)`` — #156 catastrophe path;
+      ``w.tune() → w.predict(test_df) → w.retune()`` regressed to ~11x
+      under PR #155 thread fallback. P-038 keeps it within 1.2x; the
+      grid pins the 1.5x catastrophe ceiling.
+    * ``(main_thread_fit_predict, fit)`` — covers a pattern where the
+      user runs lightgbm directly in a cell, then later kicks off a
+      widget Fit that gets stuck on the bound pool.
+    """
+    os.environ.pop("LZW_FORCE_THREAD", None)
+
+    with _real_strategy_patch():
+        w = _make_perf_widget()
+
+        if next_op == "retune":
+            _prime_for_retune_cell(w)
+
+        baseline_per_unit = _OP_RUNNERS[next_op](w)
+
+        # Intermediate parent-main-thread op (or noop). After this point
+        # the libgomp pool may be bound to the parent main thread.
+        _INTERMEDIATES[intermediate](w)
+
+        # Measured run — same op as baseline so fixed overheads amortise
+        # identically and only catastrophe-level slowdowns survive.
+        next_per_unit = _OP_RUNNERS[next_op](w)
+
+    ratio = next_per_unit / baseline_per_unit if baseline_per_unit > 0 else float("inf")
+
+    UPPER_BOUND = 1.5
+    assert ratio < UPPER_BOUND, (
+        f"INV-#160-A regression: next_op={next_op!r} after "
+        f"intermediate={intermediate!r} per-unit wall {next_per_unit:.2f}s "
+        f"is {ratio:.2f}x op-matched clean baseline {baseline_per_unit:.2f}s "
+        f"(bound {UPPER_BOUND}x). "
+        f"This indicates a libgomp pool-affinity catastrophe — most "
+        f"likely a new code path that runs an OpenMP parallel region "
+        f"on the parent main thread before the next ML op fires. See "
+        f"P-039 in HISTORY.md."
+    )

--- a/tests/test_backend_executor.py
+++ b/tests/test_backend_executor.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``BackendExecutor`` (P-039 Phase 3).
+
+The executor is the caller-thread chokepoint for ML library calls.
+Phase 3's behavioral guarantee is narrow: ``run_ml`` invokes the
+provided callable, returns its result (or re-raises), and marks the
+service's libgomp owner state to ``"main"`` for kinds that bind
+libgomp.
+
+Phase 4 (lint rule) will enforce that no ML library call site exists
+outside the executor module — these tests pin the executor's own
+contract so that enforcement has a stable target.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from lizyml_widget.backend_executor import BackendExecutor
+
+
+def _make_executor() -> tuple[BackendExecutor, MagicMock]:
+    svc = MagicMock()
+    svc._libgomp_pool_owner = "unknown"
+
+    def _mark(owner: str) -> None:
+        if svc._libgomp_pool_owner == "main" and owner != "main":
+            return
+        svc._libgomp_pool_owner = owner
+
+    svc.mark_libgomp_owner.side_effect = _mark
+    return BackendExecutor(svc), svc
+
+
+# ---------------------------------------------------------------------------
+# Return value / exception transparency
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlBehavior:
+    def test_returns_callable_result(self) -> None:
+        ex, _ = _make_executor()
+        assert ex.run_ml(lambda: 42, ml_kind="plot_other") == 42
+
+    def test_runs_callable_exactly_once(self) -> None:
+        ex, _ = _make_executor()
+        op = MagicMock(return_value="ok")
+        ex.run_ml(op, ml_kind="predict")
+        assert op.call_count == 1
+
+    def test_propagates_callable_exception(self) -> None:
+        ex, _ = _make_executor()
+
+        def boom() -> None:
+            raise RuntimeError("op failed")
+
+        with pytest.raises(RuntimeError, match="op failed"):
+            ex.run_ml(boom, ml_kind="predict")
+
+
+# ---------------------------------------------------------------------------
+# Owner-state marking — only kinds that bind libgomp transition to "main"
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlOwnerMarking:
+    @pytest.mark.parametrize("kind", ["predict", "explain", "plot_shap"])
+    def test_libgomp_binding_kinds_mark_main(self, kind: str) -> None:
+        ex, svc = _make_executor()
+        ex.run_ml(lambda: None, ml_kind=kind)  # type: ignore[arg-type]
+        svc.mark_libgomp_owner.assert_called_once_with("main")
+
+    def test_plot_other_does_not_mark_main(self) -> None:
+        ex, svc = _make_executor()
+        ex.run_ml(lambda: None, ml_kind="plot_other")
+        svc.mark_libgomp_owner.assert_not_called()
+
+    def test_marks_main_even_when_callable_raises(self) -> None:
+        """LightGBM may have already entered the parallel region by the
+        time the exception unwinds — defensively mark "main" so the
+        next worker-thread Tune/Fit re-routes regardless."""
+        ex, svc = _make_executor()
+
+        def boom() -> None:
+            raise RuntimeError("op failed")
+
+        with pytest.raises(RuntimeError):
+            ex.run_ml(boom, ml_kind="predict")
+
+        svc.mark_libgomp_owner.assert_called_once_with("main")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — multiple threads each get their own state transition.
+# ---------------------------------------------------------------------------
+
+
+class TestRunMlThreadSafety:
+    def test_concurrent_run_ml_calls_all_record_main(self) -> None:
+        ex, svc = _make_executor()
+
+        def work() -> int:
+            ex.run_ml(lambda: 1, ml_kind="predict")
+            return 1
+
+        threads = [threading.Thread(target=work) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Every thread should have hit mark_libgomp_owner("main").
+        assert svc.mark_libgomp_owner.call_count == 20
+        for call in svc.mark_libgomp_owner.call_args_list:
+            assert call.args == ("main",)

--- a/tests/test_ml_call_lint.py
+++ b/tests/test_ml_call_lint.py
@@ -1,0 +1,154 @@
+"""Self-tests for ``scripts/lint_ml_imports.py`` (P-039 Phase 4).
+
+The lint script is the structural enforcement of INV-H: ML library
+imports outside the allowlist must fail CI. These tests pin the
+script's positive and negative paths so a future refactor cannot
+silently break the gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lint_ml_imports.py"
+
+
+@pytest.fixture(scope="module")
+def lint_module() -> object:
+    """Load the lint script as a module so we can call ``main`` and
+    helpers directly without spawning a subprocess."""
+    spec = importlib.util.spec_from_file_location("lint_ml_imports", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["lint_ml_imports"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Detection regex — verifies the patterns the spec calls out.
+# ---------------------------------------------------------------------------
+
+
+class TestImportPattern:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "import lightgbm",
+            "import lightgbm as lgb",
+            "from lightgbm import Booster",
+            "from lightgbm.sklearn import LGBMClassifier",
+            "import shap",
+            "from shap import TreeExplainer",
+            "import xgboost",
+            "from xgboost import Booster",
+            "import lizyml",
+            "from lizyml import Model",
+            "from lizyml.core import something",
+            "    import lightgbm  # nested under indent",
+        ],
+    )
+    def test_matches_disallowed_imports(self, lint_module: object, line: str) -> None:
+        assert lint_module._IMPORT_PATTERN.match(line), (  # type: ignore[attr-defined]
+            f"Pattern should match: {line!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "import os",
+            "from typing import Any",
+            "import lightgbm_helper",  # similar prefix, NOT lightgbm itself
+            "from lightgbmlike import x",  # similar prefix, NOT lightgbm itself
+            "x = 'import lightgbm'",  # string content, not actual import
+            "# import lightgbm  # comment-only is fine via NOQA path",
+        ],
+    )
+    def test_does_not_match_unrelated_lines(self, lint_module: object, line: str) -> None:
+        # NOTE: a leading ``#`` comment line is technically not an import,
+        # so the regex does not match it; the NOQA tag is for actual
+        # imports that need the escape hatch.
+        if line.lstrip().startswith("#"):
+            assert not lint_module._IMPORT_PATTERN.match(line)  # type: ignore[attr-defined]
+            return
+        assert not lint_module._IMPORT_PATTERN.match(line), (  # type: ignore[attr-defined]
+            f"Pattern should NOT match: {line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _scan_file — the per-file driver
+# ---------------------------------------------------------------------------
+
+
+class TestScanFile:
+    def test_clean_file_yields_no_violations(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("import os\nfrom typing import Any\n")
+        assert lint_module._scan_file(f) == []  # type: ignore[attr-defined]
+
+    def test_dirty_file_yields_violations(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "dirty.py"
+        f.write_text("import os\nimport lightgbm\nfrom shap import TreeExplainer\n")
+        violations = lint_module._scan_file(f)  # type: ignore[attr-defined]
+        assert len(violations) == 2
+        assert violations[0][0] == 2
+        assert "lightgbm" in violations[0][1]
+        assert violations[1][0] == 3
+        assert "shap" in violations[1][1]
+
+    def test_noqa_tag_skips_violation(self, tmp_path: Path, lint_module: object) -> None:
+        f = tmp_path / "noqa.py"
+        f.write_text("import os\nimport lightgbm  # noqa: ML-CALL — needed for env detection\n")
+        assert lint_module._scan_file(f) == []  # type: ignore[attr-defined]
+
+    def test_noqa_only_applies_to_tagged_line(self, tmp_path: Path, lint_module: object) -> None:
+        """A ``# noqa: ML-CALL`` on one line must NOT cover an
+        un-tagged import on a different line."""
+        f = tmp_path / "mixed.py"
+        f.write_text("import lightgbm  # noqa: ML-CALL — env detection only\nimport shap\n")
+        violations = lint_module._scan_file(f)  # type: ignore[attr-defined]
+        assert len(violations) == 1
+        assert "shap" in violations[0][1]
+
+
+# ---------------------------------------------------------------------------
+# main — repo-level integration
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_repo_passes_lint_today(self, lint_module: object) -> None:
+        """The repo at HEAD must be clean — every legitimate ML-using
+        module is in the allowlist."""
+        rc = lint_module.main()  # type: ignore[attr-defined]
+        assert rc == 0, "P-039 Phase 4 lint must pass on a clean develop"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist sanity — every allowlisted file actually exists.
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistSanity:
+    def test_every_allowlisted_file_exists(self, lint_module: object) -> None:
+        src = REPO_ROOT / "src" / "lizyml_widget"
+        for fname in lint_module.ALLOWLISTED_FILES:  # type: ignore[attr-defined]
+            assert (src / fname).is_file(), (
+                f"Allowlisted file {fname!r} does not exist in {src}; "
+                f"a refactor renamed/removed it. Update the lint allowlist."
+            )
+
+    def test_allowlist_does_not_include_widget_or_service(self, lint_module: object) -> None:
+        """Defensive assertion: a future refactor must not allow
+        ``widget.py`` / ``service.py`` to import ML libraries — that
+        would defeat the executor funnel."""
+        assert "widget.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "service.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "widget_actions.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]
+        assert "job_runner.py" not in lint_module.ALLOWLISTED_FILES  # type: ignore[attr-defined]


### PR DESCRIPTION
release: v0.10.0 — LizyML-Widget 0.10.0

## Release notes


### Added
- **CI gate: ML library imports outside the BackendExecutor / Adapter
  layer fail CI** (P-039 Phase 4 / INV-H,
  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
  New ``scripts/lint_ml_imports.py`` walks every ``.py`` file under
  ``src/lizyml_widget/`` and fails (exit 1) on any import of
  ``lightgbm`` / ``shap`` / ``xgboost`` / ``lizyml`` that is not in
  the allowlist (``adapter.py`` / ``adapter_*.py`` / ``backend_executor.py``
  / ``_subprocess_entry.py`` / ``openmp_detect.py``). The CI quality
  job runs the lint between mypy and pytest. ``# noqa: ML-CALL``
  on the offending line is the documented escape hatch — the
  surrounding docstring / PR body must explain the exception.
  CLAUDE.md §8 codifies the rule and explicitly tags new caller-
  thread ML call sites as a change-gate-required category. With
  Phase 4, P-039 is fully landed: catastrophe class is now blocked
  by (a) Phase 1 perf-grid catching it on a PR, (b) Phase 2 runtime
  guard auto-routing it on production, (c) Phase 3 funnel
  centralising the marking, and (d) Phase 4 lint blocking new call
  sites at PR review. Issue #160 closes when this PR merges.
- **BackendExecutor caller-thread ML library funnel** (P-039 Phase 3,
  [#160](https://github.com/nbx-liz/2LizyML-Widget/issues/160)).
  New module ``src/lizyml_widget/backend_executor.py`` exposes
  ``BackendExecutor.run_ml(op, *, ml_kind)`` — a single chokepoint for
  every caller-thread ML library call. ``WidgetService.predict``,
  ``WidgetService.get_plot``, and ``WidgetService.get_inference_plot``
  now route through ``self._executor.run_ml(...)`` instead of marking
  ``_libgomp_pool_owner`` directly. ``ml_kind`` categorises the call
  (``predict`` / ``explain`` / ``plot_shap`` / ``plot_other``) so the
  executor knows which calls bind libgomp pool affinity and which do
  not. This consolidates Phase 2's owner-state marking into one place
  and sets up Phase 4 (lint rule) to enforce "no ML library call
  outside the executor" as a structural invariant. No behavioural
  change for end users — predict / plot semantics are unchanged.
- **Runtime guard: parent-main-thread libgomp binding auto-routes
  Tune/Fit/Retune to subprocess** (P-039 Phase 2 / INV-G,
  [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
  ``WidgetService`` now tracks ``_libgomp_pool_owner`` (one of
  ``"unknown" / "subprocess" / "worker" / "main"``). Calls that run an
  OpenMP parallel region on the caller thread —
  ``WidgetService.predict``, ``WidgetService.get_plot("feature-importance-shap")``,
  ``WidgetService.get_inference_plot(..., "shap-summary")`` — mark the
  state ``"main"``. ``ThreadJobRunner`` / ``SubprocessJobRunner`` mark
  ``"worker"`` / ``"subprocess"`` on successful completion.
  ``LizyWidget._run_job`` reads the state and re-routes a thread-strategy
  job to subprocess when the state is ``"main"`` (with a structured WARN
  log), since GCC libgomp's pool affinity (#108494) would otherwise
  deliver a 10-50x slowdown for the next worker-thread call.
  ``LZW_FORCE_THREAD=1`` is honored as an explicit user opt-out — only
  WARN, no auto-reroute. The state is process-sticky: ``load_data``
  does NOT reset it because the libgomp bind in this process does not
  unbind on data reload. BLUEPRINT.md §6.4 declares INV-G with the
  state-transition table.
- **CI: `libgomp-perf` job runs a parameterised libgomp perf regression
  grid on every PR** (P-039 Phase 1, [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160)).
  The libgomp pool-affinity / "CPU core usage decreases" regression has
  reoccurred four times in this codebase
  ([#147](https://github.com/nbx-liz/LizyML-Widget/issues/147) /
  [#154](https://github.com/nbx-liz/LizyML-Widget/issues/154) /
  [#156](https://github.com/nbx-liz/LizyML-Widget/issues/156) /
  [#158](https://github.com/nbx-liz/LizyML-Widget/issues/158)). Each
  prior fix only pinned the *specific* path observed — a future code
  change could silently re-introduce the same class of 10-50x slowdown
  via a new ML call site. P-039 Phase 1 closes that gap by adding a
  dedicated CI job that runs ``tests/regression/test_reg_160_libgomp_perf_grid.py``
  on ``ubuntu-latest`` (libgomp by default). The grid covers the
  cross-product ``{intermediate parent-thread op ∈ noop /
  main_thread_predict / main_thread_fit_predict}`` × ``{next ML op ∈
  retune / fit}`` and asserts INV-#160-A: per-unit wall-clock of every
  cell stays within 1.5x of an op-matched clean baseline. The grid uses
  small datasets (5k × 20, 2 trials) so the job fits the CI budget;
  catastrophe is not dataset-size dependent so the 1.5x bound retains
  its expressiveness on small data. Phases 2-4 (runtime INV-G guard,
  ``BackendExecutor`` funnel, change-gate codification) are tracked
  under [#160](https://github.com/nbx-liz/LizyML-Widget/issues/160) and
  ship in follow-up PRs.



## Test plan

- [x] All P-039 Phase 1-4 PRs merged via CI green (PRs #162 #163 #164 #165)
- [x] CHANGELOG cut PR merged (#166)
- [x] develop tip clean: ruff / format / mypy / ml-lint / pytest (1043 fast + 6 slow) all pass
- [ ] CI green on this release PR
- [ ] After merge: auto-release.yml fires, v0.10.0 tag created, GitHub Release published, PyPI publish succeeds

**Note**: merge with **merge commit** (NOT squash) so ``auto-release.yml`` detects the develop→main merge and fires. The previous v0.9.0 release used the same flow.
