### PR TITLE
feat(policy): promote managed Git safeguards

### DIFF
--- a/.githooks/artifact-language.py
+++ b/.githooks/artifact-language.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Validate English-only commit and GitHub artifact boundaries for Issue #22."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+MAX_INPUT_BYTES = 2 * 1024 * 1024
+JAPANESE = re.compile(
+    r"[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uff00-\uffef]"
+)
+CONVENTIONAL_SUBJECT = re.compile(
+    r"[a-z][a-z0-9-]*(?:\([^()\s]+\))?!?: [^\r\n]+"
+)
+PULL_REQUEST_ACTIONS = {"opened", "edited", "reopened", "synchronize"}
+ISSUE_ACTIONS = {"opened", "edited", "reopened"}
+COMMENT_ACTIONS = {"created", "edited"}
+FULL_SHA = re.compile(r"[0-9a-fA-F]{40}")
+
+
+class PolicyError(RuntimeError):
+    """One selected artifact boundary is malformed or violates policy."""
+
+
+def require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PolicyError(f"{label} must be a JSON object")
+    return value
+
+
+def require_string(value: Any, label: str, *, optional: bool = False) -> str:
+    if optional and value is None:
+        return ""
+    if not isinstance(value, str):
+        raise PolicyError(f"{label} must be a string")
+    return value
+
+
+def read_utf8(path: pathlib.Path, label: str) -> str:
+    try:
+        if not path.is_file():
+            raise PolicyError(f"{label} is missing or not a regular file")
+        if path.stat().st_size > MAX_INPUT_BYTES:
+            raise PolicyError(f"{label} exceeds {MAX_INPUT_BYTES} bytes")
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise PolicyError(f"{label} is not UTF-8") from exc
+    except OSError as exc:
+        raise PolicyError(f"cannot read {label}: {exc}") from exc
+
+
+def validate_english(label: str, text: str) -> None:
+    match = JAPANESE.search(text)
+    if match:
+        raise PolicyError(
+            f"{label} contains a disallowed non-English character "
+            f"U+{ord(match.group(0)):04X}"
+        )
+
+
+def validate_commit_message(message: str, label: str = "commit message") -> None:
+    # The hook receives a proposed message while GitHub supplies the persisted
+    # message. Explicit `-m '# ...'` paragraphs are persisted even though they
+    # look like editor-template comments, so both language and subject checks
+    # must cover the raw message rather than a guessed cleanup post-image.
+    validate_english(label, message)
+    payload = message.strip()
+    if not payload:
+        raise PolicyError(f"{label} is empty")
+    subject = payload.splitlines()[0]
+    if subject.startswith("Merge ") or subject.startswith('Revert "'):
+        return
+    if CONVENTIONAL_SUBJECT.fullmatch(subject) is None:
+        raise PolicyError(
+            f"{label} subject is not Conventional Commits form: "
+            "<type>(<optional-scope>): <subject>"
+        )
+
+
+def validate_field(container: dict[str, Any], key: str, label: str,
+                   *, optional: bool = False) -> None:
+    if key not in container:
+        raise PolicyError(f"{label} is missing")
+    text = require_string(container.get(key), label, optional=optional)
+    validate_english(label, text)
+
+
+def commit_messages(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise PolicyError(f"{label} must be a JSON array")
+    messages: list[str] = []
+    for index, row in enumerate(value):
+        commit = require_object(row, f"{label}[{index}]").get("commit")
+        commit_object = require_object(commit, f"{label}[{index}].commit")
+        messages.append(
+            require_string(
+                commit_object.get("message"), f"{label}[{index}].commit.message"
+            )
+        )
+    return messages
+
+
+def fetch_pull_request_commits(event: dict[str, Any]) -> list[dict[str, Any]]:
+    repository = require_object(event.get("repository"), "repository")
+    full_name = require_string(repository.get("full_name"), "repository.full_name")
+    pull_request = require_object(event.get("pull_request"), "pull_request")
+    number = pull_request.get("number")
+    if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+        raise PolicyError("pull_request.number must be a positive integer")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    if not token:
+        raise PolicyError("GITHUB_TOKEN is required to inspect pull request commits")
+    rows: list[dict[str, Any]] = []
+    for page in range(1, 101):
+        encoded_repo = urllib.parse.quote(full_name, safe="/")
+        url = (
+            f"{api}/repos/{encoded_repo}/pulls/{number}/commits"
+            f"?per_page=100&page={page}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read(MAX_INPUT_BYTES + 1)
+        except (OSError, urllib.error.URLError) as exc:
+            raise PolicyError(f"cannot fetch pull request commits: {exc}") from exc
+        if len(raw) > MAX_INPUT_BYTES:
+            raise PolicyError("pull request commit response exceeds the input cap")
+        try:
+            page_rows = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PolicyError("pull request commit response is not valid UTF-8 JSON") from exc
+        if not isinstance(page_rows, list):
+            raise PolicyError("pull request commit response must be a JSON array")
+        rows.extend(page_rows)
+        if len(page_rows) < 100:
+            return rows
+    raise PolicyError("pull request commit pagination exceeds 100 pages")
+
+
+def fetch_push_commits(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fetch the complete pushed range from the webhook's before/after SHAs."""
+    repository = require_object(event.get("repository"), "repository")
+    full_name = require_string(repository.get("full_name"), "repository.full_name")
+    before = require_string(event.get("before"), "before")
+    after = require_string(event.get("after"), "after")
+    for label, value in (("before", before), ("after", after)):
+        if FULL_SHA.fullmatch(value) is None:
+            raise PolicyError(f"{label} must be a 40-character commit SHA")
+    if event.get("created") is not False or event.get("deleted") is not False:
+        raise PolicyError("default-branch creation or deletion requires manual review")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    if not token:
+        raise PolicyError("GITHUB_TOKEN is required to inspect pushed commits")
+    encoded_repo = urllib.parse.quote(full_name, safe="/")
+    encoded_before = urllib.parse.quote(before, safe="")
+    encoded_after = urllib.parse.quote(after, safe="")
+    rows: list[dict[str, Any]] = []
+    expected_total: int | None = None
+    seen: set[str] = set()
+    for page in range(1, 101):
+        url = (
+            f"{api}/repos/{encoded_repo}/compare/{encoded_before}...{encoded_after}"
+            f"?per_page=100&page={page}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read(MAX_INPUT_BYTES + 1)
+        except (OSError, urllib.error.URLError) as exc:
+            raise PolicyError(f"cannot fetch pushed commits: {exc}") from exc
+        if len(raw) > MAX_INPUT_BYTES:
+            raise PolicyError("push comparison response exceeds the input cap")
+        try:
+            comparison = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PolicyError("push comparison response is not valid UTF-8 JSON") from exc
+        comparison_object = require_object(comparison, "push comparison response")
+        total = comparison_object.get("total_commits")
+        if isinstance(total, bool) or not isinstance(total, int) or total < 1:
+            raise PolicyError(
+                "push comparison total_commits must be a positive integer"
+            )
+        if expected_total is None:
+            expected_total = total
+        elif total != expected_total:
+            raise PolicyError("push comparison total changed during pagination")
+        page_rows = comparison_object.get("commits")
+        if not isinstance(page_rows, list):
+            raise PolicyError("push comparison commits must be a JSON array")
+        if not page_rows:
+            raise PolicyError(
+                f"push comparison is incomplete: total={expected_total}, rows={len(rows)}"
+            )
+        for index, row in enumerate(page_rows):
+            commit = require_object(row, f"push comparison commits[{index}]")
+            sha = require_string(
+                commit.get("sha"), f"push comparison commits[{index}].sha"
+            )
+            if FULL_SHA.fullmatch(sha) is None:
+                raise PolicyError(
+                    f"push comparison commits[{index}].sha must be a 40-character SHA"
+                )
+            if sha in seen:
+                raise PolicyError(f"push comparison repeats commit {sha}")
+            seen.add(sha)
+            rows.append(commit)
+        if len(rows) == expected_total:
+            final_sha = require_string(
+                rows[-1].get("sha"), "push comparison final commit.sha"
+            )
+            if final_sha.lower() != after.lower():
+                raise PolicyError(
+                    "push comparison does not terminate at the webhook after SHA"
+                )
+            return rows
+        if len(rows) > expected_total:
+            raise PolicyError(
+                f"push comparison exceeds total: total={expected_total}, rows={len(rows)}"
+            )
+    raise PolicyError("push comparison pagination exceeds 100 pages")
+
+
+def validate_event_value(
+    event_name: str,
+    event: dict[str, Any],
+    *,
+    pull_request_commits: Any | None = None,
+    push_commits: Any | None = None,
+) -> bool:
+    """Validate one selected event; return False only for a non-default push."""
+    action = event.get("action")
+    if event_name == "pull_request":
+        if action not in PULL_REQUEST_ACTIONS:
+            raise PolicyError(f"unsupported pull_request action: {action!r}")
+        pull_request = require_object(event.get("pull_request"), "pull_request")
+        validate_field(pull_request, "title", "pull_request.title")
+        validate_field(pull_request, "body", "pull_request.body", optional=True)
+        rows = (
+            fetch_pull_request_commits(event)
+            if pull_request_commits is None else pull_request_commits
+        )
+        for index, message in enumerate(commit_messages(rows, "pull_request.commits")):
+            validate_commit_message(message, f"pull_request.commits[{index}].message")
+        return True
+    if event_name == "issues":
+        if action not in ISSUE_ACTIONS:
+            raise PolicyError(f"unsupported issues action: {action!r}")
+        issue = require_object(event.get("issue"), "issue")
+        validate_field(issue, "title", "issue.title")
+        validate_field(issue, "body", "issue.body", optional=True)
+        return True
+    if event_name == "issue_comment":
+        if action not in COMMENT_ACTIONS:
+            raise PolicyError(f"unsupported issue_comment action: {action!r}")
+        comment = require_object(event.get("comment"), "comment")
+        validate_field(comment, "body", "comment.body")
+        return True
+    if event_name == "push":
+        repository = require_object(event.get("repository"), "repository")
+        default_branch = require_string(
+            repository.get("default_branch"), "repository.default_branch"
+        )
+        ref = require_string(event.get("ref"), "ref")
+        if ref != f"refs/heads/{default_branch}":
+            return False
+        rows = fetch_push_commits(event) if push_commits is None else push_commits
+        for index, message in enumerate(commit_messages(rows, "push.commits")):
+            validate_commit_message(message, f"push.commits[{index}].message")
+        return True
+    raise PolicyError(f"unsupported GitHub event: {event_name!r}")
+
+
+def self_test() -> None:
+    validate_commit_message("fix(test): valid English message\n")
+    validate_commit_message("Merge branch 'feature/example'\n")
+    validate_commit_message('Revert "fix(test): example"\n\nThis reverts commit abc.\n')
+
+    def rejected(callable_object: Any, contains: str) -> None:
+        try:
+            callable_object()
+        except PolicyError as exc:
+            if contains not in str(exc):
+                raise AssertionError(f"{contains!r} absent from {str(exc)!r}") from exc
+        else:
+            raise AssertionError(f"expected PolicyError containing {contains!r}")
+
+    rejected(lambda: validate_commit_message("fix(test): 日本語\n"), "commit message")
+    rejected(lambda: validate_commit_message("not conventional\n"), "Conventional")
+    pr = {
+        "action": "opened",
+        "pull_request": {"number": 1, "title": "English PR", "body": "English body"},
+        "repository": {"full_name": "o/r"},
+    }
+    commits = [{"commit": {"message": "fix(test): English commit"}}]
+    validate_event_value("pull_request", pr, pull_request_commits=commits)
+    for field in ("title", "body"):
+        mutated = json.loads(json.dumps(pr))
+        mutated["pull_request"][field] = "日本語"
+        rejected(
+            lambda value=mutated: validate_event_value(
+                "pull_request", value, pull_request_commits=commits
+            ),
+            f"pull_request.{field}",
+        )
+    rejected(
+        lambda: validate_event_value(
+            "pull_request", pr,
+            pull_request_commits=[{"commit": {"message": "fix(test): 日本語"}}],
+        ),
+        "pull_request.commits[0].message",
+    )
+    issue = {"action": "opened", "issue": {"title": "English", "body": None}}
+    validate_event_value("issues", issue)
+    issue["issue"]["body"] = "日本語"
+    rejected(lambda: validate_event_value("issues", issue), "issue.body")
+    comment = {"action": "created", "comment": {"body": "English"}}
+    validate_event_value("issue_comment", comment)
+    comment["comment"]["body"] = "日本語"
+    rejected(lambda: validate_event_value("issue_comment", comment), "comment.body")
+    push = {
+        "ref": "refs/heads/main",
+        "repository": {"default_branch": "main"},
+    }
+    push_rows = [{"commit": {"message": "fix(test): English"}}]
+    validate_event_value("push", push, push_commits=push_rows)
+    push_rows[0]["commit"]["message"] = "fix(test): 日本語"
+    rejected(
+        lambda: validate_event_value("push", push, push_commits=push_rows),
+        "push.commits[0].message",
+    )
+    push["ref"] = "refs/heads/feature/example"
+    if validate_event_value("push", push, push_commits=push_rows):
+        raise AssertionError("a non-default push must be non-applicable")
+    print("artifact-language: self-test passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    commit_parser = subparsers.add_parser("commit-message")
+    commit_parser.add_argument("--file", type=pathlib.Path, required=True)
+    event_parser = subparsers.add_parser("github-event")
+    event_parser.add_argument("--event-name", required=True)
+    event_parser.add_argument("--event-path", type=pathlib.Path, required=True)
+    event_parser.add_argument("--pr-commits-file", type=pathlib.Path)
+    event_parser.add_argument("--push-commits-file", type=pathlib.Path)
+    subparsers.add_parser("self-test")
+    args = parser.parse_args()
+    try:
+        if args.command == "commit-message":
+            validate_commit_message(read_utf8(args.file, "commit message file"))
+            print("artifact-language: commit message accepted")
+        elif args.command == "github-event":
+            try:
+                event = json.loads(read_utf8(args.event_path, "GitHub event payload"))
+            except json.JSONDecodeError as exc:
+                raise PolicyError(f"GitHub event payload is invalid JSON: {exc}") from exc
+            event_object = require_object(event, "GitHub event payload")
+            pr_fixture = None
+            if args.pr_commits_file:
+                try:
+                    pr_fixture = json.loads(
+                        read_utf8(args.pr_commits_file, "pull request commits fixture")
+                    )
+                except json.JSONDecodeError as exc:
+                    raise PolicyError(
+                        f"pull request commits fixture is invalid JSON: {exc}"
+                    ) from exc
+            push_fixture = None
+            if args.push_commits_file:
+                try:
+                    push_fixture = json.loads(
+                        read_utf8(args.push_commits_file, "push commits fixture")
+                    )
+                except json.JSONDecodeError as exc:
+                    raise PolicyError(
+                        f"push commits fixture is invalid JSON: {exc}"
+                    ) from exc
+            applicable = validate_event_value(
+                args.event_name,
+                event_object,
+                pull_request_commits=pr_fixture,
+                push_commits=push_fixture,
+            )
+            print(
+                "artifact-language: accepted"
+                if applicable else "artifact-language: not-applicable"
+            )
+        else:
+            self_test()
+        return 0
+    except PolicyError as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+VALIDATOR="$HOOK_DIR/artifact-language.py"
+
+if [ "$#" -ne 1 ]; then
+  echo "BLOCKED: commit-msg requires exactly one message-file argument" >&2
+  exit 1
+fi
+if [ ! -f "$VALIDATOR" ]; then
+  echo "BLOCKED: artifact-language validator is missing from $HOOK_DIR" >&2
+  exit 1
+fi
+exec python3 "$VALIDATOR" commit-message --file "$1"

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+# install.sh — install this repository's branch-protection hooks into a clone's
+# own hooks directory, then prove that Git actually runs them.
+#
+# Usage: bash .githooks/install.sh [--preserve-pre-commit] [<target repository>]
+#
+# Why a copy instead of `git config core.hooksPath .githooks`: that setting points
+# Git at a directory **inside the worktree**, so the gate is content rather than
+# configuration and disappears the moment the worktree does not contain it — a
+# `git sparse-checkout` set that excludes it, a checkout of any branch predating
+# it, or a detached checkout of an older commit. Git runs no hook and prints no
+# diagnostic in that state, so protection vanishes without a word (DC1). The
+# hooks directory under `.git` is not touched by checkout, which is the whole
+# reason Git puts hooks there.
+#
+# Why this script lives in `.githooks/` rather than `scripts/`: `scripts` is a
+# managed root deployed wholesale to the live `~/.claude` tree. This installer is
+# repository tooling with no business being deployed, and #122 pins the exact
+# production delta it would otherwise perturb.
+#
+# **This script accepts one state and refuses every other.** It does not migrate
+# settings, merge with a foreign hook, or repair a destination it does not
+# recognise. Three adversarial rounds produced escapes exclusively from branches
+# that tried to be accommodating: a `--unset` that cleared one scope while
+# another still overrode it and reported success; an `rm -rf` that deleted the
+# tracked source when `.git/hooks` was a symlink to it; a backup that a second
+# run overwrote. The input here is a whole repository's configuration and layout,
+# which is an open-ended space — so the way to be safe in it is to keep the set
+# of accepted states small and say precisely what to do about the rest.
+set -euo pipefail
+
+SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SOURCE_ROOT="$(dirname "$SOURCE")"
+MODE="native"
+if [ "${1:-}" = "--preserve-pre-commit" ]; then
+  MODE="framework"
+  shift
+fi
+if [ "$#" -gt 1 ]; then
+  echo "BLOCKED: usage: bash .githooks/install.sh [--preserve-pre-commit] [<target repository>]" >&2
+  exit 1
+fi
+TARGET_REPO="${1:-$SOURCE_ROOT}"
+
+HOOK_FILES="commit-msg pre-commit pre-merge-commit pre-push"
+INSTALL_HOOK_FILES="$HOOK_FILES"
+if [ "$MODE" = "framework" ]; then
+  INSTALL_HOOK_FILES="commit-msg pre-merge-commit pre-push"
+fi
+LIB_FILES="artifact-language.py protected-refs.sh"
+MARKER="managed-by: claude-code-config"
+FRAMEWORK_CONFIG_MARKER="managed-by: claude-code-config (.githooks/pre-commit runs through pre-commit)"
+FRAMEWORK_PROBE_NAME="protected local commit (claude-code-config)"
+FRAMEWORK_PROBE_ID="claude-code-config-protected-commit"
+
+die() { echo "BLOCKED: $*" >&2; exit 1; }
+
+for name in $HOOK_FILES $LIB_FILES; do
+  [ -f "$SOURCE/$name" ] || die "missing source hook: $SOURCE/$name"
+  # The marker is how an installed file is recognised as ours on the next run, so
+  # a source file that has lost it installs once and is then refused forever as a
+  # stranger's hook — with remediation advice that makes no sense for a file this
+  # script wrote. Check the source side too; the boundary has to be symmetric.
+  grep -q "$MARKER" "$SOURCE/$name" \
+    || die "$SOURCE/$name no longer carries the '$MARKER' marker line; restore it before installing"
+done
+
+git -C "$TARGET_REPO" rev-parse --git-dir >/dev/null 2>&1 \
+  || die "not a git repository: $TARGET_REPO"
+
+DEST="$(git -C "$TARGET_REPO" rev-parse --path-format=absolute --git-common-dir)/hooks"
+
+# --- core.hooksPath must not point away from the destination -----------------
+# It overrides the hooks directory completely, so a value pointing elsewhere
+# makes this install inert (DC4). Presence is decided by `git config --get`'s
+# exit status, never by the emptiness of its output: `core.hooksPath = ""` is
+# *set*, prints nothing, and disables every hook — a state in which a string test
+# reports "unset" while no gate runs at all.
+#
+# A value that resolves to the destination itself is fine and is left alone:
+# refusing it would block the reinstall that CONTRIBUTING.md tells everyone to
+# run after editing a hook, in a clone where the gate demonstrably works.
+#
+# The origins are reported by `git config --show-origin`, which names the file
+# that actually supplies each value. Probing the four file scopes instead gets
+# this wrong in both directions: `--worktree` falls back to the local file when
+# `extensions.worktreeConfig` is off (so an ordinary local value is reported as
+# living in two scopes, and the `--worktree --unset-all` remedy edits a file the
+# operator was not told about), and a value arriving through `include` /
+# `includeIf` or `GIT_CONFIG_COUNT` lives in no scope at all.
+if git -C "$TARGET_REPO" config --get core.hooksPath >/dev/null 2>&1; then
+  effective_now="$(git -C "$TARGET_REPO" rev-parse --path-format=absolute --git-path hooks 2>/dev/null || true)"
+  if [ "$effective_now" != "$DEST" ]; then
+    echo "BLOCKED: core.hooksPath sends Git to ${effective_now:-an unusable path}, not $DEST, so this install would not run." >&2
+    echo "It is set here:" >&2
+    git -C "$TARGET_REPO" config --show-origin --get-all core.hooksPath 2>/dev/null |
+      while IFS="$(printf '\t')" read -r origin value; do
+        case "$value" in
+          *[![:space:]]*) ;;
+          *) value="(the empty string, which disables every hook)" ;;
+        esac
+        case "$origin" in
+          file:*) printf '  %s = %s\n' "${origin#file:}" "$value" >&2 ;;
+          *)      printf '  %s = %s (not a config file)\n' "$origin" "$value" >&2 ;;
+        esac
+      done
+    # The first remedy is local and reversible. Clearing the value is offered
+    # second and with a warning, because a global `core.hooksPath` is how husky
+    # and the pre-commit framework install themselves: unsetting it here disables
+    # the gate in every other repository on the machine, silently.
+    echo "Point this clone at its own hooks directory — this leaves every other repository alone:" >&2
+    echo "  git -C '$TARGET_REPO' config core.hooksPath '$DEST'" >&2
+    echo "then re-run this installer." >&2
+    echo "Clearing the entries above works too, but a value in a shared config file is what your" >&2
+    echo "other repositories use (husky, pre-commit): git config --file <path> --unset-all core.hooksPath" >&2
+    exit 1
+  fi
+fi
+
+# --- refuse a destination that is not plainly ours --------------------------
+# `.git/hooks` symlinked to the worktree's `.githooks` is the pre-`core.hooksPath`
+# idiom for exactly this job, and it makes destination and source the same files:
+# a copy through it would rewrite the tracked source, and any cleanup would delete
+# it.
+if [ -L "$DEST" ]; then
+  die "$DEST is a symbolic link. Replace it with a real directory (the hooks are copied, not linked), then re-run."
+fi
+if [ -d "$DEST" ] && [ "$(cd "$DEST" && pwd -P)" = "$SOURCE" ]; then
+  die "$DEST resolves to the source directory itself. Nothing to install; remove that arrangement first."
+fi
+
+# In framework-preserving mode, `.git/hooks/pre-commit` belongs to pre-commit.
+# Validate the complete accepted state before writing any native slot: the
+# configuration is tracked and explicitly names our integration, while the
+# effective hook is a plain executable generated by pre-commit. The generated
+# hook's digest is pinned across the install below so this mode cannot quietly
+# replace or rewrite the framework it promises to preserve.
+framework_digest=""
+if [ "$MODE" = "framework" ]; then
+  config="$TARGET_REPO/.pre-commit-config.yaml"
+  git -C "$TARGET_REPO" cat-file -e HEAD:.pre-commit-config.yaml 2>/dev/null \
+    || die "$config must be tracked in HEAD before framework-preserving installation"
+  [ -f "$config" ] && [ ! -L "$config" ] \
+    || die "$config must be a plain regular file"
+  rc=0
+  git -C "$TARGET_REPO" diff --cached --quiet -- || rc=$?
+  case "$rc" in
+    0) ;;
+    1) die "the index must be clean before the pre-commit framework probe" ;;
+    *) die "Git could not verify that the index is clean (exit $rc)" ;;
+  esac
+  rc=0
+  git -C "$TARGET_REPO" diff --quiet -- .pre-commit-config.yaml || rc=$?
+  case "$rc" in
+    0) ;;
+    1) die "$config must match its indexed and HEAD version" ;;
+    *) die "Git could not verify $config against the index (exit $rc)" ;;
+  esac
+  grep -Fq "$FRAMEWORK_CONFIG_MARKER" "$config" \
+    || die "$config does not carry the reviewed framework integration marker"
+  pre_commit_command="$(command -v pre-commit 2>/dev/null)" \
+    || die "pre-commit must be on PATH for framework-preserving installation; run this installer through the repository's environment"
+  case "$pre_commit_command" in
+    /*) ;;
+    *) die "pre-commit must resolve to an absolute executable path, not $pre_commit_command" ;;
+  esac
+  [ -x "$pre_commit_command" ] \
+    || die "$pre_commit_command is not an executable pre-commit command"
+  pre_commit_version="$("$pre_commit_command" --version 2>/dev/null)" \
+    || die "$pre_commit_command could not report its version"
+  case "$pre_commit_version" in
+    "pre-commit "*) ;;
+    *) die "$pre_commit_command did not identify itself as pre-commit" ;;
+  esac
+  pre_commit_python="$(command -v python3 2>/dev/null)" \
+    || die "python3 from the repository environment is required to inspect the pre-commit configuration"
+  case "$pre_commit_python" in
+    /*) ;;
+    *) die "python3 must resolve to an absolute executable path, not $pre_commit_python" ;;
+  esac
+  semantic_rc=0
+  semantic_out="$(
+    "$pre_commit_python" - "$config" "$FRAMEWORK_PROBE_ID" 2>&1 <<'PY'
+from __future__ import annotations
+
+import sys
+
+from pre_commit.clientlib import load_config
+
+
+config_path, required_id = sys.argv[1:]
+try:
+    config = load_config(config_path)
+except Exception as error:
+    print(f"pre-commit could not load the committed configuration: {error}")
+    raise SystemExit(1)
+
+matches = []
+for repository in config["repos"]:
+    for hook in repository.get("hooks", ()):
+        if hook.get("id") == required_id:
+            matches.append((repository.get("repo"), hook))
+
+if len(matches) != 1:
+    print(f"expected exactly one {required_id!r} hook, found {len(matches)}")
+    raise SystemExit(1)
+
+repository, hook = matches[0]
+problems = []
+if repository != "local":
+    problems.append("repo must be local")
+if hook.get("name") != "protected local commit (claude-code-config)":
+    problems.append("name does not match")
+if hook.get("entry") != ".githooks/pre-commit":
+    problems.append("entry must be .githooks/pre-commit")
+# pre-commit 4.x normalises the legacy `system` spelling to `unsupported`.
+if hook.get("language") not in {"system", "unsupported"}:
+    problems.append("language must be system")
+if hook.get("pass_filenames") is not False:
+    problems.append("pass_filenames must be false")
+if hook.get("always_run") is not True:
+    problems.append("always_run must be true")
+if hook.get("stages") != ["pre-commit"]:
+    problems.append("stages must contain only pre-commit")
+if hook.get("args") != []:
+    problems.append("args must be empty")
+if hook.get("additional_dependencies") != []:
+    problems.append("additional_dependencies must be empty")
+
+if problems:
+    print("; ".join(problems))
+    raise SystemExit(1)
+PY
+  )" || semantic_rc=$?
+  [ "$semantic_rc" -eq 0 ] \
+    || die "the committed pre-commit integration is not the reviewed definition: ${semantic_out:-no diagnostic}"
+  framework_hook="$DEST/pre-commit"
+  [ -f "$framework_hook" ] && [ ! -L "$framework_hook" ] && [ -x "$framework_hook" ] \
+    || die "$framework_hook must be a plain executable pre-commit framework hook"
+  grep -Fq "File generated by pre-commit" "$framework_hook" \
+    || die "$framework_hook is not owned by the pre-commit framework"
+  framework_digest="$(sha256sum <"$framework_hook" | cut -d' ' -f1)"
+  framework_probe_dir="$(mktemp -d)"
+  framework_probe_repo="$framework_probe_dir/repo"
+  framework_probe_file="$framework_probe_dir/reached"
+  target_head="$(git -C "$TARGET_REPO" rev-parse HEAD)"
+  # Never run the repository's complete pre-commit chain against the operator's
+  # worktree. A no-checkout clone plus plumbing commands materialises exactly
+  # HEAD without firing checkout hooks. Generate the framework hook again with
+  # the command in this environment and require byte parity: a comment-shaped
+  # foreign script is not evidence that pre-commit owns the target slot.
+  if ! (
+    set -e
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_COUNT=0
+    git clone --quiet --no-hardlinks --no-checkout "$TARGET_REPO" "$framework_probe_repo"
+    git -C "$framework_probe_repo" update-ref refs/heads/claude-code-config-probe "$target_head"
+    git -C "$framework_probe_repo" symbolic-ref HEAD refs/heads/claude-code-config-probe
+    git -C "$framework_probe_repo" read-tree "$target_head"
+    git -C "$framework_probe_repo" checkout-index -a
+    cd "$framework_probe_repo"
+    "$pre_commit_command" install --config .pre-commit-config.yaml >/dev/null
+  ); then
+    rm -rf "$framework_probe_dir"
+    die "could not prepare an isolated clone for the pre-commit framework probe"
+  fi
+  if ! cmp -s "$framework_hook" "$framework_probe_repo/.git/hooks/pre-commit"; then
+    rm -rf "$framework_probe_dir"
+    die "$framework_hook does not match the hook generated by $pre_commit_version in the repository environment; re-run pre-commit install through that environment"
+  fi
+  # Export the sentinel only to a targeted `pre-commit run <id>`, never to the
+  # generated hook chain. An unrelated hook therefore cannot answer for the
+  # reviewed entry, and an absent or skipped id leaves no sentinel.
+  framework_rc=0
+  framework_out="$(
+    cd "$framework_probe_repo" &&
+      env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_COUNT=0 \
+        CLAUDE_CODE_CONFIG_PRE_COMMIT_PROBE="$framework_probe_file" \
+        "$pre_commit_command" run "$FRAMEWORK_PROBE_ID" \
+          --hook-stage pre-commit 2>&1
+  )" || framework_rc=$?
+  if [ "$framework_rc" -ne 0 ]; then
+    rm -rf "$framework_probe_dir"
+    die "the preserved pre-commit framework hook failed its integration probe: ${framework_out:-no output}"
+  fi
+  if [ ! -f "$framework_probe_file" ] || [ -L "$framework_probe_file" ]; then
+    rm -rf "$framework_probe_dir"
+    die "the preserved pre-commit framework hook did not execute '$FRAMEWORK_PROBE_NAME'"
+  fi
+  if [ "$(cat "$framework_probe_file")" != "claude-code-config-pre-commit-reached" ]; then
+    rm -rf "$framework_probe_dir"
+    die "the preserved pre-commit framework hook published an invalid integration probe"
+  fi
+  rm -rf "$framework_probe_dir"
+fi
+
+mkdir -p "$DEST"
+
+for name in $INSTALL_HOOK_FILES $LIB_FILES; do
+  target="$DEST/$name"
+  [ -e "$target" ] || [ -L "$target" ] || continue
+  # A symlink is never something this script wrote, and writing through one is
+  # how the gate silently becomes worktree content again: `cp` follows it, and so
+  # does every check that comes after — `-f`, the hash, `-x`, and `git hook run`
+  # all report a healthy install while the real file lives in the worktree and
+  # disappears on the next checkout. It is also how a copy can overwrite a
+  # tracked file. Refuse the shape rather than try to see through it.
+  if [ -L "$target" ]; then
+    die "$target is a symbolic link. The hooks are copied, not linked — remove it and re-run."
+  fi
+  if [ "$target" -ef "$SOURCE/$name" ]; then
+    die "$target is the same file as $SOURCE/$name. Remove that arrangement and re-run."
+  fi
+  # A hook that is not ours belongs to someone else — a pre-commit framework,
+  # husky, an operator's own script. Replacing it would disable their gate to
+  # enable ours, and keeping a backup only moves the problem (a second run
+  # overwrites the first backup). Refuse and let a human decide.
+  if [ -d "$target" ] || ! grep -q "$MARKER" "$target" 2>/dev/null; then
+    die "$target already exists and was not installed by this script. Move it aside (or fold it into .githooks/) and re-run."
+  fi
+done
+
+# Stage every post-image and preserve every pre-image before the first managed
+# slot changes. The EXIT handler restores only paths that still match the bytes
+# this transaction installed; if a concurrent writer changes one, its work is
+# preserved and the retained transaction directory identifies the incomplete
+# recovery instead of silently overwriting it.
+transaction="$(mktemp -d "$DEST/.claude-code-config-install.XXXXXX")"
+if ! (
+  set -e
+  mkdir "$transaction/stage" "$transaction/backup" "$transaction/installed"
+  for name in $INSTALL_HOOK_FILES; do
+    cp "$SOURCE/$name" "$transaction/stage/$name"
+    chmod 755 "$transaction/stage/$name"
+  done
+  for name in $LIB_FILES; do
+    cp "$SOURCE/$name" "$transaction/stage/$name"
+    chmod 644 "$transaction/stage/$name"
+  done
+  for name in $INSTALL_HOOK_FILES $LIB_FILES; do
+    if [ -e "$DEST/$name" ]; then
+      cp -p "$DEST/$name" "$transaction/backup/$name"
+    fi
+  done
+); then
+  rm -rf "$transaction"
+  die "could not stage the managed hook transaction"
+fi
+
+transaction_active=0
+probe=""
+message_probe=""
+on_exit() {  # <original status>
+  local original_status="$1" name target tmp rollback_failed=0
+  trap - EXIT HUP INT TERM
+  set +e
+  [ -z "$probe" ] || rm -f "$probe"
+  [ -z "$message_probe" ] || rm -f "$message_probe"
+  if [ "$transaction_active" -eq 1 ]; then
+    for name in $INSTALL_HOOK_FILES $LIB_FILES; do
+      [ -e "$transaction/installed/$name" ] || continue
+      target="$DEST/$name"
+      if [ ! -f "$target" ] || [ -L "$target" ] \
+        || ! cmp -s "$transaction/stage/$name" "$target" \
+        || [ "$(stat -c '%a' "$transaction/stage/$name" 2>/dev/null)" \
+          != "$(stat -c '%a' "$target" 2>/dev/null)" ]; then
+        echo "BLOCKED: rollback preserved a concurrently changed path: $target" >&2
+        rollback_failed=1
+        continue
+      fi
+      if [ -f "$transaction/backup/$name" ]; then
+        tmp="$DEST/.$name.rollback.$$"
+        cp -p "$transaction/backup/$name" "$tmp" && mv -f "$tmp" "$target" \
+          || rollback_failed=1
+      else
+        rm -f "$target" || rollback_failed=1
+      fi
+    done
+    if [ "$rollback_failed" -eq 0 ]; then
+      rm -rf "$transaction"
+    else
+      echo "BLOCKED: rollback was incomplete; pre-images remain in $transaction" >&2
+    fi
+  elif [ -n "$transaction" ]; then
+    rm -rf "$transaction"
+  fi
+  exit "$original_status"
+}
+trap 'on_exit $?' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Each staged file is copied to a fresh name and then renamed over the target, so
+# the write never follows a destination link. Keep the stage copy for exact
+# post-image matching if a later verification step needs rollback.
+install_one() {  # <name>
+  local name="$1" tmp="$DEST/.$1.install.$$"
+  cp -p "$transaction/stage/$name" "$tmp"
+  mv -f "$tmp" "$DEST/$name"
+  : >"$transaction/installed/$name"
+}
+transaction_active=1
+for name in $INSTALL_HOOK_FILES; do install_one "$name"; done
+for name in $LIB_FILES;  do install_one "$name"; done
+
+# --- verify the copy --------------------------------------------------------
+for name in $INSTALL_HOOK_FILES $LIB_FILES; do
+  [ -f "$DEST/$name" ] && [ ! -L "$DEST/$name" ] \
+    || die "$DEST/$name is not a plain regular file after the copy"
+  if [ "$(sha256sum <"$SOURCE/$name" | cut -d' ' -f1)" \
+     != "$(sha256sum <"$DEST/$name" | cut -d' ' -f1)" ]; then
+    die "$DEST/$name does not match $SOURCE/$name after the copy"
+  fi
+done
+for name in $INSTALL_HOOK_FILES; do
+  [ -x "$DEST/$name" ] || die "$DEST/$name is not executable — Git would ignore it silently"
+done
+if [ "$MODE" = "framework" ]; then
+  [ "$(sha256sum <"$DEST/pre-commit" | cut -d' ' -f1)" = "$framework_digest" ] \
+    || die "$DEST/pre-commit changed during framework-preserving installation"
+fi
+
+# --- prove Git runs THIS copy ----------------------------------------------
+# Two questions, because either alone can be satisfied by the wrong file: where
+# Git looks (it must be where we installed — an override pointing elsewhere would
+# otherwise let an identical worktree copy answer the probe; re-checked here
+# because config can change between the check above and now), and whether the
+# hook there actually refuses. `git hook run` resolves the hook the way a real
+# operation does; "cannot find a hook" also exits non-zero, which is why the
+# refusal message is what is asserted.
+effective=""
+effective="$(git -C "$TARGET_REPO" rev-parse --path-format=absolute --git-path hooks 2>/dev/null)" || true
+[ -n "$effective" ] || die "Git could not resolve a hooks directory in $TARGET_REPO"
+if [ "$effective" != "$DEST" ]; then
+  die "Git resolves hooks to $effective, not $DEST — the installed copy would never run."
+fi
+
+probe="$(mktemp)"
+message_probe="$(mktemp)"
+printf 'refs/heads/master %040d refs/heads/master %040d\n' 0 0 >"$probe"
+
+probe_how="git hook run"
+use_git_hook_run=1
+probe_rc=0
+probe_out="$(git -C "$TARGET_REPO" hook run --to-stdin="$probe" pre-push 2>&1)" || probe_rc=$?
+case "$probe_out" in
+  *"is not a git command"* | *"unknown subcommand"*)
+    # `git hook run` arrived in git 2.36; 2.34 is still current on Ubuntu 22.04
+    # LTS. The hooks themselves work fine there, so refusing the install would
+    # deny the gate to the clone over a missing verification verb. Invoke the
+    # installed file the way Git would instead — the destination has already been
+    # proven to be where Git resolves hooks.
+    probe_how="the installed hook, directly (this git has no 'git hook run')"
+    use_git_hook_run=0
+    probe_rc=0
+    probe_out="$(bash "$DEST/pre-push" origin "$TARGET_REPO" <"$probe" 2>&1)" || probe_rc=$?
+    ;;
+esac
+
+case "$probe_out" in
+  *"BLOCKED:"*)
+    [ "$probe_rc" -ne 0 ] || die "the installed pre-push printed a refusal but exited 0"
+    ;;
+  *)
+    die "the installed pre-push did not refuse a protected record in $TARGET_REPO (exit $probe_rc: ${probe_out:-no output}). The hooks are on disk but inert."
+    ;;
+esac
+
+# The message boundary has one positive and one negative control. A non-zero
+# status alone is not proof of policy execution (a missing hook also fails), so
+# the Japanese probe must carry the validator's structured refusal.
+printf 'fix(test): installer English control\n' >"$message_probe"
+if [ "$use_git_hook_run" -eq 1 ]; then
+  git -C "$TARGET_REPO" hook run commit-msg -- "$message_probe" >/dev/null \
+    || die "the installed commit-msg rejected the English control"
+else
+  bash "$DEST/commit-msg" "$message_probe" >/dev/null \
+    || die "the installed commit-msg rejected the English control"
+fi
+printf 'fix(test): Japanese control \346\227\245\346\234\254\350\252\236\n' >"$message_probe"
+message_rc=0
+if [ "$use_git_hook_run" -eq 1 ]; then
+  message_out="$(git -C "$TARGET_REPO" hook run commit-msg -- "$message_probe" 2>&1)" \
+    || message_rc=$?
+else
+  message_out="$(bash "$DEST/commit-msg" "$message_probe" 2>&1)" || message_rc=$?
+fi
+case "$message_out" in
+  *"BLOCKED:"*) [ "$message_rc" -ne 0 ] \
+    || die "the installed commit-msg printed a refusal but exited 0" ;;
+  *) die "the installed commit-msg did not reject the Japanese control" ;;
+esac
+
+transaction_active=0
+rm -rf "$transaction"
+transaction=""
+
+if [ "$MODE" = "framework" ]; then
+  echo "installed $INSTALL_HOOK_FILES into $DEST, preserved pre-commit, verified with $probe_how"
+else
+  echo "installed $INSTALL_HOOK_FILES into $DEST, verified with $probe_how"
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+# pre-commit — refuse a commit made while HEAD is on a protected branch.
+#
+# Git runs this on the commit *operation*, so the command form cannot route
+# around it: `git add -A && git commit …`, `true; git commit …` and
+# `git commit --amend` all reach it, while all three skip
+# `hooks/validate-commit.sh`, which matches `^\s*git\s+commit` against the whole
+# command string (claude-code-config#147).
+set -euo pipefail
+
+probe_file="${CLAUDE_CODE_CONFIG_PRE_COMMIT_PROBE:-}"
+if [ -n "$probe_file" ]; then
+  case "$probe_file" in
+    /*) ;;
+    *) echo "BLOCKED: pre-commit integration probe path must be absolute" >&2; exit 1 ;;
+  esac
+  probe_parent="${probe_file%/*}"
+  [ -n "$probe_parent" ] || probe_parent="/"
+  [ -d "$probe_parent" ] && [ ! -L "$probe_parent" ] \
+    || { echo "BLOCKED: pre-commit integration probe parent is unsafe" >&2; exit 1; }
+  [ ! -e "$probe_file" ] && [ ! -L "$probe_file" ] \
+    || { echo "BLOCKED: pre-commit integration probe path already exists" >&2; exit 1; }
+  umask 077
+  (set -o noclobber; printf '%s\n' 'claude-code-config-pre-commit-reached' >"$probe_file") \
+    || { echo "BLOCKED: cannot publish pre-commit integration probe" >&2; exit 1; }
+fi
+
+# shellcheck source=./protected-refs.sh
+. "$(dirname "${BASH_SOURCE[0]}")/protected-refs.sh"
+
+assert_not_on_protected_branch commit

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+# pre-merge-commit — refuse a merge commit created while HEAD is on a protected
+# branch.
+#
+# Git does not run `pre-commit` for a merge commit, so without this hook
+# `git merge <feature>` onto `master` would create a local commit with no gate at
+# all — the same destination `pre-commit` refuses for an ordinary commit.
+set -euo pipefail
+
+# shellcheck source=./protected-refs.sh
+. "$(dirname "${BASH_SOURCE[0]}")/protected-refs.sh"
+
+assert_not_on_protected_branch merge

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+# pre-push — refuse a push whose destination is a protected branch.
+#
+# Git supplies one line per ref on stdin:
+#
+#   <local ref> <local sha> <remote ref> <remote sha>
+#
+# with the remote ref **already resolved**, which is the whole point: `HEAD`,
+# `@`, `HEAD:master`, `+master`, `--all` and a bare `git push` under
+# `push.default` all arrive as `refs/heads/master`. `hooks/validate-push.sh`
+# compares the refspec as it was typed and therefore lets `git push -u origin
+# HEAD` through (claude-code-config#147).
+#
+# A deletion written as a refspec (`git push origin :master`,
+# `git push --prune origin '+refs/heads/*:refs/heads/*'`) arrives with
+# `<local ref>` set to `(delete)` and its sha all zeros, while `<remote ref>`
+# still names the branch — so it is refused by the same comparison.
+#
+# A mirror prune is the exception, and it is not fixable from the record stream:
+# when `git push --mirror` deletes a remote branch that has no local counterpart,
+# Git writes **no record at all** for it, so the hook is handed a clean-looking
+# stream and exits 0 while a protected branch is deleted. The configured form of
+# that push is refused below; the command-line `--mirror` flag is invisible to a
+# hook and is documented as uncovered in CONTRIBUTING.md.
+set -euo pipefail
+
+# shellcheck source=./protected-refs.sh
+. "$(dirname "${BASH_SOURCE[0]}")/protected-refs.sh"
+
+blocked=0
+
+# `$1` is the remote's name (or its URL for an anonymous push). A remote carrying
+# `remote.<name>.mirror` — which `git clone --mirror` sets — turns a plain
+# `git push <name>` into a mirror push, and a mirror push can delete a protected
+# branch without ever reporting it here. Refuse the whole push rather than let
+# the deletion through unseen; `--no-verify` remains for the operator who means
+# it.
+if [ -n "${1:-}" ] &&
+   [ "$(git config --bool --get "remote.$1.mirror" 2>/dev/null || echo false)" = true ]; then
+  echo "BLOCKED: '$1' is configured as a mirror remote (remote.$1.mirror)." >&2
+  echo "A mirror push deletes remote branches without reporting them to this hook," >&2
+  echo "so a protected branch could be removed unseen." >&2
+  blocked=1
+fi
+
+# The line is read whole and split afterwards, rather than read straight into
+# four names, so that "the record was empty" and "the record consumed bytes"
+# stay distinguishable. `|| [ -n "$record" ]` then keeps a final record that
+# arrives without a trailing newline: `read` returns non-zero at EOF even though
+# it consumed the line, so a plain loop drops it and exits 0 — a protected ref
+# silently unexamined (DC1). Splitting into named fields directly would lose the
+# same way on a whitespace-only tail, which reads as four empty fields.
+# Git terminates every record it writes, so this is belt and braces rather than a
+# live bypass.
+set -f   # ref names cannot contain glob metacharacters, but do not rely on it
+while IFS= read -r record || [ -n "${record:-}" ]; do
+  # shellcheck disable=SC2086  # deliberate word splitting: the record's fields
+  set -- $record
+  local_ref="${1:-}"
+  local_sha="${2:-}"
+  remote_ref="${3:-}"
+  remote_sha="${4:-}"
+
+  # Ref names cannot contain whitespace (git-check-ref-format), so the four
+  # fields are unambiguous. Anything other than exactly four is not a
+  # Git-produced record; refuse rather than guess which field is missing.
+  if [ "$#" -ne 4 ] || [ -z "$local_ref" ] || [ -z "$local_sha" ] ||
+     [ -z "$remote_ref" ] || [ -z "$remote_sha" ]; then
+    echo "BLOCKED: unparseable pre-push record: '$record'" >&2
+    blocked=1
+    record=""
+    continue
+  fi
+
+  if protected_ref "$remote_ref"; then
+    if [ "$local_ref" = "(delete)" ]; then
+      echo "BLOCKED: refusing to delete the protected branch '$remote_ref'." >&2
+    else
+      echo "BLOCKED: '$remote_ref' is protected." >&2
+      echo "Push a feature branch and open a PR instead." >&2
+    fi
+    blocked=1
+  fi
+done
+
+exit "$blocked"

--- a/.githooks/protected-refs.sh
+++ b/.githooks/protected-refs.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# managed-by: claude-code-config (.githooks/install.sh installs this copy)
+# protected-refs.sh — the branches this repository refuses to commit onto or
+# push to, and the predicates the hooks in this directory share.
+#
+# Sourced by `pre-commit`, `pre-merge-commit` and `pre-push`; it is never
+# executed on its own, so it carries no exec bit.
+#
+# This list is the SSOT for the repository-local layer. `hooks/validate-*.sh`
+# keep their own copies because they are deployed to a live `~/.claude` that has
+# no access to this checkout, so the duplication is structural rather than
+# accidental (DC3). `tests/test-githooks-protection.sh` compares the three lists
+# and fails when they drift.
+PROTECTED_BRANCHES="main master develop production"
+
+# protected_ref <full ref, e.g. refs/heads/master>
+# True when the ref names a protected branch. Every caller compares the
+# fully-qualified form, so there is deliberately no short-name predicate to reach
+# for: Git hands `pre-push` the resolved destination ref — `HEAD`, `@`,
+# `HEAD:master`, `+master` and a bare push under `push.default` all arrive as
+# `refs/heads/master`, the resolution `hooks/validate-push.sh` fails to perform
+# on the command string — and the commit side asks `symbolic-ref` for the same
+# form. The comparison is exact, so `feature/master` and `master-2` are ordinary
+# branches (DC2).
+protected_ref() {
+  local candidate="$1" name
+  for name in $PROTECTED_BRANCHES; do
+    if [ "$candidate" = "refs/heads/$name" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# assert_not_on_protected_branch <operation label>
+# Refuses the operation when HEAD is on a protected branch. Used by the commit
+# and merge hooks, which — unlike `pre-push` — receive no ref on stdin and must
+# ask Git where HEAD points.
+#
+# The question is asked in fully-qualified form. `--short` runs
+# `shorten_unambiguous_ref`, which returns `heads/master` — with exit status 0 —
+# whenever a second ref named `master` exists (a tag, or `refs/master`), so an
+# exact comparison against `master` silently answers "not protected" while the
+# status-based fail-loud arm below never fires. Tags arrive from any remote via
+# `git fetch --tags`, so one pushed tag would disarm every clone that fetched it.
+# `pre-push` never had this hole because Git hands it the full ref; asking for
+# the same authoritative form here removes the ambiguous derived one.
+assert_not_on_protected_branch() {
+  local operation="$1" branch status
+
+  set +e
+  branch="$(git symbolic-ref --quiet HEAD)"
+  status=$?
+  set -e
+
+  case "$status" in
+    0) ;;
+    # 1 = HEAD is not a symbolic ref (detached). There is no branch name to
+    # protect; the destination is still covered by `pre-push`.
+    1) return 0 ;;
+    # Anything else is Git failing, not Git answering. Refuse rather than read
+    # the silence as "not on a protected branch" (DC1).
+    *)
+      echo "BLOCKED: cannot determine the current branch" \
+           "(git symbolic-ref exited $status); refusing the $operation." >&2
+      return 1
+      ;;
+  esac
+
+  if protected_ref "$branch"; then
+    echo "BLOCKED: $operation on protected branch '${branch#refs/heads/}'." >&2
+    echo "Create a feature branch first: git checkout -b <type>/<name>" >&2
+    return 1
+  fi
+  return 0
+}

--- a/.github/workflows/artifact-language.yml
+++ b/.github/workflows/artifact-language.yml
@@ -1,0 +1,33 @@
+name: artifact-language
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate selected artifact boundary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            bash tests/test-artifact-language.sh
+          else
+            python3 .githooks/artifact-language.py github-event \
+              --event-name "$GITHUB_EVENT_NAME" \
+              --event-path "$GITHUB_EVENT_PATH"
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,14 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
       - id: detect-private-key
+
+  # managed-by: claude-code-config (.githooks/pre-commit runs through pre-commit)
+  - repo: local
+    hooks:
+      - id: claude-code-config-protected-commit
+        name: protected local commit (claude-code-config)
+        entry: .githooks/pre-commit
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Thank you for your interest in contributing!
 git clone https://github.com/nbx-liz/LizyML-Widget.git
 cd LizyML-Widget
 uv sync --frozen --dev
-pre-commit install
+uv run pre-commit install
+uv run bash .githooks/install.sh --preserve-pre-commit
 
 # JS frontend
 cd js && pnpm install && pnpm build && cd ..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,12 @@ packages = ["src/lizyml_widget"]
 [tool.ruff]
 target-version = "py310"
 line-length = 100
-exclude = ["notebooks/"]
+exclude = [
+    "notebooks/",
+    ".githooks/",
+    "scripts/verify-artifact-language-bundle.py",
+    "tests/artifact-language-probe.py",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
@@ -109,4 +114,3 @@ dev = [
     "playwright>=1.58.0",
     "requests>=2.32.5",
 ]
-

--- a/scripts/verify-artifact-language-bundle.py
+++ b/scripts/verify-artifact-language-bundle.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Verify one repository carries the canonical Issue #22 artifact bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+FILES = {
+    ".githooks/artifact-language.py": 0o755,
+    ".githooks/commit-msg": 0o755,
+    ".github/workflows/artifact-language.yml": 0o644,
+}
+
+
+def digest(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    target = args.target.resolve()
+    failures: list[str] = []
+    bundle = hashlib.sha256()
+    for relative, expected_mode in FILES.items():
+        canonical = ROOT / relative
+        candidate = target / relative
+        if not canonical.is_file() or canonical.is_symlink():
+            failures.append(f"canonical file is missing or unsafe: {relative}")
+            continue
+        if not candidate.is_file() or candidate.is_symlink():
+            failures.append(f"target file is missing or unsafe: {relative}")
+            continue
+        tracked = subprocess.run(
+            ["git", "-C", os.fspath(target), "ls-files", "--error-unmatch", "--", relative],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if tracked.returncode != 0:
+            failures.append(f"target file is not tracked: {relative}")
+        canonical_digest = digest(canonical)
+        candidate_digest = digest(candidate)
+        if canonical_digest != candidate_digest:
+            failures.append(f"target bytes differ: {relative}")
+        mode = stat.S_IMODE(candidate.stat().st_mode)
+        if mode != expected_mode:
+            failures.append(
+                f"target mode differs: {relative} is {mode:04o}, expected {expected_mode:04o}"
+            )
+        bundle.update(relative.encode("utf-8") + b"\0")
+        bundle.update(bytes.fromhex(canonical_digest))
+    if failures:
+        for failure in failures:
+            print(f"BLOCKED: {failure}", file=sys.stderr)
+        return 1
+    print(f"artifact-language bundle sha256={bundle.hexdigest()} target={target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/artifact-language-probe.py
+++ b/tests/artifact-language-probe.py
@@ -1,0 +1,1004 @@
+#!/usr/bin/env python3
+"""Production-shaped offline probes for the Issue #22 artifact boundaries."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / ".githooks" / "artifact-language.py"
+WRAPPER = ROOT / ".githooks" / "commit-msg"
+VERIFIER = ROOT / "scripts" / "verify-artifact-language-bundle.py"
+
+spec = importlib.util.spec_from_file_location("artifact_language", VALIDATOR)
+assert spec and spec.loader
+artifact_language = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = artifact_language
+spec.loader.exec_module(artifact_language)
+
+
+class ArtifactLanguageTests(unittest.TestCase):
+    def assert_blocked(self, callable_object, label: str) -> None:
+        with self.assertRaisesRegex(artifact_language.PolicyError, label):
+            callable_object()
+
+    @staticmethod
+    def push_event() -> dict:
+        return {
+            "ref": "refs/heads/main",
+            "before": "1" * 40,
+            "after": "2" * 40,
+            "created": False,
+            "deleted": False,
+            "repository": {"default_branch": "main", "full_name": "o/r"},
+        }
+
+    @staticmethod
+    def push_row(
+        index: int,
+        message: str = "fix(test): English",
+        *,
+        sha: str | None = None,
+    ) -> dict:
+        return {"sha": sha or f"{index:040x}", "commit": {"message": message}}
+
+    def test_commit_boundary(self) -> None:
+        for message in (
+            "fix(test): valid English message\n",
+            "feat(parser)!: describe a breaking change\n\nBREAKING CHANGE: details\n",
+            "Merge branch 'feature/example'\n",
+            'Revert "fix(test): example"\n\nThis reverts commit abc.\n',
+            "fix(test): message\n# English template comment\n",
+            "fix(test): message\n# ------------------------ >8 ------------------------\nEnglish discarded\n",
+        ):
+            artifact_language.validate_commit_message(message)
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message("fix(test): 日本語\n"),
+            "commit message",
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message(
+                "fix(test): English\n\n日本語 body\n"
+            ),
+            "commit message",
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message(
+                "fix(test): English\n\n# 日本語 retained body\n"
+            ),
+            "commit message",
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message(
+                "fix(test): English\n"
+                "# ------------------------ >8 ------------------------\n"
+                "日本語 retained by explicit message input\n"
+            ),
+            "commit message",
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message(
+                "# plain English invalid subject\n\n"
+                "fix(test): conventional second paragraph\n"
+            ),
+            "Conventional",
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_commit_message("plain English\n"),
+            "Conventional",
+        )
+
+    @staticmethod
+    def pr_event() -> tuple[dict, list[dict]]:
+        return (
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 7,
+                    "title": "English title",
+                    "body": "English body",
+                },
+                "repository": {"full_name": "o/r"},
+            },
+            [{"commit": {"message": "fix(test): English commit"}}],
+        )
+
+    def test_pull_request_matrix(self) -> None:
+        event, commits = self.pr_event()
+        for action in ("opened", "edited", "reopened", "synchronize"):
+            event["action"] = action
+            artifact_language.validate_event_value(
+                "pull_request", event, pull_request_commits=commits
+            )
+            for field in ("title", "body"):
+                mutated = json.loads(json.dumps(event))
+                mutated["pull_request"][field] = "日本語"
+                self.assert_blocked(
+                    lambda value=mutated: artifact_language.validate_event_value(
+                        "pull_request", value, pull_request_commits=commits
+                    ),
+                    f"pull_request.{field}",
+                )
+            self.assert_blocked(
+                lambda: artifact_language.validate_event_value(
+                    "pull_request",
+                    event,
+                    pull_request_commits=[
+                        {
+                            "commit": {
+                                "message": (
+                                    "fix(test): English\n\n# 日本語 retained body"
+                                )
+                            }
+                        }
+                    ],
+                ),
+                "pull_request.commits",
+            )
+            self.assert_blocked(
+                lambda: artifact_language.validate_event_value(
+                    "pull_request",
+                    event,
+                    pull_request_commits=[
+                        {
+                            "commit": {
+                                "message": (
+                                    "# plain English invalid subject\n\n"
+                                    "fix(test): conventional second paragraph"
+                                )
+                            }
+                        }
+                    ],
+                ),
+                "Conventional",
+            )
+        event["action"] = "closed"
+        self.assert_blocked(
+            lambda: artifact_language.validate_event_value(
+                "pull_request", event, pull_request_commits=commits
+            ),
+            "unsupported",
+        )
+
+    def test_issue_and_comment_matrix(self) -> None:
+        for action in ("opened", "edited", "reopened"):
+            artifact_language.validate_event_value(
+                "issues",
+                {"action": action, "issue": {"title": "English", "body": None}},
+            )
+            for field in ("title", "body"):
+                issue = {
+                    "action": action,
+                    "issue": {"title": "English", "body": "English"},
+                }
+                issue["issue"][field] = "日本語"
+                self.assert_blocked(
+                    lambda value=issue: artifact_language.validate_event_value(
+                        "issues", value
+                    ),
+                    f"issue.{field}",
+                )
+        for action in ("created", "edited"):
+            artifact_language.validate_event_value(
+                "issue_comment",
+                {"action": action, "comment": {"body": "English"}},
+            )
+            self.assert_blocked(
+                lambda value=action: artifact_language.validate_event_value(
+                    "issue_comment",
+                    {"action": value, "comment": {"body": "日本語"}},
+                ),
+                "comment.body",
+            )
+
+    def test_malformed_fields_fail_closed(self) -> None:
+        malformed = (
+            ("pull_request", {"action": "opened", "pull_request": []}),
+            (
+                "pull_request",
+                {
+                    "action": "opened",
+                    "pull_request": {"number": 1, "title": "English"},
+                },
+            ),
+            ("issues", {"action": "opened", "issue": {"title": 7, "body": None}}),
+            ("issues", {"action": "opened", "issue": {"title": "English"}}),
+            (
+                "issue_comment",
+                {"action": "created", "comment": {"body": ["English"]}},
+            ),
+            (
+                "push",
+                {
+                    "ref": "refs/heads/main",
+                    "created": True,
+                    "deleted": False,
+                    "repository": {
+                        "default_branch": "main",
+                        "full_name": "o/r",
+                    },
+                    "before": "0" * 40,
+                    "after": "1" * 40,
+                },
+            ),
+        )
+        for event_name, event in malformed:
+            with self.subTest(event_name=event_name):
+                self.assertRaises(
+                    artifact_language.PolicyError,
+                    artifact_language.validate_event_value,
+                    event_name,
+                    event,
+                )
+
+    def test_default_push_and_non_artifact_scope(self) -> None:
+        push = self.push_event()
+        push["irrelevant_source_text"] = "日本語 outside the artifact fields"
+        rows = [
+            self.push_row(1),
+            self.push_row(
+                2,
+                "Merge branch 'feature/example'",
+                sha=push["after"],
+            ),
+        ]
+        self.assertNotIn("size", push)
+        self.assertTrue(
+            artifact_language.validate_event_value("push", push, push_commits=rows)
+        )
+        rows[1]["commit"]["message"] = "fix(test): 日本語"
+        self.assert_blocked(
+            lambda: artifact_language.validate_event_value(
+                "push", push, push_commits=rows
+            ),
+            r"push.commits\[1\].message",
+        )
+        rows[1]["commit"]["message"] = (
+            "fix(test): English\n\n# 日本語 retained body"
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_event_value(
+                "push", push, push_commits=rows
+            ),
+            r"push.commits\[1\].message",
+        )
+        rows[1]["commit"]["message"] = (
+            "# plain English invalid subject\n\n"
+            "fix(test): conventional second paragraph"
+        )
+        self.assert_blocked(
+            lambda: artifact_language.validate_event_value(
+                "push", push, push_commits=rows
+            ),
+            "Conventional",
+        )
+        rows[1]["commit"]["message"] = "Merge branch 'feature/example'"
+        push["ref"] = "refs/heads/feature/example"
+        self.assertFalse(
+            artifact_language.validate_event_value("push", push, push_commits=rows)
+        )
+
+    def test_default_push_fetches_complete_compare_range(self) -> None:
+        first_page = [self.push_row(index) for index in range(1, 101)]
+        second_page = [self.push_row(101, sha=self.push_event()["after"])]
+
+        class Response:
+            def __init__(self, payload: dict) -> None:
+                self.payload = json.dumps(payload).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self, _limit: int) -> bytes:
+                return self.payload
+
+        responses = [
+            Response({"total_commits": 101, "commits": first_page}),
+            Response({"total_commits": 101, "commits": second_page}),
+        ]
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=responses,
+        ) as opened:
+            rows = artifact_language.fetch_push_commits(self.push_event())
+        self.assertEqual(len(rows), 101)
+        comparison = (
+            "https://api.github.com/repos/o/r/compare/"
+            f"{self.push_event()['before']}...{self.push_event()['after']}"
+        )
+        self.assertEqual(
+            [call.args[0].full_url for call in opened.call_args_list],
+            [
+                f"{comparison}?per_page=100&page=1",
+                f"{comparison}?per_page=100&page=2",
+            ],
+        )
+
+        incomplete = [
+            Response({"total_commits": 101, "commits": first_page}),
+            Response({"total_commits": 101, "commits": []}),
+        ]
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=incomplete,
+        ):
+            self.assert_blocked(
+                lambda: artifact_language.fetch_push_commits(self.push_event()),
+                "incomplete",
+            )
+
+        wrong_endpoint = [
+            Response(
+                {
+                    "total_commits": 1,
+                    "commits": [self.push_row(1, sha="3" * 40)],
+                }
+            )
+        ]
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=wrong_endpoint,
+        ):
+            self.assert_blocked(
+                lambda: artifact_language.fetch_push_commits(self.push_event()),
+                "does not terminate",
+            )
+
+        duplicate = [
+            Response({"total_commits": 101, "commits": first_page}),
+            Response({"total_commits": 101, "commits": [first_page[-1]]}),
+        ]
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=duplicate,
+        ):
+            self.assert_blocked(
+                lambda: artifact_language.fetch_push_commits(self.push_event()),
+                "repeats commit",
+            )
+
+        changed_total = [
+            Response({"total_commits": 101, "commits": first_page}),
+            Response({"total_commits": 102, "commits": second_page}),
+        ]
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=changed_total,
+        ):
+            self.assert_blocked(
+                lambda: artifact_language.fetch_push_commits(self.push_event()),
+                "total changed",
+            )
+
+        capped = []
+        for page in range(100):
+            start = page * 100 + 1
+            capped.append(
+                Response(
+                    {
+                        "total_commits": 10001,
+                        "commits": [
+                            self.push_row(index)
+                            for index in range(start, start + 100)
+                        ],
+                    }
+                )
+            )
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "test-token"}
+        ), mock.patch.object(
+            artifact_language.urllib.request,
+            "urlopen",
+            side_effect=capped,
+        ):
+            self.assert_blocked(
+                lambda: artifact_language.fetch_push_commits(self.push_event()),
+                "pagination exceeds",
+            )
+
+    def test_cli_wrapper_and_fixture_event(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            hook_dir = root / "hooks"
+            hook_dir.mkdir()
+            shutil.copy2(VALIDATOR, hook_dir / VALIDATOR.name)
+            shutil.copy2(WRAPPER, hook_dir / WRAPPER.name)
+            (hook_dir / WRAPPER.name).chmod(0o755)
+            message = root / "message"
+            message.write_text("fix(test): English\n", encoding="utf-8")
+            accepted = subprocess.run(
+                [os.fspath(hook_dir / WRAPPER.name), os.fspath(message)],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            message.write_text("fix(test): 日本語\n", encoding="utf-8")
+            blocked = subprocess.run(
+                [os.fspath(hook_dir / WRAPPER.name), os.fspath(message)],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertNotEqual(blocked.returncode, 0)
+            self.assertIn("BLOCKED:", blocked.stderr)
+
+            event, commits = self.pr_event()
+            event_path = root / "event.json"
+            commits_path = root / "commits.json"
+            event_path.write_text(json.dumps(event), encoding="utf-8")
+            commits_path.write_text(json.dumps(commits), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable, os.fspath(VALIDATOR), "github-event",
+                    "--event-name", "pull_request", "--event-path", os.fspath(event_path),
+                    "--pr-commits-file", os.fspath(commits_path),
+                ],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            push_event_path = root / "push-event.json"
+            push_commits_path = root / "push-commits.json"
+            push_event_path.write_text(json.dumps(self.push_event()), encoding="utf-8")
+            push_commits_path.write_text(
+                json.dumps(
+                    [self.push_row(1, sha=self.push_event()["after"])]
+                ),
+                encoding="utf-8",
+            )
+            push_result = subprocess.run(
+                [
+                    sys.executable,
+                    os.fspath(VALIDATOR),
+                    "github-event",
+                    "--event-name",
+                    "push",
+                    "--event-path",
+                    os.fspath(push_event_path),
+                    "--push-commits-file",
+                    os.fspath(push_commits_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(push_result.returncode, 0, push_result.stderr)
+
+            invalid_utf8 = root / "invalid-utf8"
+            invalid_utf8.write_bytes(b"fix(test): invalid \xff\n")
+            invalid = subprocess.run(
+                [
+                    sys.executable,
+                    os.fspath(VALIDATOR),
+                    "commit-message",
+                    "--file",
+                    os.fspath(invalid_utf8),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(invalid.returncode, 0)
+            self.assertIn("not UTF-8", invalid.stderr)
+
+    def test_installed_hook_controls_real_git_commits(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            target = pathlib.Path(temporary) / "repo"
+            target.mkdir()
+            subprocess.run(["git", "init", "-q", os.fspath(target)], check=True)
+            subprocess.run(
+                ["git", "-C", os.fspath(target), "config", "user.name", "Test User"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    os.fspath(target),
+                    "config",
+                    "user.email",
+                    "test@example.com",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", os.fspath(target), "checkout", "-q", "-b", "feature/test"],
+                check=True,
+            )
+            installed = subprocess.run(
+                ["bash", os.fspath(ROOT / ".githooks" / "install.sh"), os.fspath(target)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(installed.returncode, 0, installed.stderr)
+
+            accepted = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    os.fspath(target),
+                    "commit",
+                    "--allow-empty",
+                    "-m",
+                    "fix(test): English control",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            accepted_head = subprocess.run(
+                ["git", "-C", os.fspath(target), "rev-parse", "HEAD"],
+                text=True,
+                capture_output=True,
+                check=True,
+            ).stdout.strip()
+
+            blocked_messages = (
+                (
+                    "fix(test): English subject",
+                    "# Japanese control \u65e5\u672c\u8a9e retained body",
+                ),
+                (
+                    "# plain English invalid subject",
+                    "fix(test): conventional second paragraph",
+                ),
+            )
+            for subject, body in blocked_messages:
+                blocked = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        os.fspath(target),
+                        "commit",
+                        "--allow-empty",
+                        "-m",
+                        subject,
+                        "-m",
+                        body,
+                    ],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertNotEqual(blocked.returncode, 0)
+                self.assertIn("BLOCKED:", blocked.stderr)
+                blocked_head = subprocess.run(
+                    ["git", "-C", os.fspath(target), "rev-parse", "HEAD"],
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                ).stdout.strip()
+                self.assertEqual(blocked_head, accepted_head)
+
+    def test_framework_preserving_install_keeps_pre_commit_owner(self) -> None:
+        marker = (
+            "# managed-by: claude-code-config "
+            "(.githooks/pre-commit runs through pre-commit)\n"
+        )
+        generated = """#!/usr/bin/env bash
+# File generated by pre-commit: https://pre-commit.com
+exit 0
+"""
+        managed_names = (
+            "commit-msg",
+            "pre-merge-commit",
+            "pre-push",
+            "artifact-language.py",
+            "protected-refs.sh",
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            fake_modules = root / "modules"
+            fake_package = fake_modules / "pre_commit"
+            fake_package.mkdir(parents=True)
+            (fake_package / "__init__.py").write_text("", encoding="utf-8")
+            (fake_package / "clientlib.py").write_text(
+                "from __future__ import annotations\n"
+                "\n"
+                "import pathlib\n"
+                "import re\n"
+                "\n"
+                "def load_config(path: str) -> dict[str, object]:\n"
+                "    text = pathlib.Path(path).read_text(encoding='utf-8')\n"
+                "    if 'repos: []' in text:\n"
+                "        return {'repos': []}\n"
+                "    def value(name: str, default: str = '') -> str:\n"
+                "        match = re.search(\n"
+                "            rf'^[ \\t]+(?:-[ \\t]+)?{name}:[ \\t]*(.+?)[ \\t]*$',\n"
+                "            text,\n"
+                "            re.MULTILINE,\n"
+                "        )\n"
+                "        return match.group(1) if match else default\n"
+                "    hook = {\n"
+                "        'id': value('id'),\n"
+                "        'name': value('name'),\n"
+                "        'entry': value('entry'),\n"
+                "        'language': 'unsupported' if value('language') == 'system' "
+                "else value('language'),\n"
+                "        'pass_filenames': value('pass_filenames') == 'true',\n"
+                "        'always_run': value('always_run') == 'true',\n"
+                "        'stages': ['pre-commit'] if value('stages') == '[pre-commit]' else [],\n"
+                "        'args': [],\n"
+                "        'additional_dependencies': [],\n"
+                "    }\n"
+                "    return {'repos': [{'repo': 'local', 'hooks': [hook]}]}\n",
+                encoding="utf-8",
+            )
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_pre_commit = fake_bin / "pre-commit"
+            fake_pre_commit.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os\n"
+                "import pathlib\n"
+                "import subprocess\n"
+                "import sys\n"
+                f"GENERATED = {generated!r}\n"
+                "if sys.argv[1:] == ['--version']:\n"
+                "    print('pre-commit 4.5.1-test')\n"
+                "    raise SystemExit(0)\n"
+                "if len(sys.argv) > 1 and sys.argv[1] == 'install':\n"
+                "    hook = pathlib.Path('.git/hooks/pre-commit')\n"
+                "    hook.write_text(GENERATED, encoding='utf-8')\n"
+                "    hook.chmod(0o755)\n"
+                "    raise SystemExit(0)\n"
+                "if len(sys.argv) > 2 and sys.argv[1:3] == "
+                "['run', 'claude-code-config-protected-commit']:\n"
+                "    config = pathlib.Path('.pre-commit-config.yaml').read_text(encoding='utf-8')\n"
+                "    required = (\n"
+                "        'id: claude-code-config-protected-commit',\n"
+                "        'entry: .githooks/pre-commit',\n"
+                "        'language: system',\n"
+                "        'pass_filenames: false',\n"
+                "        'always_run: true',\n"
+                "    )\n"
+                "    if not all(value in config for value in required):\n"
+                "        print('protected local commit (claude-code-config)........Skipped')\n"
+                "        raise SystemExit(0)\n"
+                "    touch_relative = os.environ.get('FAKE_PRE_COMMIT_TOUCH_RELATIVE')\n"
+                "    if touch_relative:\n"
+                "        pathlib.Path(touch_relative).write_text('changed\\n', encoding='utf-8')\n"
+                "    result = subprocess.run(['.githooks/pre-commit'], check=False)\n"
+                "    mutate = os.environ.get('FAKE_PRE_COMMIT_MUTATE_TARGET')\n"
+                "    if mutate:\n"
+                "        with open(mutate, 'a', encoding='utf-8') as stream:\n"
+                "            stream.write('# changed during probe\\n')\n"
+                "    raise SystemExit(result.returncode)\n"
+                "raise SystemExit(2)\n",
+                encoding="utf-8",
+            )
+            fake_pre_commit.chmod(0o755)
+
+            def fixture(
+                name: str,
+                *,
+                config_marker: bool = True,
+                generated_hook: str = generated,
+                always_run: bool = True,
+                empty_repos: bool = False,
+                entry: str = ".githooks/pre-commit",
+            ) -> pathlib.Path:
+                target = root / name
+                target.mkdir()
+                subprocess.run(["git", "init", "-q", os.fspath(target)], check=True)
+                subprocess.run(
+                    ["git", "-C", os.fspath(target), "checkout", "-q", "-b", "feature/test"],
+                    check=True,
+                )
+                config = target / ".pre-commit-config.yaml"
+                config_text = marker if config_marker else ""
+                if empty_repos:
+                    config_text += "repos: []\n"
+                else:
+                    config_text += (
+                        "repos:\n"
+                        "  - repo: local\n"
+                        "    hooks:\n"
+                        "      - id: claude-code-config-protected-commit\n"
+                        "        name: protected local commit (claude-code-config)\n"
+                        f"        entry: {entry}\n"
+                        "        language: system\n"
+                        "        stages: [pre-commit]\n"
+                        "        pass_filenames: false\n"
+                    )
+                    if always_run:
+                        config_text += "        always_run: true\n"
+                config.write_text(config_text, encoding="utf-8")
+                source_hook = target / ".githooks" / "pre-commit"
+                source_hook.parent.mkdir()
+                shutil.copy2(ROOT / ".githooks" / "pre-commit", source_hook)
+                shutil.copy2(
+                    ROOT / ".githooks" / "protected-refs.sh",
+                    target / ".githooks" / "protected-refs.sh",
+                )
+                if entry != ".githooks/pre-commit":
+                    wrong_entry = target / entry.removeprefix("./")
+                    wrong_entry.write_text(
+                        "#!/usr/bin/env bash\n"
+                        "printf 'claude-code-config-pre-commit-reached\\n' "
+                        ">\"$CLAUDE_CODE_CONFIG_PRE_COMMIT_PROBE\"\n",
+                        encoding="utf-8",
+                    )
+                    wrong_entry.chmod(0o755)
+                subprocess.run(
+                    ["git", "-C", os.fspath(target), "add", "."],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        os.fspath(target),
+                        "-c",
+                        "user.name=Artifact Probe",
+                        "-c",
+                        "user.email=artifact@example.invalid",
+                        "-c",
+                        "core.hooksPath=/dev/null",
+                        "commit",
+                        "-qm",
+                        "test: commit framework fixture",
+                    ],
+                    check=True,
+                )
+                hook = target / ".git" / "hooks" / "pre-commit"
+                hook.write_text(generated_hook, encoding="utf-8")
+                hook.chmod(0o755)
+                return target
+
+            def install(
+                target: pathlib.Path,
+                *,
+                extra_env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                environment = os.environ.copy()
+                environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+                environment["PYTHONPATH"] = (
+                    f"{fake_modules}{os.pathsep}{environment.get('PYTHONPATH', '')}"
+                )
+                if extra_env:
+                    environment.update(extra_env)
+                return subprocess.run(
+                    [
+                        "bash",
+                        os.fspath(ROOT / ".githooks" / "install.sh"),
+                        "--preserve-pre-commit",
+                        os.fspath(target),
+                    ],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    env=environment,
+                )
+
+            def assert_native_slots_absent(target: pathlib.Path) -> None:
+                for name in managed_names:
+                    self.assertFalse((target / ".git" / "hooks" / name).exists(), name)
+
+            target = fixture("accepted")
+            framework_hook = target / ".git" / "hooks" / "pre-commit"
+            before = framework_hook.read_bytes()
+            installed = install(target)
+            self.assertEqual(installed.returncode, 0, installed.stderr)
+            self.assertEqual(framework_hook.read_bytes(), before)
+            self.assertNotEqual(
+                framework_hook.read_bytes(), (ROOT / ".githooks" / "pre-commit").read_bytes()
+            )
+            for name in managed_names:
+                self.assertEqual(
+                    (target / ".git" / "hooks" / name).read_bytes(),
+                    (ROOT / ".githooks" / name).read_bytes(),
+                )
+
+            isolated = fixture("isolated-side-effects")
+            isolated_user = isolated / "user.txt"
+            isolated_user.write_text("committed\n", encoding="utf-8")
+            subprocess.run(["git", "-C", os.fspath(isolated), "add", "user.txt"], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    os.fspath(isolated),
+                    "-c",
+                    "user.name=Artifact Probe",
+                    "-c",
+                    "user.email=artifact@example.invalid",
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "commit",
+                    "-qm",
+                    "test: add user content",
+                ],
+                check=True,
+            )
+            before_user = isolated_user.read_bytes()
+            installed = install(
+                isolated,
+                extra_env={"FAKE_PRE_COMMIT_TOUCH_RELATIVE": "user.txt"},
+            )
+            self.assertEqual(installed.returncode, 0, installed.stderr)
+            self.assertEqual(isolated_user.read_bytes(), before_user)
+
+            missing = fixture("missing-marker", config_marker=False)
+            refused = install(missing)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("integration marker", refused.stderr)
+            assert_native_slots_absent(missing)
+
+            staged_only = fixture("staged-only-marker", config_marker=False)
+            staged_config = staged_only / ".pre-commit-config.yaml"
+            staged_config.write_text(marker + staged_config.read_text(encoding="utf-8"))
+            subprocess.run(
+                ["git", "-C", os.fspath(staged_only), "add", ".pre-commit-config.yaml"],
+                check=True,
+            )
+            refused = install(staged_only)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("index must be clean", refused.stderr)
+            assert_native_slots_absent(staged_only)
+
+            staged_content = fixture("staged-user-content")
+            user_file = staged_content / "user.txt"
+            user_file.write_text("original\n", encoding="utf-8")
+            subprocess.run(["git", "-C", os.fspath(staged_content), "add", "user.txt"], check=True)
+            before_user = user_file.read_bytes()
+            mutating_hook = staged_content / ".git" / "hooks" / "pre-commit"
+            mutating_hook.write_text(
+                "#!/usr/bin/env bash\n"
+                "# File generated by pre-commit: https://pre-commit.com\n"
+                f"printf 'changed\\n' >>{shlex.quote(os.fspath(user_file))}\n"
+                "exec .githooks/pre-commit\n",
+                encoding="utf-8",
+            )
+            mutating_hook.chmod(0o755)
+            refused = install(staged_content)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("index must be clean", refused.stderr)
+            self.assertEqual(user_file.read_bytes(), before_user)
+            assert_native_slots_absent(staged_content)
+
+            foreign = fixture("foreign-owner")
+            foreign_hook = foreign / ".git" / "hooks" / "pre-commit"
+            foreign_hook.write_text(
+                "#!/usr/bin/env bash\n# another framework\nexit 0\n", encoding="utf-8"
+            )
+            foreign_hook.chmod(0o755)
+            refused = install(foreign)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("not owned by the pre-commit framework", refused.stderr)
+            assert_native_slots_absent(foreign)
+
+            silent = fixture("missing-runtime-entry", always_run=False)
+            silent_hook = silent / ".git" / "hooks" / "pre-commit"
+            before_silent = silent_hook.read_bytes()
+            refused = install(silent)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("always_run must be true", refused.stderr)
+            self.assertEqual(silent_hook.read_bytes(), before_silent)
+            assert_native_slots_absent(silent)
+
+            spoofed = fixture(
+                "spoofed-generated-hook",
+                generated_hook=(
+                    "#!/usr/bin/env bash\n"
+                    "# File generated by pre-commit: https://pre-commit.com\n"
+                    "echo 'protected local commit (claude-code-config)........Passed'\n"
+                ),
+            )
+            refused = install(spoofed)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("does not match the hook generated", refused.stderr)
+            assert_native_slots_absent(spoofed)
+
+            sentinel_fake = fixture(
+                "sentinel-writing-foreign-hook",
+                empty_repos=True,
+                generated_hook=(
+                    "#!/usr/bin/env bash\n"
+                    "# File generated by pre-commit: https://pre-commit.com\n"
+                    "if [ -n \"${CLAUDE_CODE_CONFIG_PRE_COMMIT_PROBE:-}\" ]; then\n"
+                    "  printf 'claude-code-config-pre-commit-reached\\n' "
+                    ">\"$CLAUDE_CODE_CONFIG_PRE_COMMIT_PROBE\"\n"
+                    "fi\n"
+                    "exit 0\n"
+                ),
+            )
+            refused = install(sentinel_fake)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("expected exactly one", refused.stderr)
+            assert_native_slots_absent(sentinel_fake)
+
+            wrong_entry = fixture(
+                "wrong-semantic-entry",
+                entry="./wrong-entry.sh",
+            )
+            refused = install(wrong_entry)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("entry must be .githooks/pre-commit", refused.stderr)
+            assert_native_slots_absent(wrong_entry)
+
+            changing = fixture("self-modifying-framework")
+            changing_hook = changing / ".git" / "hooks" / "pre-commit"
+            refused = install(
+                changing,
+                extra_env={
+                    "FAKE_PRE_COMMIT_MUTATE_TARGET": os.fspath(changing_hook),
+                },
+            )
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("changed during framework-preserving installation", refused.stderr)
+            assert_native_slots_absent(changing)
+
+            linked = fixture("symlinked-framework")
+            linked_hook = linked / ".git" / "hooks" / "pre-commit"
+            linked_target = root / "generated-pre-commit"
+            linked_target.write_text(generated, encoding="utf-8")
+            linked_target.chmod(0o755)
+            linked_hook.unlink()
+            linked_hook.symlink_to(linked_target)
+            refused = install(linked)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("plain executable", refused.stderr)
+            assert_native_slots_absent(linked)
+
+    def test_bundle_verifier_accepts_exact_tracked_copy_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            target = pathlib.Path(temporary) / "repo"
+            target.mkdir()
+            subprocess.run(["git", "init", "-q", os.fspath(target)], check=True)
+            for relative in (
+                ".githooks/artifact-language.py",
+                ".githooks/commit-msg",
+                ".github/workflows/artifact-language.yml",
+            ):
+                destination = target / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(ROOT / relative, destination)
+            subprocess.run(["git", "-C", os.fspath(target), "add", "."], check=True)
+            accepted = subprocess.run(
+                [sys.executable, os.fspath(VERIFIER), "--target", os.fspath(target)],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            (target / ".github/workflows/artifact-language.yml").write_text(
+                "name: mutated\n", encoding="utf-8"
+            )
+            blocked = subprocess.run(
+                [sys.executable, os.fspath(VERIFIER), "--target", os.fspath(target)],
+                text=True, capture_output=True, check=False,
+            )
+            self.assertNotEqual(blocked.returncode, 0)
+            self.assertIn("target bytes differ", blocked.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test-artifact-language.sh
+++ b/tests/test-artifact-language.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+python3 "$ROOT/tests/artifact-language-probe.py"
+python3 "$ROOT/.githooks/artifact-language.py" self-test


### PR DESCRIPTION
## Summary

- promote only the reviewed Git safeguards from integration PR #197 to the GitHub default branch
- keep the existing release train unchanged; this PR does not use a `release:` title and does not trigger package publication
- enable the real default-push artifact and quality acceptance boundary required by `nbx-liz/claude-code-config#147`

Canonical source: `nbx-liz/claude-code-config@c4653610b32120681c11ce19b6215d4f52626d0c`.

## Test plan

- `bash tests/test-artifact-language.sh`
- canonical bundle verifier: digest `46a282a6fc38d590cceb4215068beefb98ec4e27d1c96eacbccbfadf1b9da6c8`
- exact 14-file diff from `main`; no unrelated `develop` change is included
- GitHub pull-request checks
- after merge: real `main` push artifact and quality runs, then merged-source installation and runtime controls
