### PR TITLE
ci: guard against uv.lock drift with uv lock --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
           cache: pnpm
           cache-dependency-path: js/pnpm-lock.yaml
 
+      - name: Verify uv.lock is in sync with pyproject.toml
+        # Guard against the silent dependency-drift class: dependabot pip
+        # bumps update pyproject.toml but do NOT regenerate uv.lock, and
+        # `uv sync --frozen` tolerates a stale lock — so without this check
+        # CI can run against an out-of-date dependency set. This actually
+        # happened pre-v0.10.1 (lizyml pinned <0.13 in the lock while the
+        # manifest already said <0.17). `uv lock --check` fails when the
+        # lockfile no longer matches the manifest, forcing a regen at PR time.
+        run: uv lock --check
+
       - name: Install Python dependencies
         run: uv sync --frozen --dev
 


### PR DESCRIPTION
## Summary
Add a `uv lock --check` step to the CI quality job so a lockfile that no longer matches `pyproject.toml` fails the PR instead of being silently tolerated by `uv sync --frozen`.

## Motivation
During the v0.10.1 release prep we found `uv.lock` still pinned the `lizyml` requirement at `<0.13` even though dependabot (#176) had widened `pyproject.toml` to `<0.17`. Because every CI job uses `uv sync --frozen --dev` (which uses the lock as-is without checking freshness), CI had been running against a stale dependency set with no signal. Dependabot's pip ecosystem updates the manifest but does not regenerate `uv.lock`.

`uv lock --check` is non-destructive (resolves and verifies, never writes) and exits non-zero on drift, forcing the lock to be regenerated at PR time.

## Scope
- CI-only hardening; no runtime / API / build-method change. Not change-gate-required (test/CI-gate addition).
- Placed once in the `quality` matrix job — enough to block any PR to main/develop.

## Test plan
- [x] `uv lock --check` passes locally on current develop (lock in sync post-v0.10.1)
- [ ] CI green on this PR
- [ ] (manual follow-up) confirm a future dependabot pip PR that leaves uv.lock stale now goes red